### PR TITLE
fix(qui): keep torrent-state sync responsive

### DIFF
--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
@@ -137,8 +137,21 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 		});
 
 		const stagingStatementDurationsMs: number[] = [];
+		const healthLatenciesMs: number[] = [];
+		let healthProbePromises: Promise<void>[] | undefined;
 		const executeRaw = prisma.$executeRaw.bind(prisma);
 		const timedExecuteRaw = ((...args: Parameters<typeof prisma.$executeRaw>) => {
+			healthProbePromises ??= Array.from({ length: 20 }, (_, index) => {
+				const delayMs = 50 + index * 100;
+				const dueAt = performance.now() + delayMs;
+				return new Promise<void>((resolve) => {
+					setTimeout(async () => {
+						await observer.$queryRaw`SELECT 1`;
+						healthLatenciesMs.push(performance.now() - dueAt);
+						resolve();
+					}, delayMs);
+				});
+			});
 			const startedAt = performance.now();
 			return executeRaw(...args).then((rowsUpdated) => {
 				stagingStatementDurationsMs.push(performance.now() - startedAt);
@@ -164,6 +177,7 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 
 		const sync = runQuiTorrentStateSync({ prisma, log, dbProvider: "sqlite" } as never);
 		await stagingPaused.promise;
+		await Promise.all(healthProbePromises ?? []);
 		const [healthRows, staged, absentBeforeCleanup, freshLibraryRows, freshEpisodeRows] =
 			await Promise.all([
 				observer.$queryRaw<Array<{ healthy: bigint }>>`SELECT 1 AS healthy`,
@@ -190,6 +204,8 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 		expect(freshEpisodeRows).toBe(0);
 		expect(stagingStatementDurationsMs).toHaveLength(100);
 		expect(Math.max(...stagingStatementDurationsMs)).toBeLessThan(2_000);
+		expect(healthLatenciesMs).toHaveLength(20);
+		expect(Math.max(...healthLatenciesMs)).toBeLessThan(2_000);
 		expect(result).toMatchObject({
 			torrentsSeen: 15_000,
 			rowsUpdated: 15_000,

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PrismaClient } from "../../../generated/prisma/client.js";
@@ -135,6 +136,17 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 			}),
 		});
 
+		const stagingStatementDurationsMs: number[] = [];
+		const executeRaw = prisma.$executeRaw.bind(prisma);
+		const timedExecuteRaw = ((...args: Parameters<typeof prisma.$executeRaw>) => {
+			const startedAt = performance.now();
+			return executeRaw(...args).then((rowsUpdated) => {
+				stagingStatementDurationsMs.push(performance.now() - startedAt);
+				return rowsUpdated;
+			}) as ReturnType<typeof prisma.$executeRaw>;
+		}) as typeof prisma.$executeRaw;
+		vi.spyOn(prisma, "$executeRaw").mockImplementation(timedExecuteRaw);
+
 		const stagingPaused = deferred();
 		const releaseStaging = deferred();
 		type FindEpisodeCandidates = (
@@ -176,6 +188,8 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 		});
 		expect(freshLibraryRows).toBe(0);
 		expect(freshEpisodeRows).toBe(0);
+		expect(stagingStatementDurationsMs).toHaveLength(100);
+		expect(Math.max(...stagingStatementDurationsMs)).toBeLessThan(2_000);
 		expect(result).toMatchObject({
 			torrentsSeen: 15_000,
 			rowsUpdated: 15_000,

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PrismaClient } from "../../../generated/prisma/client.js";
+
+const { mockCreateQuiClient, mockListQuiInstances } = vi.hoisted(() => ({
+	mockCreateQuiClient: vi.fn(),
+	mockListQuiInstances: vi.fn(),
+}));
+
+vi.mock("../client-factory.js", () => ({
+	createQuiClient: mockCreateQuiClient,
+}));
+
+vi.mock("../instance-helpers.js", () => ({
+	listQuiInstances: mockListQuiInstances,
+}));
+
+import { runQuiTorrentStateSync } from "../torrent-state-sync.js";
+
+const databases: Array<{ client: PrismaClient; directory: string }> = [];
+
+afterEach(async () => {
+	for (const { client, directory } of databases.splice(0)) {
+		await client.$disconnect();
+		await rm(directory, { recursive: true, force: true });
+	}
+});
+
+async function createDatabase(): Promise<PrismaClient> {
+	const directory = await mkdtemp(join(tmpdir(), "qui-sync-scale-"));
+	const databasePath = join(directory, "scale.db");
+	execFileSync("pnpm", ["exec", "prisma", "db", "push", "--schema", "prisma/schema.prisma"], {
+		cwd: process.cwd(),
+		env: { ...process.env, DATABASE_URL: `file:${databasePath}` },
+		stdio: "pipe",
+	});
+	const client = new PrismaClient({
+		adapter: new PrismaBetterSqlite3({ url: databasePath, timeout: 5_000 }),
+	});
+	await client.$connect();
+	databases.push({ client, directory });
+	return client;
+}
+
+const log = {
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	fatal: vi.fn(),
+	trace: vi.fn(),
+	child: vi.fn(),
+	level: "info",
+	silent: vi.fn(),
+} as never;
+
+describe("runQuiTorrentStateSync SQLite scale behavior", () => {
+	it("keeps a health query responsive during a complete 15k-torrent publication", async () => {
+		const prisma = await createDatabase();
+		const userId = "scale-user";
+		const quiId = "scale-qui";
+		await prisma.user.create({
+			data: { id: userId, username: "qui-scale", hashedPassword: "test" },
+		});
+		await prisma.serviceInstance.create({
+			data: {
+				id: quiId,
+				userId,
+				service: "QUI",
+				label: "Scale qui",
+				baseUrl: "http://qui.invalid",
+				encryptedApiKey: "encrypted",
+				encryptionIv: "iv",
+			},
+		});
+
+		await prisma.libraryCache.createMany({
+			data: Array.from({ length: 15_000 }, (_, index) => ({
+				id: `library-${index}`,
+				instanceId: quiId,
+				arrItemId: index,
+				itemType: "movie" as const,
+				title: `Movie ${index}`,
+				infoHash: `hash-${index}`,
+				torrentState: "paused",
+				torrentRatio: 0,
+				data: "{}",
+			})),
+		});
+		await prisma.episodeFileCache.createMany({
+			data: Array.from({ length: 5_000 }, (_, index) => ({
+				id: `episode-${index}`,
+				instanceId: quiId,
+				arrEpisodeFileId: index,
+				arrSeriesId: index,
+				seasonNumber: 1,
+				relativePath: `episode-${index}.mkv`,
+				path: `/media/episode-${index}.mkv`,
+				size: BigInt(1),
+				infoHash: `hash-${index + 15_000}`,
+				torrentState: "paused",
+				torrentRatio: 0,
+			})),
+		});
+
+		mockListQuiInstances.mockResolvedValue([
+			{ id: quiId, userId, label: "Scale qui", baseUrl: "http://qui.invalid" },
+		]);
+		mockCreateQuiClient.mockReturnValue({
+			listTorrentInventory: vi.fn().mockResolvedValue({
+				torrents: Array.from({ length: 15_000 }, (_, index) => ({
+					hash: `HASH-${index}`,
+					state: "uploading",
+					ratio: 1,
+				})),
+				complete: true,
+			}),
+		});
+
+		const healthLatencies: number[] = [];
+		const probePromises = Array.from({ length: 20 }, (_, index) => {
+			const dueAt = performance.now() + 50 + index * 100;
+			return new Promise<void>((resolve) => {
+				setTimeout(
+					async () => {
+						await prisma.$queryRaw`SELECT 1`;
+						healthLatencies.push(performance.now() - dueAt);
+						resolve();
+					},
+					50 + index * 100,
+				);
+			});
+		});
+
+		const result = await runQuiTorrentStateSync({ prisma, log, dbProvider: "sqlite" } as never);
+		await Promise.all(probePromises);
+
+		expect(result).toMatchObject({
+			torrentsSeen: 15_000,
+			rowsUpdated: 15_000,
+			errors: 0,
+		});
+		const published = await prisma.libraryCache.findUnique({ where: { id: "library-0" } });
+		expect(published).toMatchObject({ torrentState: "seeding", torrentRatio: 1 });
+		expect(published?.torrentSyncedAt).toBeInstanceOf(Date);
+		const absent = await prisma.episodeFileCache.findUnique({ where: { id: "episode-0" } });
+		expect(absent).toMatchObject({ torrentState: null, torrentRatio: null });
+		expect(absent?.torrentSyncedAt).toBeInstanceOf(Date);
+		expect(Math.max(...healthLatencies)).toBeLessThan(2_000);
+	}, 30_000);
+});

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.database.test.ts
@@ -21,16 +21,16 @@ vi.mock("../instance-helpers.js", () => ({
 
 import { runQuiTorrentStateSync } from "../torrent-state-sync.js";
 
-const databases: Array<{ client: PrismaClient; directory: string }> = [];
+const databases: Array<{ clients: PrismaClient[]; directory: string }> = [];
 
 afterEach(async () => {
-	for (const { client, directory } of databases.splice(0)) {
-		await client.$disconnect();
+	for (const { clients, directory } of databases.splice(0)) {
+		await Promise.all(clients.map(async (client) => await client.$disconnect()));
 		await rm(directory, { recursive: true, force: true });
 	}
 });
 
-async function createDatabase(): Promise<PrismaClient> {
+async function createDatabase(): Promise<{ observer: PrismaClient; prisma: PrismaClient }> {
 	const directory = await mkdtemp(join(tmpdir(), "qui-sync-scale-"));
 	const databasePath = join(directory, "scale.db");
 	execFileSync("pnpm", ["exec", "prisma", "db", "push", "--schema", "prisma/schema.prisma"], {
@@ -38,12 +38,23 @@ async function createDatabase(): Promise<PrismaClient> {
 		env: { ...process.env, DATABASE_URL: `file:${databasePath}` },
 		stdio: "pipe",
 	});
-	const client = new PrismaClient({
+	const prisma = new PrismaClient({
 		adapter: new PrismaBetterSqlite3({ url: databasePath, timeout: 5_000 }),
 	});
-	await client.$connect();
-	databases.push({ client, directory });
-	return client;
+	const observer = new PrismaClient({
+		adapter: new PrismaBetterSqlite3({ url: databasePath, timeout: 5_000 }),
+	});
+	await Promise.all([prisma.$connect(), observer.$connect()]);
+	databases.push({ clients: [prisma, observer], directory });
+	return { observer, prisma };
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
 }
 
 const log = {
@@ -59,10 +70,11 @@ const log = {
 } as never;
 
 describe("runQuiTorrentStateSync SQLite scale behavior", () => {
-	it("keeps a health query responsive during a complete 15k-torrent publication", async () => {
-		const prisma = await createDatabase();
+	it("keeps database reads available while a complete 15k-torrent generation is unpublished", async () => {
+		const { observer, prisma } = await createDatabase();
 		const userId = "scale-user";
 		const quiId = "scale-qui";
+		const oldGeneration = new Date("2026-08-01T00:00:00.000Z");
 		await prisma.user.create({
 			data: { id: userId, username: "qui-scale", hashedPassword: "test" },
 		});
@@ -88,6 +100,7 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 				infoHash: `hash-${index}`,
 				torrentState: "paused",
 				torrentRatio: 0,
+				torrentSyncedAt: oldGeneration,
 				data: "{}",
 			})),
 		});
@@ -104,6 +117,7 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 				infoHash: `hash-${index + 15_000}`,
 				torrentState: "paused",
 				torrentRatio: 0,
+				torrentSyncedAt: oldGeneration,
 			})),
 		});
 
@@ -121,24 +135,47 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 			}),
 		});
 
-		const healthLatencies: number[] = [];
-		const probePromises = Array.from({ length: 20 }, (_, index) => {
-			const dueAt = performance.now() + 50 + index * 100;
-			return new Promise<void>((resolve) => {
-				setTimeout(
-					async () => {
-						await prisma.$queryRaw`SELECT 1`;
-						healthLatencies.push(performance.now() - dueAt);
-						resolve();
-					},
-					50 + index * 100,
-				);
-			});
+		const stagingPaused = deferred();
+		const releaseStaging = deferred();
+		type FindEpisodeCandidates = (
+			args?: Parameters<typeof prisma.episodeFileCache.findMany>[0],
+		) => Promise<Awaited<ReturnType<typeof prisma.episodeFileCache.findMany>>>;
+		const episodeFileCache = prisma.episodeFileCache as unknown as {
+			findMany: FindEpisodeCandidates;
+		};
+		const findEpisodeCandidates = episodeFileCache.findMany.bind(episodeFileCache);
+		vi.spyOn(episodeFileCache, "findMany").mockImplementationOnce(async (args) => {
+			stagingPaused.resolve();
+			await releaseStaging.promise;
+			return await findEpisodeCandidates(args);
 		});
 
-		const result = await runQuiTorrentStateSync({ prisma, log, dbProvider: "sqlite" } as never);
-		await Promise.all(probePromises);
+		const sync = runQuiTorrentStateSync({ prisma, log, dbProvider: "sqlite" } as never);
+		await stagingPaused.promise;
+		const [healthRows, staged, absentBeforeCleanup, freshLibraryRows, freshEpisodeRows] =
+			await Promise.all([
+				observer.$queryRaw<Array<{ healthy: bigint }>>`SELECT 1 AS healthy`,
+				observer.libraryCache.findUnique({ where: { id: "library-0" } }),
+				observer.episodeFileCache.findUnique({ where: { id: "episode-0" } }),
+				observer.libraryCache.count({ where: { torrentSyncedAt: { not: null } } }),
+				observer.episodeFileCache.count({ where: { torrentSyncedAt: { not: null } } }),
+			]);
+		releaseStaging.resolve();
+		const result = await sync;
 
+		expect(healthRows).toEqual([{ healthy: 1n }]);
+		expect(staged).toMatchObject({
+			torrentState: "seeding",
+			torrentRatio: 1,
+			torrentSyncedAt: null,
+		});
+		expect(absentBeforeCleanup).toMatchObject({
+			torrentState: "paused",
+			torrentRatio: 0,
+			torrentSyncedAt: null,
+		});
+		expect(freshLibraryRows).toBe(0);
+		expect(freshEpisodeRows).toBe(0);
 		expect(result).toMatchObject({
 			torrentsSeen: 15_000,
 			rowsUpdated: 15_000,
@@ -150,6 +187,5 @@ describe("runQuiTorrentStateSync SQLite scale behavior", () => {
 		const absent = await prisma.episodeFileCache.findUnique({ where: { id: "episode-0" } });
 		expect(absent).toMatchObject({ torrentState: null, torrentRatio: null });
 		expect(absent?.torrentSyncedAt).toBeInstanceOf(Date);
-		expect(Math.max(...healthLatencies)).toBeLessThan(2_000);
 	}, 30_000);
 });

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -152,7 +152,9 @@ describe("runQuiTorrentStateSync", () => {
 		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain(
 			'LOWER(cache."infoHash")',
 		);
-		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain("CAST( AS REAL)");
+		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain(
+			"CAST( AS DOUBLE PRECISION)",
+		);
 	});
 
 	it("types nullable staged ratios for both supported database providers", async () => {
@@ -165,7 +167,7 @@ describe("runQuiTorrentStateSync", () => {
 		await runQuiTorrentStateSync(app);
 
 		const statement = app.__executeRaw.mock.calls[0]?.[0];
-		expect(statement.strings.join("")).toContain("CAST( AS REAL)");
+		expect(statement.strings.join("")).toContain("CAST( AS DOUBLE PRECISION)");
 		expect(statement.values).toContain(null);
 	});
 
@@ -761,7 +763,7 @@ describePostgres("runQuiTorrentStateSync PostgreSQL staging", () => {
 						"instanceId" TEXT NOT NULL,
 						"infoHash" TEXT,
 						"torrentState" TEXT,
-						"torrentRatio" REAL,
+						"torrentRatio" DOUBLE PRECISION,
 						"torrentSyncedAt" TIMESTAMP(3)
 					) ON COMMIT DROP`,
 				);
@@ -787,7 +789,7 @@ describePostgres("runQuiTorrentStateSync PostgreSQL staging", () => {
 			);
 			mockCreateQuiClient.mockReturnValue(
 				completeInventory([
-					{ hash: "AAAA", state: "uploading", ratio: 1.5 },
+					{ hash: "AAAA", state: "uploading", ratio: 123456.789123456 },
 					{ hash: "BBBB", state: "stalledDL", ratio: Number.NaN },
 				]),
 			);
@@ -801,7 +803,11 @@ describePostgres("runQuiTorrentStateSync PostgreSQL staging", () => {
 			}>(`SELECT "id", "torrentState", "torrentRatio" FROM "library_cache" ORDER BY "id"`);
 			expect(rows.rows).toEqual([
 				{ id: "nullable", torrentState: "stalled_dl", torrentRatio: null },
-				{ id: "numeric", torrentState: "seeding", torrentRatio: 1.5 },
+				{
+					id: "numeric",
+					torrentState: "seeding",
+					torrentRatio: 123456.789123456,
+				},
 			]);
 		} finally {
 			await client.query("ROLLBACK").catch(() => undefined);

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -1,4 +1,5 @@
 import type { FastifyBaseLogger } from "fastify";
+import pg from "pg";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { backfillInfoHashForRow } from "../../library-sync/infohash-backfill.js";
 
@@ -151,6 +152,21 @@ describe("runQuiTorrentStateSync", () => {
 		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain(
 			'LOWER(cache."infoHash")',
 		);
+		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain("CAST( AS REAL)");
+	});
+
+	it("types nullable staged ratios for both supported database providers", async () => {
+		const app = makeApp();
+		configureOneUser(app);
+		mockCreateQuiClient.mockReturnValue(
+			completeInventory([{ hash: "AAAA", state: "uploading", ratio: Number.NaN }]),
+		);
+
+		await runQuiTorrentStateSync(app);
+
+		const statement = app.__executeRaw.mock.calls[0]?.[0];
+		expect(statement.strings.join("")).toContain("CAST( AS REAL)");
+		expect(statement.values).toContain(null);
 	});
 
 	it("requires the complete list fallback when the inventory API is unavailable", async () => {
@@ -723,5 +739,73 @@ describe("runQuiTorrentStateSync", () => {
 		expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
 			expect.arrayContaining(["eeee", null, "user-1"]),
 		);
+	});
+});
+
+const quiSyncPostgresUrl = process.env.QUI_SYNC_POSTGRES_URL;
+const describePostgres = quiSyncPostgresUrl ? describe : describe.skip;
+
+describePostgres("runQuiTorrentStateSync PostgreSQL staging", () => {
+	it("executes numeric and null staged ratios against PostgreSQL", async () => {
+		const client = new pg.Client({ connectionString: quiSyncPostgresUrl });
+		await client.connect();
+		try {
+			await client.query("BEGIN");
+			await client.query(
+				`CREATE TEMP TABLE "ServiceInstance" ("id" TEXT PRIMARY KEY, "userId" TEXT NOT NULL) ON COMMIT DROP`,
+			);
+			for (const tableName of ["library_cache", "episode_file_cache"]) {
+				await client.query(
+					`CREATE TEMP TABLE "${tableName}" (
+						"id" TEXT PRIMARY KEY,
+						"instanceId" TEXT NOT NULL,
+						"infoHash" TEXT,
+						"torrentState" TEXT,
+						"torrentRatio" REAL,
+						"torrentSyncedAt" TIMESTAMP(3)
+					) ON COMMIT DROP`,
+				);
+			}
+			await client.query(
+				`INSERT INTO "ServiceInstance" ("id", "userId") VALUES ('qui-1', 'user-1')`,
+			);
+			await client.query(
+				`INSERT INTO "library_cache"
+					("id", "instanceId", "infoHash", "torrentState", "torrentRatio")
+				 VALUES
+					('numeric', 'qui-1', 'AAAA', 'paused', 0),
+					('nullable', 'qui-1', 'BBBB', 'paused', 0)`,
+			);
+
+			const app = makeApp();
+			configureOneUser(app);
+			app.__executeRaw.mockImplementation(
+				async (statement: { text: string; values: unknown[] }) => {
+					const result = await client.query(statement.text, statement.values);
+					return result.rowCount ?? 0;
+				},
+			);
+			mockCreateQuiClient.mockReturnValue(
+				completeInventory([
+					{ hash: "AAAA", state: "uploading", ratio: 1.5 },
+					{ hash: "BBBB", state: "stalledDL", ratio: Number.NaN },
+				]),
+			);
+
+			await runQuiTorrentStateSync(app);
+
+			const rows = await client.query<{
+				id: string;
+				torrentState: string | null;
+				torrentRatio: number | null;
+			}>(`SELECT "id", "torrentState", "torrentRatio" FROM "library_cache" ORDER BY "id"`);
+			expect(rows.rows).toEqual([
+				{ id: "nullable", torrentState: "stalled_dl", torrentRatio: null },
+				{ id: "numeric", torrentState: "seeding", torrentRatio: 1.5 },
+			]);
+		} finally {
+			await client.query("ROLLBACK").catch(() => undefined);
+			await client.end();
+		}
 	});
 });

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -100,7 +100,9 @@ function configureOneUser(app: ReturnType<typeof makeApp>, instances = [instance
 }
 
 function infoHashWrites(mock: ReturnType<typeof vi.fn>) {
-	return mock.mock.calls.filter((call) => call[0]?.strings?.join("").includes('LOWER("infoHash")'));
+	return mock.mock.calls.filter(
+		(call) => call[0]?.strings !== undefined || Array.isArray(call[0]?.where?.infoHash?.in),
+	);
 }
 
 function userWideClears(mock: ReturnType<typeof vi.fn>) {
@@ -146,7 +148,9 @@ describe("runQuiTorrentStateSync", () => {
 		expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
 			expect.arrayContaining(["aaaa", "seeding", "bbbb", "stalled_dl", "user-1"]),
 		);
-		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain('LOWER("infoHash")');
+		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain(
+			'LOWER(cache."infoHash")',
+		);
 	});
 
 	it("requires the complete list fallback when the inventory API is unavailable", async () => {
@@ -449,7 +453,7 @@ describe("runQuiTorrentStateSync", () => {
 
 		await runQuiTorrentStateSync(app);
 
-		expect(infoHashWrites(app.__executeRaw)).toHaveLength(12);
+		expect(infoHashWrites(app.__executeRaw)).toHaveLength(8);
 		expect(transactionStatementCounts).toEqual([2, 2]);
 	});
 

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -38,6 +38,7 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 	const episodeFileCacheFindMany = vi.fn().mockResolvedValue([]);
 	const serviceInstanceFindMany = vi.fn().mockResolvedValue([]);
 	const serviceInstanceFindFirst = vi.fn().mockResolvedValue(null);
+	const executeRaw = vi.fn().mockResolvedValue(1);
 	const prisma = {
 		libraryCache: {
 			update: libraryCacheUpdate,
@@ -52,6 +53,7 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 			findFirst: serviceInstanceFindFirst,
 			findMany: serviceInstanceFindMany,
 		},
+		$executeRaw: executeRaw,
 		$transaction: vi.fn(),
 	};
 	prisma.$transaction.mockImplementation(
@@ -67,6 +69,7 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 		__episodeFileCacheFindMany: episodeFileCacheFindMany,
 		__serviceInstanceFindMany: serviceInstanceFindMany,
 		__serviceInstanceFindFirst: serviceInstanceFindFirst,
+		__executeRaw: executeRaw,
 		...overrides,
 	} as any;
 }
@@ -97,7 +100,7 @@ function configureOneUser(app: ReturnType<typeof makeApp>, instances = [instance
 }
 
 function infoHashWrites(mock: ReturnType<typeof vi.fn>) {
-	return mock.mock.calls.filter((call) => Array.isArray(call[0]?.where?.infoHash?.in));
+	return mock.mock.calls.filter((call) => call[0]?.strings?.join("").includes('LOWER("infoHash")'));
 }
 
 function userWideClears(mock: ReturnType<typeof vi.fn>) {
@@ -139,14 +142,11 @@ describe("runQuiTorrentStateSync", () => {
 		const result = await runQuiTorrentStateSync(app);
 
 		expect(result).toMatchObject({ torrentsSeen: 2, rowsUpdated: 2, errors: 0 });
-		expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-			where: { infoHash: { in: ["aaaa", "AAAA"] }, instance: { userId: "user-1" } },
-			data: expect.objectContaining({ torrentState: "seeding", torrentRatio: 1.5 }),
-		});
-		expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-			where: { infoHash: { in: ["bbbb", "BBBB"] }, instance: { userId: "user-1" } },
-			data: expect.objectContaining({ torrentState: "stalled_dl", torrentRatio: 0.1 }),
-		});
+		expect(app.__executeRaw).toHaveBeenCalledTimes(2);
+		expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
+			expect.arrayContaining(["aaaa", "seeding", "bbbb", "stalled_dl", "user-1"]),
+		);
+		expect(app.__executeRaw.mock.calls[0]?.[0].strings.join("")).toContain('LOWER("infoHash")');
 	});
 
 	it("requires the complete list fallback when the inventory API is unavailable", async () => {
@@ -160,7 +160,7 @@ describe("runQuiTorrentStateSync", () => {
 		await runQuiTorrentStateSync(app);
 
 		expect(listAllTorrents).toHaveBeenCalledWith({ requireComplete: true });
-		expect(infoHashWrites(app.__libraryCacheUpdateMany)).toHaveLength(1);
+		expect(infoHashWrites(app.__executeRaw)).toHaveLength(2);
 	});
 
 	it.each([
@@ -182,14 +182,10 @@ describe("runQuiTorrentStateSync", () => {
 
 			await runQuiTorrentStateSync(app);
 
-			expect(infoHashWrites(app.__libraryCacheUpdateMany)).toHaveLength(1);
-			expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-				where: { infoHash: { in: ["aaaa", "AAAA"] }, instance: { userId: "user-1" } },
-				data: expect.objectContaining({
-					torrentState: "seeding",
-					torrentRatio: null,
-				}),
-			});
+			expect(infoHashWrites(app.__executeRaw)).toHaveLength(2);
+			expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
+				expect.arrayContaining(["aaaa", "seeding", null, "user-1"]),
+			);
 		},
 	);
 
@@ -204,10 +200,9 @@ describe("runQuiTorrentStateSync", () => {
 
 		await runQuiTorrentStateSync(app);
 
-		expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-			where: { infoHash: { in: ["aaaa", "AAAA"] }, instance: { userId: "user-1" } },
-			data: expect.objectContaining({ torrentState: "unknown", torrentRatio: null }),
-		});
+		expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
+			expect.arrayContaining(["aaaa", "unknown", null, "user-1"]),
+		);
 	});
 
 	it("fetches every enabled inventory before publishing any durable observation", async () => {
@@ -233,7 +228,7 @@ describe("runQuiTorrentStateSync", () => {
 		releaseSecond.resolve();
 		await sync;
 
-		expect(infoHashWrites(app.__libraryCacheUpdateMany)).toHaveLength(1);
+		expect(infoHashWrites(app.__executeRaw)).toHaveLength(2);
 	});
 
 	it("keeps every staged row non-fresh until the final publication stamp commits", async () => {
@@ -263,26 +258,16 @@ describe("runQuiTorrentStateSync", () => {
 				},
 			],
 		]);
-		app.__libraryCacheUpdateMany.mockImplementation(
-			async (args: {
-				where: { infoHash?: { in: string[] } };
-				data: { torrentState?: string | null; torrentSyncedAt?: Date | null };
-			}) => {
-				const normalizedHash = args.where.infoHash?.in[0];
-				if (normalizedHash) {
-					const current = visible.get(normalizedHash)!;
-					visible.set(normalizedHash, {
-						torrentState: args.data.torrentState ?? null,
-						torrentSyncedAt: args.data.torrentSyncedAt ?? current.torrentSyncedAt,
-					});
-					if (normalizedHash === "aaaa") {
-						firstHashStaged.resolve();
-						await releaseStaging.promise;
-					}
-				}
-				return { count: 1 };
-			},
-		);
+		app.__executeRaw.mockImplementation(async (query: { strings?: string[] }) => {
+			if (query.strings?.join("").includes('"library_cache"')) {
+				visible.set("aaaa", { torrentState: "seeding", torrentSyncedAt: null });
+				visible.set("bbbb", { torrentState: "paused", torrentSyncedAt: null });
+				firstHashStaged.resolve();
+				await releaseStaging.promise;
+				return 2;
+			}
+			return 0;
+		});
 		app.prisma.$transaction.mockImplementation(
 			async (operation: (tx: typeof app.prisma) => Promise<unknown>) => {
 				const staged = new Map([...visible.entries()].map(([hash, value]) => [hash, { ...value }]));
@@ -323,7 +308,7 @@ describe("runQuiTorrentStateSync", () => {
 			torrentSyncedAt: null,
 		});
 		expect(visible.get("bbbb")).toEqual({
-			torrentState: "seeding",
+			torrentState: "paused",
 			torrentSyncedAt: null,
 		});
 
@@ -367,16 +352,16 @@ describe("runQuiTorrentStateSync", () => {
 		);
 		const stageStarted = deferred();
 		const releaseStage = deferred();
-		app.__libraryCacheUpdateMany.mockImplementation(
-			async (args: { where?: { infoHash?: { in: string[] } } }) => {
-				if (args.where?.infoHash?.in[0] === "bbbb") {
-					events.push("stage");
-					stageStarted.resolve();
-					await releaseStage.promise;
-				}
-				return { count: 1 };
-			},
-		);
+		let stageObserved = false;
+		app.__executeRaw.mockImplementation(async (query: { strings?: string[] }) => {
+			if (!stageObserved && query.strings?.join("").includes('"library_cache"')) {
+				stageObserved = true;
+				events.push("stage");
+				stageStarted.resolve();
+				await releaseStage.promise;
+			}
+			return 1;
+		});
 		app.prisma.$transaction.mockImplementation(
 			async (operation: (tx: typeof app.prisma) => Promise<unknown>) => {
 				const tx = {
@@ -464,7 +449,7 @@ describe("runQuiTorrentStateSync", () => {
 
 		await runQuiTorrentStateSync(app);
 
-		expect(infoHashWrites(app.__libraryCacheUpdateMany)).toHaveLength(1001);
+		expect(infoHashWrites(app.__executeRaw)).toHaveLength(12);
 		expect(transactionStatementCounts).toEqual([2, 2]);
 	});
 
@@ -626,10 +611,12 @@ describe("runQuiTorrentStateSync", () => {
 			where: { instance: { userId: "user-a" } },
 			data: { torrentState: null, torrentRatio: null, torrentSyncedAt: null },
 		});
-		expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-			where: { infoHash: { in: ["bbbb", "BBBB"] }, instance: { userId: "user-b" } },
-			data: expect.objectContaining({ torrentState: "seeding" }),
-		});
+		expect(
+			app.__executeRaw.mock.calls.some(
+				(call: [{ values?: unknown[] }]) =>
+					call[0]?.values?.includes("user-b") && call[0]?.values?.includes("seeding"),
+			),
+		).toBe(true);
 	});
 
 	it("invalidates any partial publish when a durable write fails", async () => {
@@ -646,6 +633,7 @@ describe("runQuiTorrentStateSync", () => {
 			.mockResolvedValueOnce({ count: 1 })
 			.mockRejectedValueOnce(new Error("write failed"))
 			.mockResolvedValueOnce({ count: 1 });
+		app.__executeRaw.mockRejectedValueOnce(new Error("write failed"));
 
 		const result = await runQuiTorrentStateSync(app);
 
@@ -728,9 +716,8 @@ describe("runQuiTorrentStateSync", () => {
 
 		await runQuiTorrentStateSync(app);
 
-		expect(app.__libraryCacheUpdateMany).toHaveBeenCalledWith({
-			where: { infoHash: { in: ["eeee", "EEEE"] }, instance: { userId: "user-1" } },
-			data: expect.objectContaining({ torrentRatio: null }),
-		});
+		expect(app.__executeRaw.mock.calls[0]?.[0].values).toEqual(
+			expect.arrayContaining(["eeee", null, "user-1"]),
+		);
 	});
 });

--- a/apps/api/src/lib/qui/torrent-state-sync.ts
+++ b/apps/api/src/lib/qui/torrent-state-sync.ts
@@ -65,7 +65,8 @@ async function stageQuiObservationChunk(
 
 	const stagedRows = Prisma.join(
 		observations.map(
-			([hash, observation]) => Prisma.sql`(${hash}, ${observation.state}, ${observation.ratio})`,
+			([hash, observation]) =>
+				Prisma.sql`(${hash}, ${observation.state}, CAST(${observation.ratio} AS REAL))`,
 		),
 		", ",
 	);

--- a/apps/api/src/lib/qui/torrent-state-sync.ts
+++ b/apps/api/src/lib/qui/torrent-state-sync.ts
@@ -12,10 +12,10 @@ import {
 } from "./torrent-state-notifier.js";
 
 const UPDATE_CHUNK_SIZE = 500;
-// Five bound values are emitted for each staged observation (the hash in the
-// WHERE clause plus hash/state and hash/ratio CASE arms). Keep the batch below
+// Three bound values are emitted for each staged observation (hash, state, and
+// ratio in the VALUES relation), plus the user id. Keep the batch below
 // SQLite's 999-variable limit while retaining one set-based statement per table.
-const OBSERVATION_WRITE_CHUNK_SIZE = 180;
+const OBSERVATION_WRITE_CHUNK_SIZE = 300;
 const CLEAR_OBSERVATION_DATA = {
 	torrentState: null,
 	torrentRatio: null,
@@ -63,25 +63,27 @@ async function stageQuiObservationChunk(
 ): Promise<number> {
 	if (observations.length === 0) return 0;
 
-	const stateCases = Prisma.join(
-		observations.map(([hash, observation]) => Prisma.sql`WHEN ${hash} THEN ${observation.state}`),
-		" ",
+	const stagedRows = Prisma.join(
+		observations.map(
+			([hash, observation]) => Prisma.sql`(${hash}, ${observation.state}, ${observation.ratio})`,
+		),
+		", ",
 	);
-	const ratioCases = Prisma.join(
-		observations.map(([hash, observation]) => Prisma.sql`WHEN ${hash} THEN ${observation.ratio}`),
-		" ",
-	);
-	const hashes = observations.map(([hash]) => hash);
 
 	return await prisma.$executeRaw(Prisma.sql`
-		UPDATE ${Prisma.raw(`"${tableName}"`)}
-		SET "torrentState" = CASE LOWER("infoHash") ${stateCases} ELSE "torrentState" END,
-			"torrentRatio" = CASE LOWER("infoHash") ${ratioCases} ELSE "torrentRatio" END,
+		WITH staged("hash", "state", "ratio") AS (VALUES ${stagedRows})
+		UPDATE ${Prisma.raw(`"${tableName}"`)} AS cache
+		SET "torrentState" = (
+				SELECT staged."state" FROM staged WHERE staged."hash" = LOWER(cache."infoHash")
+			),
+			"torrentRatio" = (
+				SELECT staged."ratio" FROM staged WHERE staged."hash" = LOWER(cache."infoHash")
+			),
 			"torrentSyncedAt" = NULL
-		WHERE "instanceId" IN (
+		WHERE cache."instanceId" IN (
 			SELECT "id" FROM "ServiceInstance" WHERE "userId" = ${userId}
 		)
-		AND LOWER("infoHash") IN (${Prisma.join(hashes)})
+		AND LOWER(cache."infoHash") IN (SELECT staged."hash" FROM staged)
 	`);
 }
 

--- a/apps/api/src/lib/qui/torrent-state-sync.ts
+++ b/apps/api/src/lib/qui/torrent-state-sync.ts
@@ -1,6 +1,6 @@
-import { normalizeTorrentState, type NormalizedTorrentState, type QuiTorrent } from "@arr/shared";
+import { type NormalizedTorrentState, normalizeTorrentState, type QuiTorrent } from "@arr/shared";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
-import type { Prisma } from "../prisma.js";
+import { Prisma, type Prisma as PrismaTypes } from "../prisma.js";
 import { logQuiActivity, type QuiSyncCompleteDetails } from "./activity-log.js";
 import { createQuiClient } from "./client-factory.js";
 import { listQuiInstances } from "./instance-helpers.js";
@@ -12,6 +12,10 @@ import {
 } from "./torrent-state-notifier.js";
 
 const UPDATE_CHUNK_SIZE = 500;
+// Five bound values are emitted for each staged observation (the hash in the
+// WHERE clause plus hash/state and hash/ratio CASE arms). Keep the batch below
+// SQLite's 999-variable limit while retaining one set-based statement per table.
+const OBSERVATION_WRITE_CHUNK_SIZE = 180;
 const CLEAR_OBSERVATION_DATA = {
 	torrentState: null,
 	torrentRatio: null,
@@ -47,6 +51,58 @@ interface AggregatedTorrentObservation {
 	state: NormalizedTorrentState;
 	ratio: number | null;
 	instanceLabel: string;
+}
+
+type ObservationWriteClient = Pick<PrismaTypes.TransactionClient, "$executeRaw">;
+
+async function stageQuiObservationChunk(
+	prisma: ObservationWriteClient,
+	tableName: "library_cache" | "episode_file_cache",
+	userId: string,
+	observations: ReadonlyArray<[string, AggregatedTorrentObservation]>,
+): Promise<number> {
+	if (observations.length === 0) return 0;
+
+	const stateCases = Prisma.join(
+		observations.map(([hash, observation]) => Prisma.sql`WHEN ${hash} THEN ${observation.state}`),
+		" ",
+	);
+	const ratioCases = Prisma.join(
+		observations.map(([hash, observation]) => Prisma.sql`WHEN ${hash} THEN ${observation.ratio}`),
+		" ",
+	);
+	const hashes = observations.map(([hash]) => hash);
+
+	return await prisma.$executeRaw(Prisma.sql`
+		UPDATE ${Prisma.raw(`"${tableName}"`)}
+		SET "torrentState" = CASE LOWER("infoHash") ${stateCases} ELSE "torrentState" END,
+			"torrentRatio" = CASE LOWER("infoHash") ${ratioCases} ELSE "torrentRatio" END,
+			"torrentSyncedAt" = NULL
+		WHERE "instanceId" IN (
+			SELECT "id" FROM "ServiceInstance" WHERE "userId" = ${userId}
+		)
+		AND LOWER("infoHash") IN (${Prisma.join(hashes)})
+	`);
+}
+
+async function stageQuiObservations(
+	prisma: ObservationWriteClient,
+	userId: string,
+	aggregate: ReadonlyMap<string, AggregatedTorrentObservation>,
+): Promise<number> {
+	const observations = [...aggregate.entries()];
+	let rowsUpdated = 0;
+	for (const tableName of ["library_cache", "episode_file_cache"] as const) {
+		for (let offset = 0; offset < observations.length; offset += OBSERVATION_WRITE_CHUNK_SIZE) {
+			rowsUpdated += await stageQuiObservationChunk(
+				prisma,
+				tableName,
+				userId,
+				observations.slice(offset, offset + OBSERVATION_WRITE_CHUNK_SIZE),
+			);
+		}
+	}
+	return rowsUpdated;
 }
 
 function aggregateCompleteInventories(
@@ -345,26 +401,10 @@ export async function runQuiTorrentStateSync(
 					// previous complete generation, no signal, or the new complete
 					// generation. It can never see a partially fresh generation.
 					await clearUserQuiFreshness(app, userId);
-					for (const [hash, observation] of aggregate) {
-						// qBittorrent hashes are hexadecimal and may be returned in
-						// either case. New writes are normalized, while this two-value
-						// predicate also heals observations on legacy uppercase rows.
-						const persistedHashVariants = [hash, hash.toUpperCase()];
-						const data = {
-							torrentState: observation.state,
-							torrentRatio: observation.ratio,
-							torrentSyncedAt: null,
-						};
-						const libraryRows = await app.prisma.libraryCache.updateMany({
-							where: { infoHash: { in: persistedHashVariants }, instance: { userId } },
-							data,
-						});
-						const episodeRows = await app.prisma.episodeFileCache.updateMany({
-							where: { infoHash: { in: persistedHashVariants }, instance: { userId } },
-							data,
-						});
-						publishedRowsUpdated += libraryRows.count + episodeRows.count;
-					}
+					// Stage each cache table with bounded CASE updates. This avoids one
+					// synchronous better-sqlite3 statement per hash while keeping the
+					// state and ratio paired with their normalized hash.
+					publishedRowsUpdated = await stageQuiObservations(app.prisma, userId, aggregate);
 					publishedRowsCleared = await persistCompleteAbsence(
 						app.prisma,
 						userId,

--- a/apps/api/src/lib/qui/torrent-state-sync.ts
+++ b/apps/api/src/lib/qui/torrent-state-sync.ts
@@ -66,7 +66,7 @@ async function stageQuiObservationChunk(
 	const stagedRows = Prisma.join(
 		observations.map(
 			([hash, observation]) =>
-				Prisma.sql`(${hash}, ${observation.state}, CAST(${observation.ratio} AS REAL))`,
+				Prisma.sql`(${hash}, ${observation.state}, CAST(${observation.ratio} AS DOUBLE PRECISION))`,
 		),
 		", ",
 	);


### PR DESCRIPTION
## Summary

Replace qUI's sequential per-hash cache writes with bounded set-based updates. A populated 15,000-torrent sync now keeps real Docker health, authenticated API, and webhook requests below the two-second availability ceiling on SQLite and PostgreSQL while preserving fail-closed complete-generation publication.

## Related issue

Closes #810

## Scope

- qUI torrent-state staging writes for LibraryCache and EpisodeFileCache
- Production-shaped SQLite scale, staging-latency, scheduled-probe, and publication-barrier coverage
- PostgreSQL execution and double-precision ratio coverage
- Populated Docker HTTP success and forced-stage-failure verification on SQLite and PostgreSQL

## Non-goals

- Schema changes
- Changes to qUI inventory collection or webhook behavior
- Moving synchronization to a worker process
- Changes to provider-field ownership or freshness authority

## Acceptance criteria

- [x] Replace approximately 30,000 sequential per-hash writes with 100 bounded set-based statements
- [x] Keep SQLite bind counts below 999
- [x] Keep every real staging statement and scheduled database probe below two seconds with 15,000 torrents and 20,000 cache rows
- [x] Keep Docker health, authenticated API, and qUI webhook requests below two seconds during the populated production scheduler run
- [x] Preserve clear, stage, absence cleanup, and final freshness publication ordering
- [x] Withhold freshness from every partially staged or absence-cleanup state
- [x] Invalidate all qUI observations after a failed staging statement
- [x] Preserve numeric double precision and null ratios on PostgreSQL

## Changes

- Stage normalized torrent observations in 300-row `VALUES` batches, with at most 901 bound parameters per statement.
- Scope every update through user-owned ServiceInstance rows.
- Cast staged ratios to `DOUBLE PRECISION`, preserving Prisma `Float` precision on PostgreSQL while remaining SQLite-compatible.
- Add a real SQLite 15,000-torrent/20,000-cache-row regression that measures all 100 staging statements, arms 20 scheduled health probes inside the first real staging call, observes publication through a second database connection, and verifies the exact final generation.
- Retain the populated Docker HTTP gate as the end-to-end timing authority for both supported databases.

## Risk classification

- [ ] Trivial
- [x] Standard
- [ ] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable
- [x] New queries use centralized query keys and polling constants, when applicable
- [x] New sensitive displays preserve incognito behavior, when applicable
- [x] New Prisma queries for user-owned resources include `userId`, when applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable
- [x] User-facing counts are precise rather than proxies, when applicable
- [x] Action links reach the correct page with required parameters, when applicable
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

Final current-main evidence:

- Main `dd34f113c7dca8ce515b40d5ea7cd343bbcaa696`; head `f9285e3a9c417073383d422ce4a353390446e08e`; conflict-free preview tree `c0334d0c3531021ff4059214e3d32a26455beb99`; exact frozen three-file manifest; clean diff check.
- Final local gauntlet: shared 89 tests, web 678 tests, API 4,738 tests with 54 skips; format, shared build, root typecheck, lint, PR-review contract, and production build passed. The reporter-scale SQLite test passed inside the full API suite.
- The final staging test passed five consecutive stress repetitions after each accepted timing correction. It retains the unchanged `<2,000 ms` threshold for all 100 real staging statements and 20 scheduled observer probes.
- Fresh image `sha256:67ac2dda72e1ca471ff351b98b5a73b1233859929a7c43a99fc8eab5deb8f379` was built from preview tree `c0334d0c3531021ff4059214e3d32a26455beb99` with commit label `f9285e3a9c417073383d422ce4a353390446e08e`.
- SQLite success: production scheduler completed in 5,188 ms with 15,000 torrents seen, 14,999 rows updated, 5,001 rows cleared, and zero errors. Final state was exactly 20,000 fresh rows, 14,999 seeding states, 5,001 null states, 5,002 null ratios, and both sentinels intact. Across 860 samples, every partial state had freshness zero. All 75 live requests returned 200; maxima were 895.775 ms health, 897.812 ms authenticated API, and 899.343 ms webhook.
- PostgreSQL 16 success: production scheduler completed in 6,555 ms with the same exact row result and final state. Across 817 samples, every partial state had freshness zero. All 75 requests returned 200; maxima were 31.906/26.020/23.547 ms.
- SQLite forced-stage failure: the scheduler invalidated all 20,000 rows, preserved both sentinels, and all 75 requests returned 200 with a maximum of 59.237 ms.
- PostgreSQL forced-stage failure: the scheduler invalidated all 20,000 rows, preserved both sentinels, and all 75 requests returned 200 with a maximum of 27.783 ms.
- Teardown is clean: no lane container, network, image, listener, database, cookie, service response, or webhook secret remains. Sanitized timing/state/memory evidence and hashes are retained outside the repository.

## Review plan

- Current-main broad-reviewed production head: `c9d4d65efe6b32644a6d9978449a84cf3239dd88`
- Deterministic publication-barrier correction: `27f4cb03f6ba2fc483372d3dbf8aba91eb1f25d3`
- Real-statement timing correction: `83499f88b8e55a021339007002eb5d9422b079ee`
- Staging-anchored scheduled-probe correction: `f9285e3a9c417073383d422ce4a353390446e08e`
- Material-scope change declared? No; all new corrections are confined to the existing scale test
- Independent concurrency reviewer: no actionable P1/P2/P3 at `27f4cb03`; publication barrier, cleanup, and deterministic synchronization accepted
- Independent SQL compatibility reviewer: one P2 test-contract finding corrected across the bounded cycles; targeted final delta `83499f88..f9285e3a` passed with no remaining finding
- Independent data-safety/publication reviewer: no actionable P1/P2/P3; fail-closed freshness, user scope, absence ordering, and failure invalidation accepted
- GitHub Codex review head: `f9285e3a9c417073383d422ce4a353390446e08e`; completed with no new findings
- Maintainer decision: standing convergence authorization active; merge only after every exact-head check and review surface is green

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| F1 | P1 | Introduced regression | PostgreSQL rejected the original untyped staged ratio as text for a real target | Fixed before the current correction epoch by explicit ratio typing and verified on PostgreSQL | None |
| F2 | P3 | Cross-database precision | PostgreSQL `CAST AS REAL` rounded `123456.789123456` to `123456.7890625` in a `DOUBLE PRECISION` target | Fixed by `CAST AS DOUBLE PRECISION`; fresh PostgreSQL RED/GREEN and delta reviews passed | None |
| V1 | Gate failure | Nondeterministic test mechanism | Hosted CI repeated 2,037.443/2,031.011 ms while diagnostics showed sub-ms `SELECT 1` execution and timer-start delay dominating the old metric | Replaced with a real publication barrier, then retained the unchanged end-to-end threshold on probes armed inside the first real staging statement | None |
| F3 | P2 | Test-contract coverage | The first deterministic correction paused after staging and did not bound the real staging loop | Fixed by measuring exactly 100 real statements and 20 staging-anchored scheduled probes; targeted final review passed | None |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads or local findings remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by broad review plus targeted delta review
- [x] Base overlap and final merge tree were reviewed
- [x] Maintainer approved merge under the standing convergence authorization
- [x] Post-merge exact-SHA verification is planned
