### PR TITLE
fix(pulse): invalidate cache after service creation

### DIFF
--- a/apps/api/src/routes/__tests__/services-pulse-cache-invalidation.test.ts
+++ b/apps/api/src/routes/__tests__/services-pulse-cache-invalidation.test.ts
@@ -1,0 +1,176 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const { collectorCalls, mockPulseCollector } = vi.hoisted(() => {
+	const calls = new Map<string, number>();
+	return {
+		collectorCalls: calls,
+		mockPulseCollector: vi.fn(async (_app: unknown, userId: string) => {
+			const generation = (calls.get(userId) ?? 0) + 1;
+			calls.set(userId, generation);
+			return [
+				{
+					id: `pulse-${userId}-${generation}`,
+					severity: "warning",
+					category: "health",
+					title: `Pulse for ${userId}`,
+					detail: `Generation ${generation}`,
+					source: "test",
+					timestamp: "2026-08-29T00:00:00.000Z",
+					actionUrl: "/settings/services",
+				},
+			];
+		}),
+	};
+});
+
+vi.mock("../../lib/pulse/collectors.js", () => ({
+	pulseCollectors: [mockPulseCollector],
+}));
+
+vi.mock("../../lib/services/tag-manager.js", () => ({
+	upsertTags: vi.fn().mockResolvedValue([]),
+	updateInstanceTags: vi.fn().mockResolvedValue(undefined),
+}));
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { registerPulseRoutes } from "../pulse.js";
+import { registerServiceRoutes } from "../services.js";
+import { createMockEncryptor, registerTestErrorHandler } from "./test-helpers.js";
+
+const USER_HEADER = "x-test-user";
+const USER_A = "pulse-cache-user-a";
+const USER_B = "pulse-cache-user-b";
+
+function createMockPrisma() {
+	const prisma = {
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
+		serviceInstance: {
+			create: vi.fn().mockImplementation(({ data }: any) => ({
+				id: "service-new",
+				...data,
+				externalUrl: data.externalUrl ?? null,
+				enabled: data.enabled ?? true,
+				isDefault: data.isDefault ?? false,
+				createdAt: new Date("2026-08-29T00:00:00.000Z"),
+				updatedAt: new Date("2026-08-29T00:00:00.000Z"),
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+				storageGroupId: data.storageGroupId ?? null,
+				hasLocalFilesystemAccess: false,
+				pathPrefix: null,
+				identityStatus: "UNVERIFIED",
+				tags: [],
+			})),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
+	};
+	return Object.assign(prisma, {
+		$transaction: vi.fn(async (callback: (tx: typeof prisma) => Promise<unknown>) =>
+			callback(prisma),
+		),
+	});
+}
+
+function setupUserAuth(app: FastifyInstance) {
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (request: any) => {
+		const userId = request.headers[USER_HEADER];
+		if (typeof userId === "string") {
+			request.currentUser = { id: userId, username: userId };
+			request.sessionToken = "test-session-token";
+		}
+	});
+}
+
+function firstPulseId(response: { payload: string }): string {
+	return JSON.parse(response.payload).items[0].id;
+}
+
+describe("service creation Pulse cache invalidation", () => {
+	let app: FastifyInstance;
+	let prisma: ReturnType<typeof createMockPrisma>;
+
+	beforeAll(async () => {
+		collectorCalls.clear();
+		prisma = createMockPrisma();
+		app = Fastify();
+		app.decorate("prisma", prisma as any);
+		app.decorate("encryptor", createMockEncryptor() as any);
+		setupUserAuth(app);
+		registerTestErrorHandler(app);
+		await app.register(registerPulseRoutes);
+		await app.register(registerServiceRoutes);
+		await app.ready();
+	});
+
+	afterAll(async () => {
+		await app?.close();
+	});
+
+	it("evicts only the creating user's real Pulse cache entry", async () => {
+		const initialA = await app.inject({
+			method: "GET",
+			url: "/pulse",
+			headers: { [USER_HEADER]: USER_A },
+		});
+		const initialB = await app.inject({
+			method: "GET",
+			url: "/pulse",
+			headers: { [USER_HEADER]: USER_B },
+		});
+
+		expect(initialA.statusCode).toBe(200);
+		expect(initialB.statusCode).toBe(200);
+		expect(firstPulseId(initialA)).toBe(`pulse-${USER_A}-1`);
+		expect(firstPulseId(initialB)).toBe(`pulse-${USER_B}-1`);
+		expect(collectorCalls).toEqual(
+			new Map([
+				[USER_A, 1],
+				[USER_B, 1],
+			]),
+		);
+
+		const createResponse = await app.inject({
+			method: "POST",
+			url: "/services",
+			headers: { [USER_HEADER]: USER_A },
+			payload: {
+				label: "Tenant A Sonarr",
+				baseUrl: "http://sonarr:8989",
+				apiKey: "tenant-a-api-key",
+				service: "sonarr",
+			},
+		});
+
+		expect(createResponse.statusCode).toBe(201);
+		expect(prisma.serviceInstance.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ userId: USER_A }),
+			}),
+		);
+
+		const refreshedA = await app.inject({
+			method: "GET",
+			url: "/pulse",
+			headers: { [USER_HEADER]: USER_A },
+		});
+		const cachedB = await app.inject({
+			method: "GET",
+			url: "/pulse",
+			headers: { [USER_HEADER]: USER_B },
+		});
+
+		expect(firstPulseId(refreshedA)).toBe(`pulse-${USER_A}-2`);
+		expect(firstPulseId(cachedB)).toBe(`pulse-${USER_B}-1`);
+		expect(collectorCalls).toEqual(
+			new Map([
+				[USER_A, 2],
+				[USER_B, 1],
+			]),
+		);
+	});
+});

