### PR TITLE
fix(web): prevent mobile page overflow

### DIFF
--- a/apps/web/src/components/layout/premium-page-header.tsx
+++ b/apps/web/src/components/layout/premium-page-header.tsx
@@ -72,7 +72,7 @@ export const PremiumPageHeader = ({
 				animationFillMode: "backwards",
 			}}
 		>
-			<div className="flex items-start justify-between gap-4">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
 				<div className="space-y-1">
 					{/* Label with optional icon */}
 					{label && (

--- a/apps/web/src/features/dashboard/components/dashboard-client.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-client.tsx
@@ -522,7 +522,7 @@ export const DashboardClient = () => {
 				className="relative animate-in fade-in slide-in-from-bottom-4 duration-500"
 				style={{ animationDelay: "0ms" }}
 			>
-				<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
 					<div className="space-y-1">
 						<div className="flex items-center gap-2 text-sm text-muted-foreground">
 							<Activity className="h-4 w-4" />

--- a/apps/web/src/features/library/components/library-header.tsx
+++ b/apps/web/src/features/library/components/library-header.tsx
@@ -218,7 +218,7 @@ export const LibraryHeader: React.FC<LibraryHeaderProps> = ({
 				className="relative animate-in fade-in slide-in-from-bottom-4 duration-500"
 				style={{ animationFillMode: "backwards" }}
 			>
-				<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
 					<div className="space-y-1">
 						{/* Label with icon */}
 						<div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -351,7 +351,7 @@ export const LibraryHeader: React.FC<LibraryHeaderProps> = ({
 					{/* Service Toggle + Search Row */}
 					<div className="flex flex-wrap items-center gap-4">
 						{/* Service Toggle Pills */}
-						<div className="inline-flex rounded-xl bg-background/50 border border-border/50 p-1">
+						<div className="inline-flex max-w-full shrink overflow-x-auto rounded-xl bg-background/50 border border-border/50 p-1">
 							{SERVICE_OPTIONS.map((option) => {
 								const Icon = option.icon;
 								const isActive = serviceFilter === option.value;

--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -154,7 +154,38 @@ test.describe("mobile page overflow", () => {
 		await installPopulatedFixtures(page);
 		for (const width of [390, 375]) {
 			await page.setViewportSize({ width, height: 844 });
-			await assertNoHorizontalOverflow(page, "/history", "The Populated History Fixture");
+			await assertNoHorizontalOverflow(
+				page,
+				"/history",
+				"The Populated History Fixture",
+				async (currentPage, clientWidth) => {
+					const timeline = currentPage.getByRole("button", { name: "Timeline", exact: true });
+					const table = currentPage.getByRole("button", { name: "Table", exact: true });
+					const viewToggle = timeline.locator("..");
+					await expect(viewToggle).toBeVisible();
+					await expect(timeline).toBeVisible();
+					await expect(table).toBeVisible();
+
+					for (const control of [viewToggle, timeline, table]) {
+						const box = await control.boundingBox();
+						expect(box?.x ?? 0).toBeGreaterThanOrEqual(0);
+						expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(clientWidth);
+					}
+
+					await timeline.click();
+					await expect(timeline).toHaveClass(/(?:^|\s)text-foreground(?:\s|$)/);
+					await expect(table).toHaveClass(/(?:^|\s)text-muted-foreground(?:\s|$)/);
+					await table.click();
+					await expect(table).toHaveClass(/(?:^|\s)text-foreground(?:\s|$)/);
+					await expect(timeline).toHaveClass(/(?:^|\s)text-muted-foreground(?:\s|$)/);
+
+					const refresh = currentPage.getByRole("button", { name: "Refresh", exact: true }).first();
+					await expect(refresh).toBeVisible();
+					const refreshBox = await refresh.boundingBox();
+					expect(refreshBox?.x ?? 0).toBeGreaterThanOrEqual(0);
+					expect((refreshBox?.x ?? 0) + (refreshBox?.width ?? 0)).toBeLessThanOrEqual(clientWidth);
+				},
+			);
 		}
 	});
 

--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -135,7 +135,18 @@ test.describe("mobile page overflow", () => {
 		await installPopulatedFixtures(page);
 		for (const width of [390, 375]) {
 			await page.setViewportSize({ width, height: 844 });
-			await assertNoHorizontalOverflow(page, "/dashboard", "items in queue");
+			await assertNoHorizontalOverflow(
+				page,
+				"/dashboard",
+				"items in queue",
+				async (currentPage, clientWidth) => {
+					const refresh = currentPage.getByRole("button", { name: "Refresh", exact: true }).first();
+					await expect(refresh).toBeVisible();
+					const box = await refresh.boundingBox();
+					expect(box?.x ?? 0).toBeGreaterThanOrEqual(0);
+					expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(clientWidth);
+				},
+			);
 		}
 	});
 
@@ -159,9 +170,25 @@ test.describe("mobile page overflow", () => {
 					const serviceTabs = currentPage
 						.getByRole("button", { name: "All", exact: true })
 						.locator("..");
+					const initialOverflow = await serviceTabs.evaluate((element) => ({
+						clientWidth: element.clientWidth,
+						scrollWidth: element.scrollWidth,
+					}));
+					expect(initialOverflow.scrollWidth).toBeGreaterThan(initialOverflow.clientWidth);
 					const box = await serviceTabs.boundingBox();
 					expect(box?.x ?? 0).toBeGreaterThanOrEqual(0);
 					expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(clientWidth);
+
+					const authorsTab = currentPage.getByRole("button", { name: "Authors", exact: true });
+					await authorsTab.scrollIntoViewIfNeeded();
+					const authorsBox = await authorsTab.boundingBox();
+					const wrapperBox = await serviceTabs.boundingBox();
+					expect(authorsBox?.x ?? 0).toBeGreaterThanOrEqual(wrapperBox?.x ?? 0);
+					expect((authorsBox?.x ?? 0) + (authorsBox?.width ?? 0)).toBeLessThanOrEqual(
+						(wrapperBox?.x ?? 0) + (wrapperBox?.width ?? 0),
+					);
+					await authorsTab.click();
+					await expect(authorsTab).toHaveClass(/text-white/);
 				},
 			);
 		}

--- a/e2e/mobile-overflow.spec.ts
+++ b/e2e/mobile-overflow.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "@playwright/test";
+
+const service = {
+	id: "sonarr-mobile-813",
+	label: "Living Room Sonarr",
+	service: "SONARR",
+	baseUrl: "http://sonarr.test",
+	externalUrl: null,
+	enabled: true,
+	isDefault: true,
+	hasApiKey: true,
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const queueItem = {
+	id: "queue-mobile-813",
+	instanceId: service.id,
+	instanceName: service.label,
+	service: "sonarr",
+	title: "The Populated Queue Fixture",
+	status: "downloading",
+	size: 100,
+	sizeleft: 40,
+};
+
+const historyItem = {
+	id: "history-mobile-813",
+	instanceId: service.id,
+	instanceName: service.label,
+	service: "sonarr",
+	title: "The Populated History Fixture",
+	status: "imported",
+	date: "2026-08-29T12:00:00.000Z",
+};
+
+const libraryItem = {
+	id: "library-mobile-813",
+	instanceId: service.id,
+	instanceName: service.label,
+	service: "sonarr",
+	type: "series",
+	title: "The Populated Library Fixture",
+	year: 2026,
+	monitored: true,
+	hasFile: true,
+};
+
+async function installPopulatedFixtures(page: import("@playwright/test").Page) {
+	await page.route("**/api/services", async (route) => {
+		if (route.request().method() === "GET") {
+			await route.fulfill({ json: { services: [service] } });
+			return;
+		}
+		await route.continue();
+	});
+	await page.route("**/api/dashboard/queue", (route) =>
+		route.fulfill({
+			json: {
+				instances: [
+					{
+						instanceId: service.id,
+						instanceName: service.label,
+						service: "sonarr",
+						data: [queueItem],
+					},
+				],
+				aggregated: [queueItem],
+				totalCount: 1,
+			},
+		}),
+	);
+	await page.route("**/api/dashboard/statistics", (route) => route.fulfill({ json: {} }));
+	await page.route("**/api/dashboard/history**", (route) =>
+		route.fulfill({
+			json: {
+				instances: [
+					{
+						instanceId: service.id,
+						instanceName: service.label,
+						service: "sonarr",
+						data: [historyItem],
+					},
+				],
+				aggregated: [historyItem],
+				totalCount: 1,
+			},
+		}),
+	);
+	await page.route("**/api/library/sync/status", (route) =>
+		route.fulfill({ json: { instances: [] } }),
+	);
+	await page.route("**/api/library?**", (route) =>
+		route.fulfill({
+			json: {
+				items: [libraryItem],
+				pagination: { page: 1, limit: 50, totalItems: 1, totalPages: 1 },
+				appliedFilters: {},
+			},
+		}),
+	);
+}
+
+async function assertNoHorizontalOverflow(
+	page: import("@playwright/test").Page,
+	path: string,
+	expectedText: string,
+	assertions?: (page: import("@playwright/test").Page, clientWidth: number) => Promise<void>,
+) {
+	await page.goto(path);
+	await expect(page.locator("main")).toBeVisible();
+	await expect(page.getByText(expectedText)).toBeVisible();
+	const metrics = await page.evaluate(() => {
+		const root = document.documentElement;
+		const offenders = [...document.querySelectorAll<HTMLElement>("body *")]
+			.map((element) => {
+				const rect = element.getBoundingClientRect();
+				return {
+					tag: element.tagName,
+					className: element.className,
+					right: rect.right,
+					left: rect.left,
+				};
+			})
+			.filter(({ right, left }) => right > root.clientWidth + 1 || left < -1)
+			.slice(0, 12);
+		return { clientWidth: root.clientWidth, scrollWidth: root.scrollWidth, offenders };
+	});
+	expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+	await assertions?.(page, metrics.clientWidth);
+}
+
+test.describe("mobile page overflow", () => {
+	test("dashboard stays within the viewport with populated data", async ({ page }) => {
+		await installPopulatedFixtures(page);
+		for (const width of [390, 375]) {
+			await page.setViewportSize({ width, height: 844 });
+			await assertNoHorizontalOverflow(page, "/dashboard", "items in queue");
+		}
+	});
+
+	test("history stays within the viewport with populated data", async ({ page }) => {
+		await installPopulatedFixtures(page);
+		for (const width of [390, 375]) {
+			await page.setViewportSize({ width, height: 844 });
+			await assertNoHorizontalOverflow(page, "/history", "The Populated History Fixture");
+		}
+	});
+
+	test("library stays within the viewport with populated data", async ({ page }) => {
+		await installPopulatedFixtures(page);
+		for (const width of [390, 375]) {
+			await page.setViewportSize({ width, height: 844 });
+			await assertNoHorizontalOverflow(
+				page,
+				"/library",
+				"The Populated Library Fixture",
+				async (currentPage, clientWidth) => {
+					const serviceTabs = currentPage
+						.getByRole("button", { name: "All", exact: true })
+						.locator("..");
+					const box = await serviceTabs.boundingBox();
+					expect(box?.x ?? 0).toBeGreaterThanOrEqual(0);
+					expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(clientWidth);
+				},
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Keeps populated Dashboard, History, and Library pages inside 390 px and 375 px mobile viewports without clipping their actions. Headers stack on mobile, and Library's media tabs remain reachable through a bounded inner scroller.

## Related issue

Closes #813

## Scope

- Responsive title and action layout for Dashboard, History's shared page header, and Library.
- Bounded, horizontally scrollable Library media tabs.
- Populated Playwright regressions for the three reported routes at 390 px and 375 px.

## Non-goals

- No API, history-pagination, service-integration, database, or dependency change.
- No global shell redesign for widths below the reported and common mobile targets.
- No change to desktop layout above the existing `sm` breakpoint.

## Acceptance criteria

- [x] Dashboard, History, and Library have no document-level horizontal overflow at 390 px and 375 px after populated data renders.
- [x] Dashboard Refresh and History actions remain visible and inside the viewport.
- [x] Library media tabs stay within a bounded inner scroller, and the final Authors tab can be scrolled into view and activated.
- [x] Desktop header layout remains a row at and above the existing `sm` breakpoint.
- [x] Playwright covers the reporter-shaped populated routes and control reachability.

## Changes

- Stack Dashboard and Library title/actions below `sm`.
- Stack title/actions in the shared `PremiumPageHeader`, including History, below `sm`.
- Bound the Library service-tab wrapper to the available width and give it intentional horizontal scrolling.
- Add populated mobile assertions for document width, Refresh bounds, inner-tab overflow, scrolling, activation, and selected state.

## Risk classification

- [ ] Trivial
- [x] Standard
- [ ] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] User-visible behavior was live-verified
- [x] Query-key, incognito, Prisma-ownership, optional-service, count, and action-link checks are not affected by this layout-only change
- [x] Duplicate surfaces were checked and the shared-header use is intentional

The original exact-head gate at `8e4eacc0bb7de87ffbfc37ec67b5c513c26a2240` passed format, shared build, root typecheck, lint, production build, and diff checks. Tests reported shared 89, web 669, and API 4,675 passed with 53 API skips. A test-only correction produced current head `8610f4ac1032fc54fc1705a4e858f07a47ac09f9` and directly covers History's Timeline/Table toggle and Refresh bounds and interactions.

A fresh corrected current-main preview merged without conflicts from `609759bc5f96b08368297ce12bf10fff9a4fda21`. Its tree is `dede279e0c67f1d774f21ac46c88e586d9596c85`, exactly matching the corrected candidate tree, with the frozen four-file manifest intact. The original preview passed shared build, 27 focused web tests, web typecheck, focused ESLint and Biome checks, and cached diff checks; the correction preview passed applicable Biome, Playwright discovery, shared build, and cached diff checks.

The fresh authenticated Playwright correction run used the repository's canonical `localhost` browser origin, one worker, traces enabled, and zero retries. It passed 4/4 project tests: auth setup plus populated Dashboard, History, and Library. Both 390 px and 375 px checks passed. Dashboard Refresh stayed in bounds; History's Timeline/Table toggle and Refresh were individually bounded and the selected state changed after each click; Library retained real inner overflow and allowed Authors to be scrolled into view, activated, and shown as selected.

An earlier evidence attempt authenticated on `127.0.0.1` while the test project navigated on `localhost`. The host-scoped session cookie was not sent, and all route cases correctly failed on the login page. This was a harness-origin mismatch, not product evidence; the canonical zero-retry run above is the acceptance result.

The first correction-preview attempt stopped in authentication setup because the fresh preview had not yet built the required `@arr/shared` workspace package; Next displayed its module-resolution build error and no mobile route test ran. After the required shared build and disposable web-process restart, the separate zero-retry run above passed. The failed artifacts remain distinct from the acceptance artifacts.

A separate authenticated populated desktop probe at 1280 x 900 passed all three routes. Each document stayed exactly 1280 px wide, each responsive header computed to a row, and every header action stayed inside the viewport.

## Review plan

- Initial broad-reviewed head for this current-main epoch: `8e4eacc0bb7de87ffbfc37ec67b5c513c26a2240`
- Correction head: `8610f4ac1032fc54fc1705a4e858f07a47ac09f9`
- Targeted delta: `8e4eacc0bb7de87ffbfc37ec67b5c513c26a2240..8610f4ac1032fc54fc1705a4e858f07a47ac09f9`
- Material scope change declared: no
- Independent responsive regression review: no P0-P2 source regression; one P3 History action-bounds coverage gap accepted and corrected; targeted delta review confirmed it resolved with no new P0-P2 finding
- Independent Playwright evidence review: no actionable P0-P3 evidence finding
- Independent data-safety review: not required; no deletion, restore, database, or upstream mutation path changes
- GitHub Codex review head: completed at `8610f4ac1032fc54fc1705a4e858f07a47ac09f9` with the configured no-findings thumbs-up signal
- Maintainer decision: pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| R1 | P2 | Contract violation | Dashboard root could remain 390 px while Refresh was visibly clipped | Fixed at `8e4eacc`; Refresh bounds pass at 390 px and 375 px | None |
| R2 | P3 | Contract violation | Library wrapper bounds did not prove tabs were scrollable or reachable | Fixed at `8e4eacc`; Authors scroll, bounds, activation, and selected state pass | None |
| R3 | P2 | Contract violation | External report initially attributed correction results to pre-correction SHA `f18b51d` | Corrected after a post-commit exact-head rerun at `8e4eacc` | None |
| R4 | P3 | Contract violation | History's document-width assertion did not independently prove Timeline/Table/Refresh remained reachable | Corrected at `8610f4a`; direct bounds and toggle-state interactions pass at 390 px and 375 px | Targeted correction-delta review confirmed resolution; no new P0-P2 finding |

## Final merge gate

- [x] Exact-head CI is green after the ready transition
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or targeted delta review
- [x] Base and merge tree were checked against current main
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
