### PR TITLE
fix(plex): contain label-sync provider logs

### DIFF
--- a/apps/api/src/lib/label-sync/__tests__/plex-entrypoint-privacy.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-entrypoint-privacy.test.ts
@@ -1,0 +1,218 @@
+import type { FastifyBaseLogger } from "fastify";
+import pino from "pino";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../prisma.js";
+
+const mocks = vi.hoisted(() => ({
+	readInstanceSelected: vi.fn(),
+	mutateMetadataTag: vi.fn(),
+}));
+
+vi.mock("../../plex/plex-authority-service.js", () => ({
+	PlexAuthorityService: class {
+		private readonly log: FastifyBaseLogger;
+
+		constructor(input: { log: FastifyBaseLogger }) {
+			this.log = input.log;
+		}
+
+		async readInstanceSelected(input: unknown) {
+			this.log.warn(
+				{
+					err: new Error(PROVIDER_ERROR),
+					token: PROVIDER_TOKEN,
+					path: PROVIDER_PATH,
+					responseBody: PROVIDER_BODY,
+				},
+				PROVIDER_ERROR,
+			);
+			return await mocks.readInstanceSelected(input);
+		}
+
+		async mutateMetadataTag(input: unknown) {
+			return await mocks.mutateMetadataTag(input);
+		}
+	},
+}));
+
+import { LabelSyncScheduler } from "../label-sync-scheduler.js";
+import { triggerLabelSyncForItem } from "../trigger-for-item.js";
+
+const PROVIDER_ERROR = "CANARY_OUTER_PROVIDER_ERROR_787";
+const PROVIDER_TOKEN = "CANARY_OUTER_PROVIDER_TOKEN_787";
+const PROVIDER_PATH = "/library/metadata/CANARY_OUTER_PATH_787?token=secret";
+const PROVIDER_BODY = "CANARY_OUTER_RESPONSE_BODY_787";
+
+const RULE = {
+	id: "CANARY_OUTER_RULE_ID_787",
+	userId: "user-787",
+	name: "Private Plex rule",
+	enabled: true,
+	sourceService: "plex",
+	sourceInstanceId: "CANARY_OUTER_SOURCE_INSTANCE_787",
+	sourceTagName: "Private source label",
+	destService: "plex",
+	destInstanceId: "CANARY_OUTER_DEST_INSTANCE_787",
+	destTagName: "Private destination label",
+	lastRunAt: null,
+	lastRunStatus: null,
+	lastRunMessage: null,
+	createdAt: new Date("2026-08-29T00:00:00.000Z"),
+	updatedAt: new Date("2026-08-29T00:00:00.000Z"),
+} as const;
+
+function serviceInstance(id: string): ServiceInstance {
+	return {
+		id,
+		userId: RULE.userId,
+		service: "PLEX",
+		label: id,
+		baseUrl: "https://CANARY_OUTER_HOST_787.invalid",
+		externalUrl: null,
+		encryptedApiKey: PROVIDER_TOKEN,
+		encryptionIv: "iv-787",
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		createdAt: RULE.createdAt,
+		updatedAt: RULE.updatedAt,
+	} as ServiceInstance;
+}
+
+function sourceEvidence() {
+	return {
+		available: true,
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		evidence: {
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			reasonCodes: [],
+		},
+		rows: [
+			{
+				tmdbId: 787,
+				mediaType: "movie",
+				title: "CANARY_OUTER_TITLE_787",
+				labels: '["Private source label"]',
+			},
+		],
+	};
+}
+
+function createPinoCapture(): { log: FastifyBaseLogger; serialized: () => string } {
+	const lines: string[] = [];
+	const log = pino(
+		{ level: "trace", base: null, timestamp: false },
+		{ write: (line: string) => lines.push(line) },
+	) as unknown as FastifyBaseLogger;
+	return { log, serialized: () => lines.join("") };
+}
+
+function expectNoProviderCanary(serialized: string): void {
+	for (const value of [
+		PROVIDER_ERROR,
+		PROVIDER_TOKEN,
+		PROVIDER_PATH,
+		PROVIDER_BODY,
+		RULE.id,
+		RULE.sourceInstanceId,
+		RULE.destInstanceId,
+	]) {
+		expect(serialized).not.toContain(value);
+	}
+}
+
+function executionPrisma() {
+	const update = vi.fn().mockImplementation(({ data }) => Promise.resolve({ ...RULE, ...data }));
+	return {
+		serviceInstance: {
+			findMany: vi.fn().mockResolvedValue([serviceInstance(RULE.sourceInstanceId)]),
+			findFirst: vi.fn().mockResolvedValue(serviceInstance(RULE.destInstanceId)),
+		},
+		labelSyncRule: {
+			findMany: vi.fn().mockResolvedValue([RULE]),
+			update,
+		},
+	};
+}
+
+describe("Plex label-sync outer exception containment", () => {
+	beforeEach(() => {
+		mocks.readInstanceSelected.mockReset();
+		mocks.mutateMetadataTag.mockReset();
+	});
+
+	it("persists a bounded scheduler result when destination provider authority throws", async () => {
+		const capture = createPinoCapture();
+		const prisma = executionPrisma();
+		mocks.readInstanceSelected
+			.mockResolvedValueOnce(sourceEvidence())
+			.mockRejectedValueOnce(new Error(PROVIDER_ERROR));
+		const scheduler = new LabelSyncScheduler(
+			prisma as never,
+			{} as never,
+			{} as never,
+			capture.log,
+		);
+
+		await (scheduler as unknown as { tick(): Promise<void> }).tick();
+
+		expect(prisma.labelSyncRule.update).toHaveBeenCalledOnce();
+		expect(prisma.labelSyncRule.update).toHaveBeenCalledWith({
+			where: { id: RULE.id },
+			data: {
+				lastRunAt: expect.any(Date),
+				lastRunStatus: "failed",
+				lastRunMessage: "All 1 attempts failed.",
+			},
+		});
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expectNoProviderCanary(capture.serialized());
+	});
+
+	it("returns a bounded event-trigger outcome when destination provider authority throws", async () => {
+		const capture = createPinoCapture();
+		const prisma = executionPrisma();
+		mocks.readInstanceSelected
+			.mockResolvedValueOnce(sourceEvidence())
+			.mockRejectedValueOnce(new Error(PROVIDER_ERROR));
+
+		const result = await triggerLabelSyncForItem({
+			userId: RULE.userId,
+			sourceService: "PLEX",
+			sourceInstanceId: RULE.sourceInstanceId,
+			arrItemId: 787,
+			itemType: "movie",
+			tmdbId: 787,
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: {} as never,
+			log: capture.log,
+		});
+
+		expect(result).toEqual({
+			rulesFired: 1,
+			results: [
+				{
+					ruleId: RULE.id,
+					ruleName: RULE.name,
+					outcome: {
+						status: "failed",
+						message: "All 1 attempts failed.",
+						totals: {
+							sourceInstancesScanned: 1,
+							taggedItemsFound: 1,
+							destMatchesFound: 0,
+							labelsApplied: 0,
+							failures: 1,
+						},
+					},
+				},
+			],
+			totals: { labelsApplied: 0, failures: 1 },
+		});
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expectNoProviderCanary(capture.serialized());
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
@@ -587,6 +587,83 @@ describe("Plex label-sync evidence boundary", () => {
 		expect(mocks.updateMetadataTags).not.toHaveBeenCalled();
 	});
 
+	it("counts a mixed ambiguous batch once when later destination authority is unavailable", async () => {
+		mocks.loadInstanceSelectedEvidence.mockResolvedValue(unavailableEvidence());
+
+		const result = await plexDestWriter.applyLabels({
+			rule,
+			destInstance: { ...instance, id: "plex-dest" } as DestWriterOpts["destInstance"],
+			candidates: [
+				{ tmdbId: 42, mediaType: "movie", title: "Movie collision" },
+				{ tmdbId: 42, mediaType: "series", title: "Series collision" },
+				{ tmdbId: 99, mediaType: "movie", title: "Unambiguous movie" },
+			],
+			prisma: destinationPrisma(),
+			arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+			encryptor: {} as DestWriterOpts["encryptor"],
+			log,
+		});
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 3 });
+		expect(result.failures).toBeLessThanOrEqual(3);
+		expect(mocks.loadInstanceSelectedEvidence).toHaveBeenCalledOnce();
+		expect(mocks.updateMetadataTags).not.toHaveBeenCalled();
+	});
+
+	it("preserves mixed-batch accounting when one unambiguous target writes", async () => {
+		mocks.loadInstanceSelectedEvidence.mockResolvedValue(
+			authoritativeEvidence([
+				{
+					tmdbId: 99,
+					mediaType: "movie",
+					title: "Unambiguous movie",
+					ratingKey: "999",
+					thumb: "/library/metadata/999/thumb/1",
+				},
+			]),
+		);
+
+		const result = await plexDestWriter.applyLabels({
+			rule,
+			destInstance: { ...instance, id: "plex-dest" } as DestWriterOpts["destInstance"],
+			candidates: [
+				{ tmdbId: 42, mediaType: "movie", title: "Movie collision" },
+				{ tmdbId: 42, mediaType: "series", title: "Series collision" },
+				{ tmdbId: 99, mediaType: "movie", title: "Unambiguous movie" },
+			],
+			prisma: destinationPrisma(),
+			arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+			encryptor: {} as DestWriterOpts["encryptor"],
+			log,
+		});
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 1, failures: 2 });
+		expect(result.failures).toBeLessThanOrEqual(3);
+		expect(mocks.updateMetadataTags).toHaveBeenCalledOnce();
+		expect(mocks.updateMetadataTags).toHaveBeenCalledWith("999", "label", "add", "Family");
+	});
+
+	it("counts every unambiguous candidate once when destination authority is unavailable", async () => {
+		mocks.loadInstanceSelectedEvidence.mockResolvedValue(unavailableEvidence());
+
+		const result = await plexDestWriter.applyLabels({
+			rule,
+			destInstance: { ...instance, id: "plex-dest" } as DestWriterOpts["destInstance"],
+			candidates: [
+				{ tmdbId: 10, mediaType: "movie", title: "Movie ten" },
+				{ tmdbId: 11, mediaType: "series", title: "Series eleven" },
+			],
+			prisma: destinationPrisma(),
+			arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+			encryptor: {} as DestWriterOpts["encryptor"],
+			log,
+		});
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 2 });
+		expect(mocks.loadInstanceSelectedEvidence).toHaveBeenCalledOnce();
+		expect(mocks.updateMetadataTags).not.toHaveBeenCalled();
+	});
+
 	it("does not infer a complete duplicate-edition set from one persisted rating key", async () => {
 		mocks.loadInstanceSelectedEvidence.mockResolvedValue(
 			authoritativeEvidence([

--- a/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
@@ -1,0 +1,337 @@
+import type { FastifyBaseLogger } from "fastify";
+import pino from "pino";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../prisma.js";
+
+const mocks = vi.hoisted(() => ({
+	readInstanceSelected: vi.fn(),
+	mutateMetadataTag: vi.fn(),
+}));
+
+vi.mock("../../plex/plex-authority-service.js", () => ({
+	PlexAuthorityService: class {
+		private readonly log: FastifyBaseLogger;
+
+		constructor(input: { log: FastifyBaseLogger }) {
+			this.log = input.log;
+		}
+
+		async readInstanceSelected(input: unknown) {
+			emitProviderCanaries(this.log);
+			return await mocks.readInstanceSelected(input);
+		}
+
+		async mutateMetadataTag(input: unknown) {
+			emitProviderCanaries(this.log);
+			return await mocks.mutateMetadataTag(input);
+		}
+	},
+}));
+
+import { executeLabelSyncRule } from "../execute-rule.js";
+
+const CANARIES = {
+	title: "CANARY_TITLE_787",
+	filename: "CANARY_FILENAME_787.mkv",
+	filePath: "/media/CANARY_PATH_787/CANARY_FILENAME_787.mkv",
+	tmdbId: 787_987_654,
+	tvdbId: 787_123_456,
+	ratingKey: "787987654321",
+	guid: "plex://CANARY_GUID_787",
+	sectionId: "CANARY_SECTION_ID_787",
+	sectionTitle: "CANARY_SECTION_TITLE_787",
+	username: "CANARY_USERNAME_787",
+	baseUrl: "https://CANARY_HOST_787.invalid:32400",
+	hostname: "CANARY_HOST_787.invalid",
+	token: "CANARY_TOKEN_787",
+	apiKey: "CANARY_API_KEY_787",
+	authorization: "Bearer CANARY_AUTHORIZATION_787",
+	requestPath: "/library/metadata/CANARY_REQUEST_PATH_787?token=CANARY_QUERY_787",
+	statusText: "CANARY_STATUS_TEXT_787",
+	responseBody: "CANARY_RESPONSE_BODY_787",
+	rawPayload: "CANARY_RAW_PAYLOAD_787",
+	errorMessage: "CANARY_ERROR_MESSAGE_787",
+	stack: "CANARY_STACK_787",
+	cause: "CANARY_CAUSE_787",
+} as const;
+
+const RULE = {
+	id: "CANARY_RULE_ID_787",
+	userId: "user-787",
+	sourceService: "plex",
+	sourceInstanceId: "CANARY_SOURCE_INSTANCE_ID_787",
+	sourceTagName: "Private source label",
+	destService: "plex",
+	destInstanceId: "CANARY_DEST_INSTANCE_ID_787",
+	destTagName: "Private destination label",
+} as const;
+
+function emitProviderCanaries(log: FastifyBaseLogger): void {
+	const cause = new Error(CANARIES.cause);
+	const error = new Error(CANARIES.errorMessage, { cause });
+	error.stack = CANARIES.stack;
+	log.warn(
+		{
+			err: error,
+			title: CANARIES.title,
+			filename: CANARIES.filename,
+			filePath: CANARIES.filePath,
+			tmdbId: CANARIES.tmdbId,
+			tvdbId: CANARIES.tvdbId,
+			ratingKey: CANARIES.ratingKey,
+			guid: CANARIES.guid,
+			sectionId: CANARIES.sectionId,
+			sectionTitle: CANARIES.sectionTitle,
+			username: CANARIES.username,
+			baseUrl: CANARIES.baseUrl,
+			hostname: CANARIES.hostname,
+			token: CANARIES.token,
+			apiKey: CANARIES.apiKey,
+			authorization: CANARIES.authorization,
+			path: CANARIES.requestPath,
+			statusText: CANARIES.statusText,
+			responseBody: CANARIES.responseBody,
+			payload: CANARIES.rawPayload,
+		},
+		CANARIES.errorMessage,
+	);
+}
+
+function createPinoCapture(): {
+	log: FastifyBaseLogger;
+	serialized: () => string;
+	records: () => Array<Record<string, unknown>>;
+} {
+	const lines: string[] = [];
+	const destination = {
+		write(line: string) {
+			lines.push(line);
+		},
+	};
+	const log = pino(
+		{
+			level: "trace",
+			base: null,
+			timestamp: false,
+		},
+		destination,
+	) as unknown as FastifyBaseLogger;
+	return {
+		log,
+		serialized: () => lines.join(""),
+		records: () =>
+			lines
+				.join("")
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as Record<string, unknown>),
+	};
+}
+
+function serviceInstance(id: string): ServiceInstance {
+	return {
+		id,
+		userId: RULE.userId,
+		service: "PLEX",
+		label: id,
+		baseUrl: CANARIES.baseUrl,
+		externalUrl: null,
+		encryptedApiKey: CANARIES.token,
+		encryptionIv: "iv-787",
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		createdAt: new Date("2026-08-29T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-29T00:00:00.000Z"),
+	} as ServiceInstance;
+}
+
+function prismaForRule() {
+	return {
+		serviceInstance: {
+			findMany: vi.fn().mockResolvedValue([serviceInstance(RULE.sourceInstanceId)]),
+			findFirst: vi.fn().mockResolvedValue(serviceInstance(RULE.destInstanceId)),
+		},
+	};
+}
+
+function sourceEvidence() {
+	return {
+		available: true,
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		evidence: {
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			reasonCodes: [],
+		},
+		rows: [
+			{
+				tmdbId: CANARIES.tmdbId,
+				mediaType: "movie",
+				title: CANARIES.title,
+				labels: '["Private source label"]',
+			},
+		],
+	};
+}
+
+function destinationEvidence() {
+	return {
+		...sourceEvidence(),
+		rows: [
+			{
+				tmdbId: CANARIES.tmdbId,
+				mediaType: "movie",
+				title: CANARIES.title,
+				ratingKey: CANARIES.ratingKey,
+				thumb: `/library/metadata/${CANARIES.ratingKey}/thumb/1`,
+			},
+		],
+	};
+}
+
+function unavailableEvidence() {
+	return {
+		available: false,
+		evidence: {
+			publicationLevel: "unavailable",
+			completeness: "unknown",
+			reasonCodes: ["missing_status"],
+		},
+		rows: [],
+	};
+}
+
+function expectNoPlexOperationLog(capture: ReturnType<typeof createPinoCapture>): void {
+	expect(capture.records()).toEqual([]);
+	const serialized = capture.serialized();
+	for (const value of [...Object.values(CANARIES), ...Object.values(RULE)]) {
+		expect(serialized).not.toContain(String(value));
+	}
+}
+
+async function runRule(log: FastifyBaseLogger) {
+	return await executeLabelSyncRule({
+		rule: RULE,
+		prisma: prismaForRule() as never,
+		arrClientFactory: {} as never,
+		encryptor: {} as never,
+		log,
+	});
+}
+
+describe("Plex label-sync whole-execution log containment", () => {
+	beforeEach(() => {
+		mocks.readInstanceSelected.mockReset();
+		mocks.mutateMetadataTag.mockReset();
+	});
+
+	it("uses a binding-aware real Pino capture", () => {
+		const capture = createPinoCapture();
+		capture.log
+			.child({ ruleId: RULE.id })
+			.child({ sourceInstanceId: RULE.sourceInstanceId })
+			.child({ destInstanceId: RULE.destInstanceId })
+			.warn("ordinary bound record");
+
+		expect(capture.records()).toEqual([
+			expect.objectContaining({
+				ruleId: RULE.id,
+				sourceInstanceId: RULE.sourceInstanceId,
+				destInstanceId: RULE.destInstanceId,
+				msg: "ordinary bound record",
+			}),
+		]);
+	});
+
+	it("contains a Plex source provider failure and does not invoke the destination", async () => {
+		const capture = createPinoCapture();
+		mocks.readInstanceSelected.mockRejectedValueOnce(new Error(CANARIES.errorMessage));
+
+		const result = await runRule(capture.log);
+
+		expect(result).toEqual({
+			status: "failed",
+			message: "Source reads failed on 1 instance — no candidates collected.",
+			totals: {
+				sourceInstancesScanned: 1,
+				taggedItemsFound: 0,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: 1,
+			},
+		});
+		expect(mocks.readInstanceSelected).toHaveBeenCalledOnce();
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expectNoPlexOperationLog(capture);
+	});
+
+	it("contains unavailable Plex destination authority with exact failure accounting", async () => {
+		const capture = createPinoCapture();
+		mocks.readInstanceSelected
+			.mockResolvedValueOnce(sourceEvidence())
+			.mockResolvedValueOnce(unavailableEvidence());
+
+		const result = await runRule(capture.log);
+
+		expect(result).toEqual({
+			status: "failed",
+			message: "All 1 attempts failed.",
+			totals: {
+				sourceInstancesScanned: 1,
+				taggedItemsFound: 1,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: 1,
+			},
+		});
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expectNoPlexOperationLog(capture);
+	});
+
+	it("contains a Plex metadata write failure without recording success", async () => {
+		const capture = createPinoCapture();
+		mocks.readInstanceSelected
+			.mockResolvedValueOnce(sourceEvidence())
+			.mockResolvedValueOnce(destinationEvidence());
+		mocks.mutateMetadataTag.mockRejectedValueOnce(new Error(CANARIES.errorMessage));
+
+		const result = await runRule(capture.log);
+
+		expect(result).toEqual({
+			status: "failed",
+			message: "All 1 attempts failed.",
+			totals: {
+				sourceInstancesScanned: 1,
+				taggedItemsFound: 1,
+				destMatchesFound: 1,
+				labelsApplied: 0,
+				failures: 1,
+			},
+		});
+		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expectNoPlexOperationLog(capture);
+	});
+
+	it("performs one successful Plex write without a per-target success event", async () => {
+		const capture = createPinoCapture();
+		mocks.readInstanceSelected
+			.mockResolvedValueOnce(sourceEvidence())
+			.mockResolvedValueOnce(destinationEvidence());
+		mocks.mutateMetadataTag.mockResolvedValueOnce({ ok: true });
+
+		const result = await runRule(capture.log);
+
+		expect(result.status).toBe("success");
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 1,
+			destMatchesFound: 1,
+			labelsApplied: 1,
+			failures: 0,
+		});
+		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expectNoPlexOperationLog(capture);
+	});
+});

--- a/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
@@ -7,12 +7,13 @@
  */
 
 import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
+import { plexProviderLogSink } from "../plex-provider-log-sink.js";
 import type { DestWriteResult, DestWriter, DestWriterOpts } from "../strategy-types.js";
 
 export const plexDestWriter: DestWriter = {
 	prismaService: "PLEX",
 	async applyLabels(opts: DestWriterOpts): Promise<DestWriteResult> {
-		const { rule, candidates, prisma, encryptor, log } = opts;
+		const { rule, candidates, prisma, encryptor } = opts;
 
 		if (candidates.length === 0) {
 			return { matchesFound: 0, labelsApplied: 0, failures: 0 };
@@ -34,20 +35,28 @@ export const plexDestWriter: DestWriter = {
 			tmdbId: candidate.tmdbId,
 			mediaType: candidate.mediaType,
 		}));
-		const authority = new PlexAuthorityService({ prisma, encryptor, log });
-		const evidence = await authority.readInstanceSelected({
-			userId: rule.userId,
-			instanceId: rule.destInstanceId,
-			selection: { kind: "targets", targets },
-			domains: ["membership"],
+		const authority = new PlexAuthorityService({
+			prisma,
+			encryptor,
+			log: plexProviderLogSink,
 		});
+		let evidence: Awaited<ReturnType<PlexAuthorityService["readInstanceSelected"]>>;
+		try {
+			evidence = await authority.readInstanceSelected({
+				userId: rule.userId,
+				instanceId: rule.destInstanceId,
+				selection: { kind: "targets", targets },
+				domains: ["membership"],
+			});
+		} catch {
+			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
+		}
 		if (
 			!evidence.available ||
 			evidence.evidence.publicationLevel !== "authoritative" ||
 			evidence.evidence.completeness !== "complete" ||
 			evidence.evidence.reasonCodes.length > 0
 		) {
-			log.warn({ instanceId: rule.destInstanceId }, "Plex label destination evidence unavailable");
 			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
 		}
 
@@ -64,10 +73,6 @@ export const plexDestWriter: DestWriter = {
 			}
 			const ratingKey = resolveParitySafeCachedRatingKey(row);
 			if (!ratingKey) {
-				log.warn(
-					{ tmdbId: row.tmdbId, title: row.title },
-					"Plex label target lacks matching cached rating-key evidence",
-				);
 				failures++;
 				continue;
 			}
@@ -84,16 +89,11 @@ export const plexDestWriter: DestWriter = {
 					action: "add",
 					name: rule.destTagName,
 				});
-			} catch (err) {
-				log.warn({ ratingKey, err }, "Failed to apply Plex label");
+			} catch {
 				failures++;
 				continue;
 			}
 			if (!mutation.ok) {
-				log.warn(
-					{ tmdbId: row.tmdbId, ratingKey },
-					"Plex label target evidence changed before mutation",
-				);
 				failures++;
 				continue;
 			}

--- a/apps/api/src/lib/label-sync/plex-provider-log-sink.ts
+++ b/apps/api/src/lib/label-sync/plex-provider-log-sink.ts
@@ -1,0 +1,20 @@
+import type { FastifyBaseLogger } from "fastify";
+
+const discard = (): void => {};
+
+const sink = {
+	child: () => sink,
+	trace: discard,
+	debug: discard,
+	info: discard,
+	warn: discard,
+	error: discard,
+	fatal: discard,
+} as unknown as FastifyBaseLogger;
+
+/**
+ * Drops nested Plex provider diagnostics only while a label-sync strategy is
+ * running. It keeps no bindings or arguments, and child loggers are the same
+ * stateless sink.
+ */
+export const plexProviderLogSink = Object.freeze(sink);

--- a/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
+++ b/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
@@ -13,18 +13,19 @@ import type {
 	SourceReadResult,
 } from "../strategy-types.js";
 import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
+import { plexProviderLogSink } from "../plex-provider-log-sink.js";
 
 export const plexSourceReader: SourceReader = {
 	prismaService: "PLEX",
 	async readTaggedItems(opts: SourceReaderOpts): Promise<SourceReadResult> {
-		const { rule, sourceInstance, prisma, log } = opts;
+		const { rule, sourceInstance, prisma } = opts;
 
 		let rows: Array<{ tmdbId: number; mediaType: string; title: string; labels: string }>;
 		try {
 			const evidence = await new PlexAuthorityService({
 				prisma,
 				encryptor: opts.encryptor,
-				log,
+				log: plexProviderLogSink,
 			}).readInstanceSelected({
 				userId: rule.userId,
 				instanceId: sourceInstance.id,
@@ -43,8 +44,7 @@ export const plexSourceReader: SourceReader = {
 				return { matches: [], failed: true };
 			}
 			rows = evidence.rows;
-		} catch (err) {
-			log.warn({ err }, "Failed to query PlexCache for source labels");
+		} catch {
 			return { matches: [], failed: true };
 		}
 


### PR DESCRIPTION
## Summary

Contain Plex provider logs during label-sync source reads and destination writes without changing the shared Plex authority or client layers. The existing label-sync result, persistence, and scheduler accounting contracts remain authoritative.

## Related issue

Related to #787

## Scope

- Add one stateless label-sync-local logger that discards nested Plex provider log arguments and bindings.
- Pass that logger only to `PlexAuthorityService` from the Plex label-sync source reader and destination writer.
- Remove Plex source and destination raw-error and per-target logging from those two strategies.
- Add regression coverage for real Pino child bindings, provider failures, successful writes, ambiguity handling, rating-key deduplication, persisted scheduler results, and event-trigger results.

## Non-goals

- No changes to `PlexAuthorityService`, `PlexClient`, shared Plex authority, or mutation authorization.
- No per-target terminal events, candidate-count audit events, reason-code system, or parallel outcome framework.
- No changes to the existing `SourceReadResult`, `DestWriteResult`, `LabelSyncRunResult`, persisted run status/message, or scheduler aggregate contracts.
- No Tautulli B2, B3, or T2 work and no v2.24.2 release preparation.
- No continuation or modification of draft PR #806.

## Acceptance criteria

- [x] Ordinary Pino behavior serializes `ruleId`, `sourceInstanceId`, and `destInstanceId` child bindings in the positive control.
- [x] Plex source authority/read failures emit no source or provider record through the operation logger and preserve the existing failed source result.
- [x] Plex destination authority failures and throws emit no destination or provider record, perform no mutation, and preserve bounded failure accounting.
- [x] Plex write failure and success paths emit no per-target Plex record and preserve exact mutation and success accounting.
- [x] Mixed ambiguous and unambiguous candidates, all-ambiguous candidates, and all-unambiguous authority failures preserve existing counters without double counting.
- [x] Repeated observations of one parity-safe rating key produce one write.
- [x] Production-shaped scheduler persistence and event-trigger execution contain a destination provider throw in the existing result contracts without exposing the raw exception.
- [x] The candidate remains within the approved boundary at six changed files.

## Changes

- Add `plexProviderLogSink`, a frozen stateless logger whose methods discard every argument and whose `child()` method returns the same sink.
- Use the sink for nested Plex authority work in the Plex source reader and destination writer only.
- Convert destination authority throws to the writer's existing bounded failure result. Remove direct Plex source/destination raw-error and per-target log calls.
- Add real-Pino whole-execution privacy tests and production-shaped scheduler and event-trigger containment tests.
- Extend Plex strategy parity tests for mixed ambiguity, unavailable authority, existing counters, and write counts.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed: Prisma generated check, 17 Prisma checker tests, 53 PR contract tests, and `git diff --check`.
- [x] Focused tests passed: 38 privacy/strategy tests, 144 label-sync and unchanged Plex authority/client tests, and 7 provider cache heap tests.
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, run as an explicit rebuild requirement although shared did not change
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: 5,433 passed across API, web, and shared packages; 53 API tests skipped
- [x] `pnpm run lint`
- [x] `pnpm run build`, required for this safety-critical backend change
- [x] User-visible behavior was live-verified, when applicable: not applicable to this backend log-containment change
- [x] New queries use centralized query keys and polling constants, when applicable: no queries added
- [x] New sensitive displays preserve incognito behavior, when applicable: no display changes
- [x] New Prisma queries for user-owned resources include `userId`, when applicable: no Prisma queries added
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable: no UI surfaces added
- [x] User-facing counts are precise rather than proxies, when applicable: existing label-sync counters are asserted directly
- [x] Action links reach the correct page with required parameters, when applicable: no links added
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable: the sink is local to Plex label-sync strategies and does not replace shared logging
- [x] `CI=true pnpm run validate:pr`

## Review plan

- Initial broad-reviewed head: `a6aebca2c4b74b4fb0c1b17aa273babc0718fd7a`
- Correction head: N/A, no code correction required
- Targeted delta range: N/A
- Material-scope change declared? No
- Independent regression reviewer: whole-execution privacy review PASS, no actionable findings
- Independent data-safety reviewer, when required: mutation and accounting parity review PASS, no findings
- GitHub Codex review head: `a6aebca2c4b74b4fb0c1b17aa273babc0718fd7a`
- Finding GCR-817-001: reproduced as a richer-observability request
- Scope disposition: `planned-later-phase`, tracked in #818
- Code change: none; candidate head remains `a6aebca2c4b74b4fb0c1b17aa273babc0718fd7a`
- Maintainer decision: Pending final review

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| LOCAL-REVIEW | None | In scope | Independent privacy and data-safety reviews found no actionable issue at `a6aebca2c4b74b4fb0c1b17aa273babc0718fd7a` | Pass | None |
| GCR-817-001 | P2 | Planned later phase | A mixed successful/failed Plex write retains only the existing bounded aggregate partial result and no structured failure category | Existing partial/failed status and exact counts are preserved; adding a privacy-safe correlation/category system is explicitly outside this reduced PR | #818 |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned: verify the exact merged SHA before a renewed release-readiness audit