--- a/apps/api/src/routes/__tests__/services-pulse-cache-invalidation.test.ts
+++ b/apps/api/src/routes/__tests__/services-pulse-cache-invalidation.test.ts
@@ -1,27 +1,63 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-const { collectorCalls, mockPulseCollector } = vi.hoisted(() => {
-	const calls = new Map<string, number>();
-	return {
-		collectorCalls: calls,
-		mockPulseCollector: vi.fn(async (_app: unknown, userId: string) => {
-			const generation = (calls.get(userId) ?? 0) + 1;
-			calls.set(userId, generation);
-			return [
-				{
-					id: `pulse-${userId}-${generation}`,
-					severity: "warning",
-					category: "health",
-					title: `Pulse for ${userId}`,
-					detail: `Generation ${generation}`,
-					source: "test",
-					timestamp: "2026-08-29T00:00:00.000Z",
-					actionUrl: "/settings/services",
-				},
-			];
-		}),
-	};
-});
+const { collectorCalls, persistedServiceRevisions, queueDeferredCollection, mockPulseCollector } =
+	vi.hoisted(() => {
+		type CollectionPlan = {
+			started: Promise<void>;
+			markStarted: () => void;
+			releasePromise: Promise<void>;
+			release: () => void;
+		};
+
+		const calls = new Map<string, number>();
+		const serviceRevisions = new Map<string, number>();
+		const plans = new Map<string, CollectionPlan[]>();
+
+		function deferred(): { promise: Promise<void>; resolve: () => void } {
+			let resolve!: () => void;
+			const promise = new Promise<void>((resolvePromise) => {
+				resolve = resolvePromise;
+			});
+			return { promise, resolve };
+		}
+
+		return {
+			collectorCalls: calls,
+			persistedServiceRevisions: serviceRevisions,
+			queueDeferredCollection(userId: string) {
+				const started = deferred();
+				const release = deferred();
+				const plan: CollectionPlan = {
+					started: started.promise,
+					markStarted: started.resolve,
+					releasePromise: release.promise,
+					release: release.resolve,
+				};
+				plans.set(userId, [...(plans.get(userId) ?? []), plan]);
+				return { started: plan.started, release: plan.release };
+			},
+			mockPulseCollector: vi.fn(async (_app: unknown, userId: string) => {
+				const call = (calls.get(userId) ?? 0) + 1;
+				calls.set(userId, call);
+				const capturedServiceRevision = serviceRevisions.get(userId) ?? 0;
+				const plan = plans.get(userId)?.shift();
+				plan?.markStarted();
+				if (plan) await plan.releasePromise;
+				return [
+					{
+						id: `pulse-${userId}-service-${capturedServiceRevision}-call-${call}`,
+						severity: "warning",
+						category: "health",
+						title: `Pulse for ${userId}`,
+						detail: `Service revision ${capturedServiceRevision}`,
+						source: "test",
+						timestamp: "2026-08-29T00:00:00.000Z",
+						actionUrl: "/settings/services",
+					},
+				];
+			}),
+		};
+	});
 
 vi.mock("../../lib/pulse/collectors.js", () => ({
 	pulseCollectors: [mockPulseCollector],
@@ -38,8 +74,6 @@ import { registerServiceRoutes } from "../services.js";
 import { createMockEncryptor, registerTestErrorHandler } from "./test-helpers.js";
 
 const USER_HEADER = "x-test-user";
-const USER_A = "pulse-cache-user-a";
-const USER_B = "pulse-cache-user-b";
 
 function createMockPrisma() {
 	const prisma = {
@@ -48,22 +82,28 @@ function createMockPrisma() {
 			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 		},
 		serviceInstance: {
-			create: vi.fn().mockImplementation(({ data }: any) => ({
-				id: "service-new",
-				...data,
-				externalUrl: data.externalUrl ?? null,
-				enabled: data.enabled ?? true,
-				isDefault: data.isDefault ?? false,
-				createdAt: new Date("2026-08-29T00:00:00.000Z"),
-				updatedAt: new Date("2026-08-29T00:00:00.000Z"),
-				encryptedHttpAuthCredentials: null,
-				httpAuthEncryptionIv: null,
-				storageGroupId: data.storageGroupId ?? null,
-				hasLocalFilesystemAccess: false,
-				pathPrefix: null,
-				identityStatus: "UNVERIFIED",
-				tags: [],
-			})),
+			create: vi.fn().mockImplementation(({ data }: any) => {
+				persistedServiceRevisions.set(
+					data.userId,
+					(persistedServiceRevisions.get(data.userId) ?? 0) + 1,
+				);
+				return {
+					id: "service-new",
+					...data,
+					externalUrl: data.externalUrl ?? null,
+					enabled: data.enabled ?? true,
+					isDefault: data.isDefault ?? false,
+					createdAt: new Date("2026-08-29T00:00:00.000Z"),
+					updatedAt: new Date("2026-08-29T00:00:00.000Z"),
+					encryptedHttpAuthCredentials: null,
+					httpAuthEncryptionIv: null,
+					storageGroupId: data.storageGroupId ?? null,
+					hasLocalFilesystemAccess: false,
+					pathPrefix: null,
+					identityStatus: "UNVERIFIED",
+					tags: [],
+				};
+			}),
 			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 		},
 	};
@@ -96,6 +136,7 @@ describe("service creation Pulse cache invalidation", () => {
 
 	beforeAll(async () => {
 		collectorCalls.clear();
+		persistedServiceRevisions.clear();
 		prisma = createMockPrisma();
 		app = Fastify();
 		app.decorate("prisma", prisma as any);
@@ -111,66 +152,114 @@ describe("service creation Pulse cache invalidation", () => {
 		await app?.close();
 	});
 
-	it("evicts only the creating user's real Pulse cache entry", async () => {
-		const initialA = await app.inject({
+	async function getPulse(userId: string) {
+		return app.inject({
 			method: "GET",
 			url: "/pulse",
-			headers: { [USER_HEADER]: USER_A },
+			headers: { [USER_HEADER]: userId },
 		});
-		const initialB = await app.inject({
-			method: "GET",
-			url: "/pulse",
-			headers: { [USER_HEADER]: USER_B },
-		});
+	}
 
-		expect(initialA.statusCode).toBe(200);
-		expect(initialB.statusCode).toBe(200);
-		expect(firstPulseId(initialA)).toBe(`pulse-${USER_A}-1`);
-		expect(firstPulseId(initialB)).toBe(`pulse-${USER_B}-1`);
-		expect(collectorCalls).toEqual(
-			new Map([
-				[USER_A, 1],
-				[USER_B, 1],
-			]),
-		);
-
-		const createResponse = await app.inject({
+	async function createService(userId: string) {
+		const response = await app.inject({
 			method: "POST",
 			url: "/services",
-			headers: { [USER_HEADER]: USER_A },
+			headers: { [USER_HEADER]: userId },
 			payload: {
-				label: "Tenant A Sonarr",
+				label: `Sonarr for ${userId}`,
 				baseUrl: "http://sonarr:8989",
-				apiKey: "tenant-a-api-key",
+				apiKey: "tenant-api-key",
 				service: "sonarr",
 			},
 		});
-
-		expect(createResponse.statusCode).toBe(201);
-		expect(prisma.serviceInstance.create).toHaveBeenCalledWith(
+		expect(response.statusCode).toBe(201);
+		expect(prisma.serviceInstance.create).toHaveBeenLastCalledWith(
 			expect.objectContaining({
-				data: expect.objectContaining({ userId: USER_A }),
+				data: expect.objectContaining({ userId }),
 			}),
 		);
+		return response;
+	}
 
-		const refreshedA = await app.inject({
-			method: "GET",
-			url: "/pulse",
-			headers: { [USER_HEADER]: USER_A },
-		});
-		const cachedB = await app.inject({
-			method: "GET",
-			url: "/pulse",
-			headers: { [USER_HEADER]: USER_B },
-		});
+	it("does not let a pre-create no-entry GET overwrite a newer published response", async () => {
+		const userId = "pulse-overlap-newer-publication";
+		const oldCollection = queueDeferredCollection(userId);
+		const oldResponsePromise = getPulse(userId);
+		await oldCollection.started;
 
-		expect(firstPulseId(refreshedA)).toBe(`pulse-${USER_A}-2`);
-		expect(firstPulseId(cachedB)).toBe(`pulse-${USER_B}-1`);
-		expect(collectorCalls).toEqual(
-			new Map([
-				[USER_A, 2],
-				[USER_B, 1],
-			]),
-		);
+		await createService(userId);
+		const newResponse = await getPulse(userId);
+		expect(firstPulseId(newResponse)).toBe(`pulse-${userId}-service-1-call-2`);
+
+		oldCollection.release();
+		const oldResponse = await oldResponsePromise;
+		expect(firstPulseId(oldResponse)).toBe(`pulse-${userId}-service-0-call-1`);
+
+		const cachedResponse = await getPulse(userId);
+		expect(firstPulseId(cachedResponse)).toBe(`pulse-${userId}-service-1-call-2`);
+		expect(collectorCalls.get(userId)).toBe(2);
+	});
+
+	it("rotates the generation when invalidation finds no cache entry", async () => {
+		const userId = "pulse-overlap-false-delete";
+		const oldCollection = queueDeferredCollection(userId);
+		const oldResponsePromise = getPulse(userId);
+		await oldCollection.started;
+
+		await createService(userId);
+		oldCollection.release();
+		const oldResponse = await oldResponsePromise;
+		expect(firstPulseId(oldResponse)).toBe(`pulse-${userId}-service-0-call-1`);
+
+		const postInvalidationResponse = await getPulse(userId);
+		expect(firstPulseId(postInvalidationResponse)).toBe(`pulse-${userId}-service-1-call-2`);
+		expect(collectorCalls.get(userId)).toBe(2);
+	});
+
+	it("keeps user B cached while user A overlaps service invalidation", async () => {
+		const userA = "pulse-overlap-tenant-a";
+		const userB = "pulse-overlap-tenant-b";
+		const primedB = await getPulse(userB);
+		expect(firstPulseId(primedB)).toBe(`pulse-${userB}-service-0-call-1`);
+
+		const oldCollectionA = queueDeferredCollection(userA);
+		const oldResponseAPromise = getPulse(userA);
+		await oldCollectionA.started;
+		await createService(userA);
+
+		const newResponseA = await getPulse(userA);
+		expect(firstPulseId(newResponseA)).toBe(`pulse-${userA}-service-1-call-2`);
+		oldCollectionA.release();
+		await oldResponseAPromise;
+
+		const cachedB = await getPulse(userB);
+		expect(firstPulseId(cachedB)).toBe(`pulse-${userB}-service-0-call-1`);
+		expect(collectorCalls.get(userB)).toBe(1);
+	});
+
+	it("rejects every old producer after a new generation publishes", async () => {
+		const userId = "pulse-overlap-multiple-old-producers";
+		const firstOldCollection = queueDeferredCollection(userId);
+		const secondOldCollection = queueDeferredCollection(userId);
+		const firstOldResponsePromise = getPulse(userId);
+		const secondOldResponsePromise = getPulse(userId);
+		await Promise.all([firstOldCollection.started, secondOldCollection.started]);
+
+		await createService(userId);
+		const newResponse = await getPulse(userId);
+		expect(firstPulseId(newResponse)).toBe(`pulse-${userId}-service-1-call-3`);
+
+		firstOldCollection.release();
+		secondOldCollection.release();
+		const [firstOldResponse, secondOldResponse] = await Promise.all([
+			firstOldResponsePromise,
+			secondOldResponsePromise,
+		]);
+		expect(firstPulseId(firstOldResponse)).toBe(`pulse-${userId}-service-0-call-1`);
+		expect(firstPulseId(secondOldResponse)).toBe(`pulse-${userId}-service-0-call-2`);
+
+		const cachedResponse = await getPulse(userId);
+		expect(firstPulseId(cachedResponse)).toBe(`pulse-${userId}-service-1-call-3`);
+		expect(collectorCalls.get(userId)).toBe(3);
 	});
 });

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -306,6 +306,34 @@ describe("POST /services", () => {
 				}),
 			}),
 		);
+
+		expect(mockInvalidatePulseCache).toHaveBeenCalledOnce();
+		expect(mockInvalidatePulseCache).toHaveBeenCalledWith("user-1");
+	});
+
+	it("invalidates only the creating user's Pulse cache once after persistence", async () => {
+		const lifecycle: string[] = [];
+		mockPrisma.serviceInstance.create.mockImplementationOnce(async ({ data }: any) => {
+			lifecycle.push("persisted:user-1");
+			return makeInstance({ id: "inst-new", ...data });
+		});
+		mockInvalidatePulseCache.mockImplementationOnce((userId: string) => {
+			lifecycle.push(`invalidated:${userId}`);
+		});
+
+		const res = await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Tenant Sonarr",
+				baseUrl: "http://sonarr:8989",
+				apiKey: "my-secret-api-key",
+				service: "sonarr",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(lifecycle).toEqual(["persisted:user-1", "invalidated:user-1"]);
+		expect(mockInvalidatePulseCache).toHaveBeenCalledOnce();
+		expect(mockInvalidatePulseCache).not.toHaveBeenCalledWith("user-2");
 	});
 
 	it("demotes other instances when isDefault is true", async () => {
@@ -359,6 +387,24 @@ describe("POST /services", () => {
 			"cannot be changed while a library cleanup operation is in progress",
 		);
 		expect(mockPrisma.serviceInstance.create).not.toHaveBeenCalled();
+		expect(mockInvalidatePulseCache).not.toHaveBeenCalled();
+	});
+
+	it("does not invalidate Pulse when instance creation fails", async () => {
+		mockPrisma.serviceInstance.create.mockRejectedValueOnce(new Error("database unavailable"));
+
+		const res = await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Unavailable Sonarr",
+				baseUrl: "http://sonarr:8989",
+				apiKey: "my-secret-api-key",
+				service: "sonarr",
+			},
+		});
+
+		expect(res.statusCode).toBe(500);
+		expect(mockPrisma.serviceInstance.create).toHaveBeenCalledOnce();
+		expect(mockInvalidatePulseCache).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -21,9 +21,24 @@ const CACHE_TTL_MS = 60_000;
 interface CacheEntry {
 	data: PulseResponse;
 	expiresAt: number;
+	generation: symbol;
 }
 
 const pulseCache = new Map<string, CacheEntry>();
+
+// The Pulse cache is process-local, and the production runtime lease permits
+// exactly one API process per database. Keep one opaque current-generation
+// token per user so invalidation can fence publications that began earlier in
+// this same process without retaining prior tokens or in-flight requests.
+const pulseCacheGenerations = new Map<string, symbol>();
+
+function currentPulseCacheGeneration(userId: string): symbol {
+	const current = pulseCacheGenerations.get(userId);
+	if (current) return current;
+	const initial = Symbol();
+	pulseCacheGenerations.set(userId, initial);
+	return initial;
+}
 
 /**
  * Drop the cached Pulse response for a user so the next GET /pulse call
@@ -32,6 +47,9 @@ const pulseCache = new Map<string, CacheEntry>();
  * waiting out the 60s TTL.
  */
 export function invalidatePulseCache(userId: string): void {
+	// Rotate even when Map.delete returns false: an uncached request may still
+	// be collecting under the old generation and must not publish afterward.
+	pulseCacheGenerations.set(userId, Symbol());
 	pulseCache.delete(userId);
 }
 
@@ -148,6 +166,7 @@ function applyAttentionFilter(response: PulseResponse): PulseResponse {
 export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	app.get("/pulse", async (request, reply) => {
 		const userId = request.currentUser!.id;
+		const generation = currentPulseCacheGeneration(userId);
 
 		// `attentionOnly=true` is a view over the same collector output — we
 		// filter the cached/fresh response rather than running a parallel
@@ -157,7 +176,7 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 
 		// Check cache
 		const cached = pulseCache.get(userId);
-		if (cached && Date.now() < cached.expiresAt) {
+		if (cached && cached.generation === generation && Date.now() < cached.expiresAt) {
 			return reply.send(attentionOnly ? applyAttentionFilter(cached.data) : cached.data);
 		}
 
@@ -204,7 +223,14 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 			generatedAt: new Date().toISOString(),
 		};
 
-		pulseCache.set(userId, { data: response, expiresAt: Date.now() + CACHE_TTL_MS });
+		const cacheEntry: CacheEntry = {
+			data: response,
+			expiresAt: Date.now() + CACHE_TTL_MS,
+			generation,
+		};
+		if (currentPulseCacheGeneration(userId) === generation) {
+			pulseCache.set(userId, cacheEntry);
+		}
 
 		return reply.send(attentionOnly ? applyAttentionFilter(response) : response);
 	});

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -26,10 +26,10 @@ interface CacheEntry {
 
 const pulseCache = new Map<string, CacheEntry>();
 
-// The Pulse cache is process-local, and the production runtime lease permits
-// exactly one API process per database. Keep one opaque current-generation
-// token per user so invalidation can fence publications that began earlier in
-// this same process without retaining prior tokens or in-flight requests.
+// Pulse cache entries and publication generations are process-local. Stable 2.x
+// supports one API process, normally one combined container, per database.
+// Multiple replicas sharing one database are unsupported; stable does not
+// enforce this topology, and #829 tracks future enforcement.
 const pulseCacheGenerations = new Map<string, symbol>();
 
 function currentPulseCacheGeneration(userId: string): symbol {

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -594,6 +594,7 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 							)
 						: await createInstance(app.prisma);
 
+				invalidatePulseCache(userId);
 				request.log.info({ service, label: rest.label }, "Service instance added");
 
 				return reply.status(201).send({


### PR DESCRIPTION
## Summary

Invalidate the authenticated user's Pulse cache after a service instance is successfully created, and fence older in-flight collections so they cannot republish stale pre-create data. This lets the Dashboard show newly introduced service warnings immediately without waiting for the Pulse TTL.

## Related issue

Closes #825

## Scope

- Invalidate only the authenticated user's Pulse state after successful service persistence.
- Add a process-local per-user generation barrier around Pulse cache hits and publications.
- Cover persistence ordering, failure behavior, user isolation, no-entry invalidation, overlapping producers, `attentionOnly`, and Pulse action invalidation.
- Clarify the supported stable process topology without claiming runtime enforcement.

## Non-goals

- No Pulse TTL, response schema, warning classification, attention filtering, or count changes.
- No distributed cache or cross-process invalidation.
- No runtime lease or schema change; #829 tracks future topology enforcement.
- No service fixture, public API, deletion-authority, release, version, image-publication, or deployment work.

## Acceptance criteria

- [x] Successful service creation invalidates Pulse only after persistence succeeds and retains the existing 201 response.
- [x] Rejected creation and persistence failure do not invalidate Pulse.
- [x] User A cannot invalidate user B's cache or generation.
- [x] Old no-entry and cached collections cannot publish after user-scoped generation rotation.
- [x] Multiple old producers cannot overwrite a newer publication.
- [x] The next Pulse request recomputes immediately without a TTL wait or manual cache clear.
- [x] Three independent fresh-stack Dashboard scenarios pass with one worker and retries disabled.

## Changes

- `apps/api/src/routes/services.ts` calls `invalidatePulseCache(userId)` after the awaited create/transaction succeeds.
- `apps/api/src/routes/pulse.ts` stores a per-user opaque generation with each process-local cache entry. GET captures the generation before collection and publishes only if it is still current; invalidation always rotates it and deletes only that user's entry.
- `services.test.ts` covers success ordering, one-call behavior, lifecycle rejection, persistence rejection, and authenticated ownership.
- `services-pulse-cache-invalidation.test.ts` uses the real service and Pulse routes with controlled collection completion to cover no-entry rotation, late old/new completion, multiple stale producers, and cross-user isolation.

Pulse cache entries and generations are process-local. Stable 2.x supports one API/container per database, but does not enforce that restriction. Multiple replicas sharing one database remain unsupported; #829 tracks future enforcement. PR #830 merged the public topology documentation before this finalization.

## Risk classification

- [ ] Trivial
- [x] Standard
- [ ] Safety-critical

## Validation

- [x] Current-main preview is conflict-free and exactly four files; `EXPECTED_825_MERGE_TREE=5ceb494d39ad5b3df72ff6e8f3544002646a852c` over exact main `6289f11766fc3c697c3dd7b7f1bb31fb227c70df`
- [x] Complete affected Pulse/service matrix: 16/16 files, 116/116 tests
- [x] Deterministic overlap matrix: 20/20 independent runs, 80/80 test executions, zero flakes, sleeps, TTL waits, or retries
- [x] Merged #831 process gates on the exact preview image: helper 20/20; stop timing 12/12; launcher 15/15; supervision 34/34; restart 14/14; shutdown grace 15/15
- [x] `pnpm run check:prisma-generated`; path-safety checker 17/17
- [x] `pnpm run format`; no fixes; preview tree unchanged
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: API 4,722 passed / 53 skipped; web 676/676; shared 89/89
- [x] `pnpm run lint`
- [x] `CI=true pnpm run validate:pr`; PR contract 53/53
- [x] `pnpm run build`
- [x] Provider-cache heap 7/7 and `git diff --check`
- [x] Three independently recreated zero-state Dashboard stacks: 3/3 in 19.2s, 3/3 in 19.2s, and 3/3 in 19.1s; one worker, retries 0, trace on, no pre-warm, manual clear, or TTL wait; complete teardown between cycles

The generation barrier does not change service persistence or HTTP results. Invalidation is synchronous and process-local; it performs no I/O and invokes no user callback.

## Review plan

- Initial broad-reviewed head: `f5d2492ccdc84fc28db2da1e5d30e511152ccaea`
- Initial published correction head: `3e4ddeb9cc1eb878aec2a4a9df35b8293019e04a`
- Generation-barrier head: `c047a3254a11a6a246570de7f03e0763a0e41ccb`
- Comment-only topology correction head: `65275840eca1754d8081550cf1cd5469897f393e`
- Material-scope change declared? The generation barrier was an authorized in-scope correction to the GitHub Codex publication-race finding; the final commit changes comments only.
- Independent regression reviewers: service lifecycle/tenancy and cache linearizability reviews passed the executable candidate; the final comment-only delta review found no P0-P3 issue and confirmed executable-token equivalence.
- Independent data-safety reviewer, when required: N/A; no deletion, cleanup execution, restore, schema, deployment, or upstream mutation behavior changed.
- GitHub Codex review head: `65275840eca1754d8081550cf1cd5469897f393e`; completed with no new submitted finding, inline comment, or review thread.
- Maintainer decision: Merge the exact reviewed head.

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| TENANCY-1 | P3 | In-scope missing regression | The mocked invalidator could not distinguish per-user deletion from a global clear | Fixed by the real-route two-user regression | None |
| GH-CODEX-1 | P2 | In-scope publication race | A pre-create uncached GET could finish after invalidation and republish stale data | Fixed by the per-user generation barrier; deterministic overlap matrix passed 20/20 | None |
| TOPOLOGY-1 | P2/P3 | In-scope inaccurate comment | The source comment claimed a runtime lease that stable does not enforce | Fixed comment-only at `65275840`; executable tokens remained identical | #829 retains future enforcement |
| MULTI-PROCESS | P2 | Architectural / unsupported topology | Separate API processes have independent Pulse maps | No distributed behavior claimed; supported topology documented by merged PR #830 | #829 |
| QUERY-CAST | P3 | Pre-existing, out of scope | `pulse.ts` casts the small `attentionOnly` query shape; unchanged from the original base | Safely deferred; unrelated to service-create invalidation | Separate maintenance consideration |

PR #832 / issue #831 merged as current main `6289f11766fc3c697c3dd7b7f1bb31fb227c70df`, replacing the earlier stop-timing measurement blocker. The fresh preview inherits #831 from main and adds no timing-harness file to this PR.

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the prior broad review plus targeted executable and comment-only delta reviews
- [x] Current-main overlap was reviewed through a conflict-free exact preview and full validation
- [x] Maintainer approved merge
- [x] Post-merge verification is planned: exact-merge focused tests and workflows, followed by three independent 104/104 cold integration cycles with one worker and zero retries
