### PR TITLE
test(docker): make stop timing monotonic and observable

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -301,7 +301,11 @@ jobs:
           test -x docker/test-dump-heap.sh
           test -x docker/test-shutdown-grace.sh
           test -x docker/test-stop-timing.sh
+          test -f docker/stop-timing-clock.cjs
+          test -x docker/stop-timing-query.sh
+          test -f docker/test-stop-timing-clock.test.cjs
           test -x docker/test-web-cache-permissions.sh
+          STOP_TIMING_TEST_IMAGE=arr-dashboard:smoke node --test docker/test-stop-timing-clock.test.cjs
           docker/test-web-cache-permissions.sh arr-dashboard:smoke
           docker/test-combined-supervision.sh arr-dashboard:smoke
           docker/test-launcher-contract.sh arr-dashboard:smoke

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -211,6 +211,7 @@ reap_tracked() {
     set +e
     wait "$1" 2>/dev/null
     _REAPED=$?
+    echo "SUPERVISOR_WAIT_COMPLETED pid=$1 status=$_REAPED"
     set -e
 }
 

--- a/docker/stop-timing-clock.cjs
+++ b/docker/stop-timing-clock.cjs
@@ -1,0 +1,65 @@
+const { spawnSync } = require("node:child_process");
+
+const TIMING_LIMITS = Object.freeze({
+	collision: { limitMilliseconds: 9_000, operator: ">=" },
+	prompt: { limitMilliseconds: 4_000, operator: "<=" },
+	restart: { limitMilliseconds: 10_000, operator: "<" },
+	stubborn: { limitMilliseconds: 9_000, operator: "<" },
+});
+
+function monotonicMilliseconds() {
+	return Number(process.hrtime.bigint() / 1_000_000n);
+}
+
+function withinTimingLimit(kind, elapsedMilliseconds) {
+	const gate = TIMING_LIMITS[kind];
+	if (!gate || !Number.isSafeInteger(elapsedMilliseconds) || elapsedMilliseconds < 0) {
+		throw new TypeError("unknown timing gate or invalid elapsed milliseconds");
+	}
+	switch (gate.operator) {
+		case "<":
+			return elapsedMilliseconds < gate.limitMilliseconds;
+		case "<=":
+			return elapsedMilliseconds <= gate.limitMilliseconds;
+		case ">=":
+			return elapsedMilliseconds >= gate.limitMilliseconds;
+		default:
+			throw new TypeError("unsupported timing operator");
+	}
+}
+
+function measureCommand(command, args) {
+	const start = process.hrtime.bigint();
+	const result = spawnSync(command, args, {
+		stdio: ["inherit", "ignore", "inherit"],
+	});
+	const elapsedMilliseconds = Number(
+		(process.hrtime.bigint() - start) / 1_000_000n,
+	);
+	process.stdout.write(`${elapsedMilliseconds}\n`);
+	if (result.error) {
+		process.stderr.write(`${result.error.message}\n`);
+		return 1;
+	}
+	return result.status ?? 1;
+}
+
+if (require.main === module) {
+	const [, , operation, ...args] = process.argv;
+	if (!operation) {
+		process.stdout.write(`${monotonicMilliseconds()}\n`);
+	} else if (operation === "measure" && args.length > 0) {
+		process.exitCode = measureCommand(args[0], args.slice(1));
+	} else if (operation === "check" && args.length === 2) {
+		process.exitCode = withinTimingLimit(args[0], Number(args[1])) ? 0 : 1;
+	} else if (operation === "limit" && args.length === 1 && TIMING_LIMITS[args[0]]) {
+		process.stdout.write(`${TIMING_LIMITS[args[0]].limitMilliseconds}\n`);
+	} else {
+		process.stderr.write(
+			"usage: stop-timing-clock.cjs [measure COMMAND...|check GATE MILLISECONDS|limit GATE]\n",
+		);
+		process.exitCode = 64;
+	}
+}
+
+module.exports = { TIMING_LIMITS, monotonicMilliseconds, withinTimingLimit };

--- a/docker/stop-timing-query.sh
+++ b/docker/stop-timing-query.sh
@@ -1,0 +1,280 @@
+#!/bin/sh
+
+# Test-only fail-closed Docker query boundary for stop-timing evidence.
+
+stop_timing_query_error() {
+    printf '%s\n' QUERY_ERROR
+    return 2
+}
+
+stop_timing_container_state() {
+    name=$1
+    case "$name" in
+        ''|*[!A-Za-z0-9_.-]*) stop_timing_query_error; return 2 ;;
+    esac
+    if ! names=$(docker ps -a --format '{{.Names}}'); then
+        stop_timing_query_error
+        return 2
+    fi
+    if ! classification=$(printf '%s' "$names" | awk -v target="$name" '
+        BEGIN { found = 0; valid = 1 }
+        NF == 0 { next }
+        $0 !~ /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ { valid = 0; next }
+        $0 == target { found++ }
+        END {
+            if (!valid || found > 1) exit 2
+            if (found == 1) print "PRESENT"
+            else print "ABSENT"
+        }
+    '); then
+        stop_timing_query_error
+        return 2
+    fi
+    printf '%s\n' "$classification"
+}
+
+stop_timing_require_present() {
+    classification=$(stop_timing_container_state "$1") || return 2
+    [ "$classification" = PRESENT ] || return 1
+}
+
+stop_timing_runtime_state() {
+    name=$1
+    stop_timing_require_present "$name" || { stop_timing_query_error; return 2; }
+    state=$(docker inspect --type container --format '{{.State.Status}}' "$name") || {
+        stop_timing_query_error
+        return 2
+    }
+    case "$state" in
+        created|running|paused|restarting|removing|exited|dead) printf '%s\n' "$state" ;;
+        *) stop_timing_query_error; return 2 ;;
+    esac
+}
+
+stop_timing_exit_code() {
+    name=$1
+    stop_timing_require_present "$name" || { stop_timing_query_error; return 2; }
+    code=$(docker inspect --type container --format '{{.State.ExitCode}}' "$name") || {
+        stop_timing_query_error
+        return 2
+    }
+    case "$code" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+        *) printf '%s\n' "$code" ;;
+    esac
+}
+
+stop_timing_oom_killed() {
+    name=$1
+    stop_timing_require_present "$name" || { stop_timing_query_error; return 2; }
+    oom=$(docker inspect --type container --format '{{.State.OOMKilled}}' "$name") || {
+        stop_timing_query_error
+        return 2
+    }
+    case "$oom" in
+        true|false) printf '%s\n' "$oom" ;;
+        *) stop_timing_query_error; return 2 ;;
+    esac
+}
+
+stop_timing_remove_container() {
+    name=$1
+    classification=$(stop_timing_container_state "$name") || return 2
+    if [ "$classification" = PRESENT ]; then
+        docker rm -f "$name" >/dev/null || return 2
+    fi
+    classification=$(stop_timing_container_state "$name") || return 2
+    [ "$classification" = ABSENT ] || return 1
+}
+
+stop_timing_owned_names() {
+    prefix=$1
+    names=$(docker ps -a --format '{{.Names}}') || { stop_timing_query_error; return 2; }
+    if ! owned=$(printf '%s' "$names" | awk -v prefix="$prefix" '
+        NF == 0 { next }
+        $0 !~ /^[A-Za-z0-9][A-Za-z0-9_.-]*$/ { invalid = 1; next }
+        index($0, prefix) == 1 { print }
+        END { if (invalid) exit 2 }
+    '); then
+        stop_timing_query_error
+        return 2
+    fi
+    printf '%s\n' "$owned"
+}
+
+stop_timing_active_ports() {
+    ledger=$1
+    [ -e "$ledger" ] || return 0
+    [ -f "$ledger" ] || { stop_timing_query_error; return 2; }
+    if ! active=$(awk -F'|' '
+        NF == 0 { next }
+        NF != 4 || $1 !~ /^[A-Za-z0-9_.-]+$/ || $2 !~ /^[A-Za-z0-9_.-]+$/ || $3 !~ /^[0-9]+$/ || $4 !~ /^[0-9]+$/ {
+            invalid = 1
+            next
+        }
+        {
+            if (($1 in owner_names) && owner_names[$1] != $2) invalid = 1
+            owner_names[$1] = $2
+            owner_key = $1 "|" $2 "|" $3
+            if (++owner_keys[owner_key] > 1 || ++host_ports[$4] > 1) invalid = 1
+            print
+        }
+        END { if (invalid) exit 2 }
+    ' "$ledger"); then
+        stop_timing_query_error
+        return 2
+    fi
+    [ -z "$active" ] || printf '%s\n' "$active"
+}
+
+stop_timing_record_port() {
+    ledger=$1
+    owner=$2
+    name=$3
+    container_port=$4
+    host_port=$5
+    case "$owner" in
+        ''|*[!A-Za-z0-9_.-]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$name" in
+        ''|*[!A-Za-z0-9_.-]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$container_port" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$host_port" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+    esac
+    if [ ! -e "$ledger" ]; then
+        : > "$ledger" || { stop_timing_query_error; return 2; }
+    fi
+    if ! active=$(stop_timing_active_ports "$ledger"); then
+        stop_timing_query_error
+        return 2
+    fi
+    if decision=$(printf '%s\n' "$active" | awk -F'|' -v owner="$owner" -v name="$name" -v container_port="$container_port" -v host_port="$host_port" '
+        NF == 0 { next }
+        $1 == owner && $2 == name && $3 == container_port && $4 == host_port { exact = 1 }
+        $1 == owner && $2 != name { conflict = 1 }
+        $1 == owner && $2 == name && $3 == container_port && $4 != host_port { conflict = 1 }
+        $4 == host_port && ($1 != owner || $2 != name || $3 != container_port) { conflict = 1 }
+        END {
+            if (conflict) exit 1
+            if (exact) print "EXISTING"
+            else print "NEW"
+        }
+    '); then
+        :
+    else
+        decision_status=$?
+        [ "$decision_status" -eq 1 ] && return 1
+        stop_timing_query_error
+        return 2
+    fi
+    if [ "$decision" = NEW ]; then
+        printf '%s|%s|%s|%s\n' "$owner" "$name" "$container_port" "$host_port" >> "$ledger" || {
+            stop_timing_query_error
+            return 2
+        }
+    fi
+    printf '%s\n' "$host_port"
+}
+
+stop_timing_release_ports() {
+    ledger=$1
+    owner=$2
+    name=$3
+    expected_state=$4
+    case "$owner" in
+        ''|*[!A-Za-z0-9_.-]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$name" in
+        ''|*[!A-Za-z0-9_.-]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$expected_state" in
+        absent|running) ;;
+        *) stop_timing_query_error; return 2 ;;
+    esac
+    if ! active=$(stop_timing_active_ports "$ledger"); then
+        stop_timing_query_error
+        return 2
+    fi
+    if ! printf '%s\n' "$active" | awk -F'|' -v owner="$owner" -v name="$name" '
+        $1 == owner && $2 == name { found = 1 }
+        END { exit(found ? 0 : 1) }
+    '; then
+        return 1
+    fi
+    case "$expected_state" in
+        absent)
+            if ! classification=$(stop_timing_container_state "$name"); then
+                stop_timing_query_error
+                return 2
+            fi
+            [ "$classification" = ABSENT ] || return 1
+            ;;
+        running)
+            if ! runtime_state=$(stop_timing_runtime_state "$name"); then
+                stop_timing_query_error
+                return 2
+            fi
+            [ "$runtime_state" = running ] || return 1
+            ;;
+    esac
+    temporary_ledger=$(mktemp "${ledger}.tmp.XXXXXX") || {
+        stop_timing_query_error
+        return 2
+    }
+    if ! printf '%s\n' "$active" | awk -F'|' -v owner="$owner" -v name="$name" 'NF != 0 && ($1 != owner || $2 != name) { print }' > "$temporary_ledger"; then
+        rm -f "$temporary_ledger"
+        stop_timing_query_error
+        return 2
+    fi
+    if ! mv "$temporary_ledger" "$ledger"; then
+        rm -f "$temporary_ledger"
+        stop_timing_query_error
+        return 2
+    fi
+}
+
+stop_timing_trigger_exit() {
+    name=$1
+    pid=$2
+    case "$pid" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+    esac
+    state=$(stop_timing_runtime_state "$name") || return 2
+    [ "$state" = running ] || { stop_timing_query_error; return 2; }
+    docker exec "$name" kill -KILL "$pid" >/dev/null || {
+        stop_timing_query_error
+        return 2
+    }
+    checks=0
+    while [ "$checks" -lt 600 ]; do
+        state=$(stop_timing_runtime_state "$name") || return 2
+        case "$state" in
+            exited|dead) return 0 ;;
+            running) ;;
+            *) stop_timing_query_error; return 2 ;;
+        esac
+        sleep 0.05
+        checks=$((checks + 1))
+    done
+    return 1
+}
+
+if [ "${0##*/}" = stop-timing-query.sh ]; then
+    command=${1:-}
+    [ "$#" -gt 0 ] && shift
+    case "$command" in
+        container-state) [ "$#" -eq 1 ] || exit 64; stop_timing_container_state "$1" ;;
+        runtime-state) [ "$#" -eq 1 ] || exit 64; stop_timing_runtime_state "$1" ;;
+        remove-container) [ "$#" -eq 1 ] || exit 64; stop_timing_remove_container "$1" ;;
+        owned-names) [ "$#" -eq 1 ] || exit 64; stop_timing_owned_names "$1" ;;
+        active-ports) [ "$#" -eq 1 ] || exit 64; stop_timing_active_ports "$1" ;;
+        record-port) [ "$#" -eq 5 ] || exit 64; stop_timing_record_port "$1" "$2" "$3" "$4" "$5" ;;
+        release-ports) [ "$#" -eq 4 ] || exit 64; stop_timing_release_ports "$1" "$2" "$3" "$4" ;;
+        trigger-exit) [ "$#" -eq 2 ] || exit 64; stop_timing_trigger_exit "$1" "$2" ;;
+        *) printf '%s\n' 'unknown stop-timing query command' >&2; exit 64 ;;
+    esac
+fi

--- a/docker/stop-timing-query.sh
+++ b/docker/stop-timing-query.sh
@@ -7,6 +7,20 @@ stop_timing_query_error() {
     return 2
 }
 
+stop_timing_host_identity() {
+    if ! host_uid=$(id -u) || ! host_gid=$(id -g); then
+        stop_timing_query_error
+        return 2
+    fi
+    case "$host_uid" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+    esac
+    case "$host_gid" in
+        ''|*[!0-9]*) stop_timing_query_error; return 2 ;;
+    esac
+    printf '%s:%s\n' "$host_uid" "$host_gid"
+}
+
 stop_timing_container_state() {
     name=$1
     case "$name" in
@@ -267,6 +281,7 @@ if [ "${0##*/}" = stop-timing-query.sh ]; then
     command=${1:-}
     [ "$#" -gt 0 ] && shift
     case "$command" in
+        host-identity) [ "$#" -eq 0 ] || exit 64; stop_timing_host_identity ;;
         container-state) [ "$#" -eq 1 ] || exit 64; stop_timing_container_state "$1" ;;
         runtime-state) [ "$#" -eq 1 ] || exit 64; stop_timing_runtime_state "$1" ;;
         remove-container) [ "$#" -eq 1 ] || exit 64; stop_timing_remove_container "$1" ;;

--- a/docker/test-stop-timing-clock.test.cjs
+++ b/docker/test-stop-timing-clock.test.cjs
@@ -400,3 +400,43 @@ test("corrupt ledgers preserve QUERY_ERROR for record and release", (t) => {
 	assert.equal(release.status, 2, release.stderr);
 	assert.equal(release.stdout, "QUERY_ERROR\n");
 });
+
+test("host identity reports the numeric bind-mount owner", (t) => {
+	const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "stop-timing-identity-"));
+	t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+	writeExecutable(
+		path.join(fixture, "id"),
+		`#!/bin/sh
+case "\${1:-}" in
+-u) printf '%s\\n' 1001 ;;
+-g) printf '%s\\n' 121 ;;
+*) exit 64 ;;
+esac
+`,
+	);
+	const result = runQuery(["host-identity"], {
+		env: { PATH: `${fixture}:${process.env.PATH}` },
+	});
+	assert.equal(result.status, 0, result.stderr);
+	assert.equal(result.stdout, "1001:121\n");
+});
+
+test("host identity rejects malformed numeric output", (t) => {
+	const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "stop-timing-identity-"));
+	t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+	writeExecutable(
+		path.join(fixture, "id"),
+		`#!/bin/sh
+case "\${1:-}" in
+-u) printf '%s\\n' 1001 ;;
+-g) printf '%s\\n' not-a-gid ;;
+*) exit 64 ;;
+esac
+`,
+	);
+	const result = runQuery(["host-identity"], {
+		env: { PATH: `${fixture}:${process.env.PATH}` },
+	});
+	assert.equal(result.status, 2, result.stderr);
+	assert.equal(result.stdout, "QUERY_ERROR\n");
+});

--- a/docker/test-stop-timing-clock.test.cjs
+++ b/docker/test-stop-timing-clock.test.cjs
@@ -1,0 +1,402 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const clockPath = path.join(__dirname, "stop-timing-clock.cjs");
+const queryPath = path.join(__dirname, "stop-timing-query.sh");
+const { withinTimingLimit } = require("./stop-timing-clock.cjs");
+
+function runQuery(args, options = {}) {
+	return spawnSync("/bin/sh", [queryPath, ...args], {
+		encoding: "utf8",
+		env: { ...process.env, ...options.env },
+	});
+}
+
+function writeExecutable(filePath, contents) {
+	fs.writeFileSync(filePath, contents, { mode: 0o755 });
+}
+
+function createDockerStateFixture(t) {
+	const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "stop-timing-ownership-"));
+	t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+	writeExecutable(
+		path.join(fixture, "docker"),
+		`#!/bin/sh
+if [ "\${FAKE_DOCKER_MODE:-absent}" = query-error ]; then
+	exit 17
+fi
+case "\${1:-}" in
+	ps)
+		if [ "\${FAKE_DOCKER_MODE:-absent}" = present ]; then
+			printf '%s\\n' "\${FAKE_CONTAINER_NAME:-owned-container}"
+		fi
+		;;
+	inspect)
+		printf '%s\\n' "\${FAKE_RUNTIME_STATE:-running}"
+		;;
+	*) exit 64 ;;
+esac
+`,
+	);
+	return {
+		ledger: path.join(fixture, "ports"),
+		env: (dockerMode, runtimeState = "running") => ({
+			PATH: `${fixture}:${process.env.PATH}`,
+			FAKE_CONTAINER_NAME: "owned-container",
+			FAKE_DOCKER_MODE: dockerMode,
+			FAKE_RUNTIME_STATE: runtimeState,
+		}),
+	};
+}
+
+test("clock CLI returns integer monotonic milliseconds", () => {
+	const result = spawnSync(process.execPath, [clockPath], { encoding: "utf8" });
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stdout, /^\d+\n$/);
+});
+
+test("one process measures one command with the monotonic clock", () => {
+	const result = spawnSync(
+		process.execPath,
+		[clockPath, "measure", process.execPath, "-e", "setTimeout(() => {}, 25)"],
+		{ encoding: "utf8" },
+	);
+	assert.equal(result.status, 0, result.stderr);
+	assert.match(result.stdout, /^\d+\n$/);
+	const elapsedMilliseconds = Number(result.stdout.trim());
+	assert.ok(elapsedMilliseconds >= 20, result.stdout);
+	assert.ok(elapsedMilliseconds < 1_000, result.stdout);
+});
+
+test("one process propagates the measured command failure", () => {
+	const result = spawnSync(process.execPath, [
+		clockPath,
+		"measure",
+		process.execPath,
+		"-e",
+		"process.exit(23)",
+	], {
+		encoding: "utf8",
+	});
+	assert.equal(result.status, 23, result.stderr);
+	assert.match(result.stdout, /^\d+\n$/);
+});
+
+test("whole-second subtraction can false-fail restart", () => {
+	const startMilliseconds = 999;
+	const endMilliseconds = 10_998;
+	assert.equal(endMilliseconds - startMilliseconds, 9_999);
+	assert.equal(
+		Math.floor(endMilliseconds / 1_000) - Math.floor(startMilliseconds / 1_000),
+		10,
+	);
+});
+
+test("whole-second subtraction can false-pass stubborn stop", () => {
+	const startMilliseconds = 0;
+	const endMilliseconds = 9_999;
+	assert.equal(endMilliseconds - startMilliseconds, 9_999);
+	assert.equal(
+		Math.floor(endMilliseconds / 1_000) - Math.floor(startMilliseconds / 1_000),
+		9,
+	);
+});
+
+test("exact boundaries preserve every timing contract", () => {
+	assert.equal(withinTimingLimit("stubborn", 8_999), true);
+	assert.equal(withinTimingLimit("stubborn", 9_000), false);
+	assert.equal(withinTimingLimit("restart", 9_999), true);
+	assert.equal(withinTimingLimit("restart", 10_000), false);
+	assert.equal(withinTimingLimit("prompt", 4_000), true);
+	assert.equal(withinTimingLimit("prompt", 4_001), false);
+	assert.equal(withinTimingLimit("collision", 8_999), false);
+	assert.equal(withinTimingLimit("collision", 9_000), true);
+});
+
+test("Docker classification proves real PRESENT and ABSENT states", (t) => {
+	const image = process.env.STOP_TIMING_TEST_IMAGE || "arr-dashboard:smoke";
+	const name = `test-stop-timing-query-${process.pid}`;
+	t.after(() => spawnSync("docker", ["rm", "-f", name], { encoding: "utf8" }));
+	const create = spawnSync(
+		"docker",
+		["create", "--name", name, "--entrypoint", "/bin/true", image],
+		{ encoding: "utf8" },
+	);
+	assert.equal(create.status, 0, create.stderr);
+	const present = runQuery(["container-state", name]);
+	assert.equal(present.status, 0, present.stderr);
+	assert.equal(present.stdout, "PRESENT\n");
+	const remove = spawnSync("docker", ["rm", name], { encoding: "utf8" });
+	assert.equal(remove.status, 0, remove.stderr);
+	const absent = runQuery(["container-state", name]);
+	assert.equal(absent.status, 0, absent.stderr);
+	assert.equal(absent.stdout, "ABSENT\n");
+});
+
+test("invalid Docker endpoint is QUERY_ERROR", () => {
+	const result = runQuery(["container-state", "not-present"], {
+		env: {
+			DOCKER_HOST: `unix://${path.join(os.tmpdir(), `missing-docker-${process.pid}.sock`)}`,
+		},
+	});
+	assert.equal(result.status, 2, result.stderr);
+	assert.equal(result.stdout, "QUERY_ERROR\n");
+});
+
+for (const [name, body] of [
+	["API", "echo simulated-api-error >&2\nexit 17"],
+	["permission", "echo permission-denied >&2\nexit 13"],
+	["execution", "exit 126"],
+]) {
+	test(`Docker ${name} failure is QUERY_ERROR`, (t) => {
+		const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "stop-timing-query-"));
+		t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+		writeExecutable(path.join(fixture, "docker"), `#!/bin/sh\n${body}\n`);
+		const result = runQuery(["container-state", "not-present"], {
+			env: { PATH: `${fixture}:${process.env.PATH}` },
+		});
+		assert.equal(result.status, 2, result.stderr);
+		assert.equal(result.stdout, "QUERY_ERROR\n");
+	});
+}
+
+test("malformed Docker output is QUERY_ERROR", (t) => {
+	const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "stop-timing-query-"));
+	t.after(() => fs.rmSync(fixture, { recursive: true, force: true }));
+	writeExecutable(
+		path.join(fixture, "docker"),
+		"#!/bin/sh\nprintf '%s\\n' 'malformed container name'\n",
+	);
+	const result = runQuery(["container-state", "not-present"], {
+		env: { PATH: `${fixture}:${process.env.PATH}` },
+	});
+	assert.equal(result.status, 2, result.stderr);
+	assert.equal(result.stdout, "QUERY_ERROR\n");
+});
+
+test("verified release permits reuse while live ownership rejects it", (t) => {
+	const { ledger, env } = createDockerStateFixture(t);
+	for (const [internalPort, hostPort] of [
+		["3001", "41001"],
+		["3000", "41002"],
+	]) {
+		const acquired = runQuery([
+			"record-port",
+			ledger,
+			"generation-a",
+			"owned-container",
+			internalPort,
+			hostPort,
+		]);
+		assert.equal(acquired.status, 0, acquired.stderr);
+	}
+
+	const liveConflict = runQuery([
+		"record-port",
+		ledger,
+		"generation-b",
+		"owned-container",
+		"3001",
+		"41001",
+	]);
+	assert.equal(liveConflict.status, 1, liveConflict.stderr);
+
+	const released = runQuery(
+		["release-ports", ledger, "generation-a", "owned-container", "absent"],
+		{ env: env("absent") },
+	);
+	assert.equal(released.status, 0, released.stderr);
+
+	const reused = runQuery([
+		"record-port",
+		ledger,
+		"generation-b",
+		"owned-container",
+		"3001",
+		"41001",
+	]);
+	assert.equal(reused.status, 0, reused.stderr);
+	assert.equal(reused.stdout, "41001\n");
+
+	const finalRelease = runQuery(
+		["release-ports", ledger, "generation-b", "owned-container", "absent"],
+		{ env: env("absent") },
+	);
+	assert.equal(finalRelease.status, 0, finalRelease.stderr);
+	const finalActive = runQuery(["active-ports", ledger]);
+	assert.equal(finalActive.status, 0, finalActive.stderr);
+	assert.equal(finalActive.stdout, "");
+});
+
+test("failed unknown and mismatched release retain exact ownership", (t) => {
+	const { ledger, env } = createDockerStateFixture(t);
+	const acquired = runQuery([
+		"record-port",
+		ledger,
+		"generation-a",
+		"owned-container",
+		"3001",
+		"42001",
+	]);
+	assert.equal(acquired.status, 0, acquired.stderr);
+
+	for (const [owner, expectedState, dockerMode, runtimeState, expectedStatus] of [
+		["generation-b", "absent", "absent", "running", 1],
+		["generation-a", "absent", "present", "running", 1],
+		["generation-a", "running", "present", "paused", 1],
+		["generation-a", "absent", "query-error", "running", 2],
+	]) {
+		const result = runQuery(
+			["release-ports", ledger, owner, "owned-container", expectedState],
+			{ env: env(dockerMode, runtimeState) },
+		);
+		assert.equal(result.status, expectedStatus, result.stderr);
+		const stillReserved = runQuery([
+			"record-port",
+			ledger,
+			"generation-b",
+			"owned-container",
+			"3001",
+			"42001",
+		]);
+		assert.equal(stillReserved.status, 1, stillReserved.stderr);
+	}
+});
+
+test("restart generation transition retires old active mappings", (t) => {
+	const { ledger, env } = createDockerStateFixture(t);
+	for (const [internalPort, hostPort] of [
+		["3001", "43001"],
+		["3000", "43002"],
+	]) {
+		const acquired = runQuery([
+			"record-port",
+			ledger,
+			"restart-generation-1",
+			"owned-container",
+			internalPort,
+			hostPort,
+		]);
+		assert.equal(acquired.status, 0, acquired.stderr);
+	}
+
+	const retired = runQuery(
+		[
+			"release-ports",
+			ledger,
+			"restart-generation-1",
+			"owned-container",
+			"running",
+		],
+		{ env: env("present", "running") },
+	);
+	assert.equal(retired.status, 0, retired.stderr);
+
+	for (const [internalPort, hostPort] of [
+		["3001", "43001"],
+		["3000", "43002"],
+	]) {
+		const reacquired = runQuery([
+			"record-port",
+			ledger,
+			"restart-generation-2",
+			"owned-container",
+			internalPort,
+			hostPort,
+		]);
+		assert.equal(reacquired.status, 0, reacquired.stderr);
+	}
+
+	const active = runQuery(["active-ports", ledger]);
+	assert.equal(active.status, 0, active.stderr);
+	assert.equal(
+		active.stdout,
+		"restart-generation-2|owned-container|3001|43001\nrestart-generation-2|owned-container|3000|43002\n",
+	);
+
+	const finalRelease = runQuery(
+		[
+			"release-ports",
+			ledger,
+			"restart-generation-2",
+			"owned-container",
+			"absent",
+		],
+		{ env: env("absent") },
+	);
+	assert.equal(finalRelease.status, 0, finalRelease.stderr);
+	const finalActive = runQuery(["active-ports", ledger]);
+	assert.equal(finalActive.status, 0, finalActive.stderr);
+	assert.equal(finalActive.stdout, "");
+});
+
+test("malformed port ownership input fails before writing", (t) => {
+	const { ledger } = createDockerStateFixture(t);
+	for (const args of [
+		["generation-a", "owned-container", "3001:3000", "44001"],
+		["generation-a", "owned-container", "3001", "44001:44002"],
+		["bad:owner", "owned-container", "3001", "44001"],
+		["generation-a", "bad:container", "3001", "44001"],
+	]) {
+		const result = runQuery(["record-port", ledger, ...args]);
+		assert.equal(result.status, 2, result.stderr);
+		assert.equal(result.stdout, "QUERY_ERROR\n");
+	}
+	assert.equal(fs.existsSync(ledger), false);
+});
+
+test("release rejects an existing owner paired with a different container", (t) => {
+	const { ledger, env } = createDockerStateFixture(t);
+	const acquired = runQuery([
+		"record-port",
+		ledger,
+		"generation-a",
+		"owned-container",
+		"3001",
+		"45001",
+	]);
+	assert.equal(acquired.status, 0, acquired.stderr);
+
+	const mismatched = runQuery(
+		["release-ports", ledger, "generation-a", "unrelated-container", "absent"],
+		{ env: env("absent") },
+	);
+	assert.equal(mismatched.status, 1, mismatched.stderr);
+
+	const stillReserved = runQuery([
+		"record-port",
+		ledger,
+		"generation-b",
+		"unrelated-container",
+		"3001",
+		"45001",
+	]);
+	assert.equal(stillReserved.status, 1, stillReserved.stderr);
+});
+
+test("corrupt ledgers preserve QUERY_ERROR for record and release", (t) => {
+	const { ledger, env } = createDockerStateFixture(t);
+	fs.writeFileSync(ledger, "malformed-ledger-row\n");
+
+	const record = runQuery([
+		"record-port",
+		ledger,
+		"generation-a",
+		"owned-container",
+		"3001",
+		"46001",
+	]);
+	assert.equal(record.status, 2, record.stderr);
+	assert.equal(record.stdout, "QUERY_ERROR\n");
+
+	const release = runQuery(
+		["release-ports", ledger, "generation-a", "owned-container", "absent"],
+		{ env: env("absent") },
+	);
+	assert.equal(release.status, 2, release.stderr);
+	assert.equal(release.stdout, "QUERY_ERROR\n");
+});

--- a/docker/test-stop-timing.sh
+++ b/docker/test-stop-timing.sh
@@ -28,6 +28,13 @@ SHIM_DIR="$WORK/shim"
 PORT_LEDGER="$WORK/ports"
 PASS=0
 FAIL=0
+HOST_IDENTITY=$(stop_timing_host_identity) || exit 2
+TEST_RUNTIME_UID=${HOST_IDENTITY%%:*}
+TEST_RUNTIME_GID=${HOST_IDENTITY#*:}
+if [ "$TEST_RUNTIME_UID" -eq 0 ]; then
+    TEST_RUNTIME_UID=1000
+    TEST_RUNTIME_GID=1000
+fi
 
 cleanup() {
     owned=$(stop_timing_owned_names "$PREFIX" 2>/dev/null) || owned=""
@@ -86,9 +93,9 @@ start_container() {
         -v "$config_dir:/config" \
         -p 127.0.0.1::3001 -p 127.0.0.1::3000
     if [ "$mode" = rootless ]; then
-        set -- "$@" --user 1000:1000
+        set -- "$@" --user "$TEST_RUNTIME_UID:$TEST_RUNTIME_GID"
     else
-        set -- "$@" -e PUID=1000 -e PGID=1000
+        set -- "$@" -e "PUID=$TEST_RUNTIME_UID" -e "PGID=$TEST_RUNTIME_GID"
     fi
     if [ "$stubborn" = stubborn ]; then
         set -- "$@" -v "$SHIM_DIR/server.js:/app/web/server.js:ro"

--- a/docker/test-stop-timing.sh
+++ b/docker/test-stop-timing.sh
@@ -1,84 +1,133 @@
 #!/bin/sh
-# Stop-timeout and process-state timing tests.
-#
-# Proves the internal SHUTDOWN_GRACE default leaves margin below Docker's
-# 10-second Linux stop timeout, and that unexpected service death is detected
-# promptly (not via the full grace + SIGKILL path).
-#
-# Cases:
-#   red-collision   SHUTDOWN_GRACE=10 + stubborn child + docker stop --time 10
-#                   -> demonstrates the internal deadline collides with Docker's
-#   green-stubborn  default grace + stubborn child + docker stop --time 10
-#                   -> internal SIGKILL, exit 0, elapsed <= 9s (5 runs)
-#   default-normal  default grace + normal children + docker stop (rootful/rootless)
-#   docker-restart  default grace + stubborn child + docker restart --time 10
-#   prompt-exit     api/web death detection timing (rootful/rootless)
-#
-# Usage: docker/test-stop-timing.sh [image] [--case NAME]
+# Binding-faithful stop-timing and tracked-child reaping tests.
 
 set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/stop-timing-query.sh"
 
 IMAGE="${1:-arr-dashboard:smoke}"
 CASE=""
 QUICK=false
-if [ "${2:-}" = "--case" ]; then
-    CASE="$3"
-fi
-if [ "${2:-}" = "--quick" ] || [ "${4:-}" = "--quick" ]; then
-    QUICK=true
-fi
+shift || true
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --case)
+            [ "$#" -ge 2 ] || { echo "--case requires a value" >&2; exit 64; }
+            CASE=$2
+            shift 2
+            ;;
+        --quick) QUICK=true; shift ;;
+        *) echo "unknown argument: $1" >&2; exit 64 ;;
+    esac
+done
 
-WORK=/tmp/test-stop-timing-$$
-CONFIG_DIR="$WORK/config"
+WORK="/tmp/test-stop-timing-$$"
+PREFIX="test-stop-timing-$$-"
 SHIM_DIR="$WORK/shim"
-
+PORT_LEDGER="$WORK/ports"
 PASS=0
 FAIL=0
 
 cleanup() {
-    for c in "${WORK##*/}-"*; do
-        docker rm -f "$c" >/dev/null 2>&1 || true
-    done
+    owned=$(stop_timing_owned_names "$PREFIX" 2>/dev/null) || owned=""
+    if [ -n "$owned" ]; then
+        printf '%s\n' "$owned" | while IFS= read -r container_name; do
+            docker rm -f "$container_name" >/dev/null 2>&1 || true
+        done
+    fi
     rm -rf "$WORK" 2>/dev/null || true
 }
 trap cleanup EXIT
 
-mkdir -p "$CONFIG_DIR" "$SHIM_DIR"
+mkdir -p "$SHIM_DIR"
+: > "$PORT_LEDGER"
 
 ok() { echo "  PASS: $*"; PASS=$((PASS + 1)); }
 bad() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
 
-HOST_API_PORT=33140
-HOST_WEB_PORT=33141
-
-# Stubborn web shim (ignores SIGTERM).
 cat > "$SHIM_DIR/server.js" <<'EOF'
 console.log("[stubborn-web] started, ignoring SIGTERM");
 process.on("SIGTERM", () => { console.log("[stubborn-web] ignoring SIGTERM"); });
 setInterval(() => {}, 1000);
 EOF
 
-wait_api_health() {
-    ctr=$1
-    timeout=${2:-120}
-    elapsed=0
-    while [ "$elapsed" -lt "$timeout" ]; do
-        a=$(curl -sf "http://localhost:$HOST_API_PORT/health" 2>/dev/null || echo '')
-        [ -n "$a" ] && return 0
-        sleep 1
-        elapsed=$((elapsed + 1))
-    done
-    return 1
+new_config_dir() {
+    config_dir="$WORK/config-$1"
+    mkdir -p "$config_dir"
+    chmod 0777 "$config_dir"
+    printf '%s\n' "$config_dir"
+}
+
+published_port() {
+    container_name=$1
+    port_owner=$2
+    container_port=$3
+    mapping=$(docker port "$container_name" "$container_port/tcp") || return 1
+    port=$(printf '%s\n' "$mapping" | awk -F: '
+        NF == 2 && $2 ~ /^[0-9]+$/ { count++; port = $2 }
+        END { if (count != 1) exit 1; print port }
+    ') || return 1
+    if ! recorded_port=$(stop_timing_record_port "$PORT_LEDGER" "$port_owner" "$container_name" "$container_port" "$port"); then
+        echo "Docker reused suite port $port across distinct owners" >&2
+        return 1
+    fi
+    printf '%s\n' "$recorded_port"
+}
+
+start_container() {
+    container_name=$1
+    mode=$2
+    stubborn=$3
+    grace=${4:-}
+    port_owner=${5:-$container_name}
+    config_dir=$(new_config_dir "$container_name")
+    set -- docker run -d --name "$container_name" \
+        -v "$config_dir:/config" \
+        -p 127.0.0.1::3001 -p 127.0.0.1::3000
+    if [ "$mode" = rootless ]; then
+        set -- "$@" --user 1000:1000
+    else
+        set -- "$@" -e PUID=1000 -e PGID=1000
+    fi
+    if [ "$stubborn" = stubborn ]; then
+        set -- "$@" -v "$SHIM_DIR/server.js:/app/web/server.js:ro"
+    fi
+    if [ -n "$grace" ]; then
+        set -- "$@" -e "SHUTDOWN_GRACE=$grace"
+    fi
+    set -- "$@" "$IMAGE"
+    "$@" >/dev/null
+    API_PORT=$(published_port "$container_name" "$port_owner" 3001) || return 1
+    WEB_PORT=$(published_port "$container_name" "$port_owner" 3000) || return 1
 }
 
 wait_health() {
-    ctr=$1
-    timeout=${2:-120}
+    api_only=$1
     elapsed=0
-    while [ "$elapsed" -lt "$timeout" ]; do
-        a=$(curl -sf "http://localhost:$HOST_API_PORT/health" 2>/dev/null || echo '')
-        w=$(curl -sf "http://localhost:$HOST_WEB_PORT/health" 2>/dev/null || echo '')
-        if [ -n "$a" ] && [ -n "$w" ]; then
+    while [ "$elapsed" -lt 120 ]; do
+        if curl -sf "http://127.0.0.1:$API_PORT/health" >/dev/null 2>&1; then
+            if [ "$api_only" = true ] || curl -sf "http://127.0.0.1:$WEB_PORT/health" >/dev/null 2>&1; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+container_logs() {
+    stop_timing_require_present "$1" || return 1
+    docker logs "$1" 2>&1
+}
+
+wait_stubborn_ready() {
+    container_name=$1
+    elapsed=0
+    while [ "$elapsed" -lt 60 ]; do
+        logs=$(container_logs "$container_name") || return 1
+        if printf '%s\n' "$logs" | grep -q '^\[stubborn-web\] started, ignoring SIGTERM$'; then
             return 0
         fi
         sleep 1
@@ -87,334 +136,294 @@ wait_health() {
     return 1
 }
 
-# Run a stubborn-child container. $1=name, $2=extra env (e.g. SHUTDOWN_GRACE=10), $3=rootless flag
-start_stubborn() {
-    name=$1
-    extra_env=$2
-    rootless=$3
-    docker rm -f "$name" >/dev/null 2>&1 || true
-    if [ "$rootless" = "rootless" ]; then
-        chown -R 1000:1000 "$CONFIG_DIR" 2>/dev/null || true
-        chmod 700 "$CONFIG_DIR" 2>/dev/null || true
-        docker run -d --name "$name" --user 1000:1000 \
-            -v "$CONFIG_DIR":/config \
-            -v "$SHIM_DIR/server.js":/app/web/server.js:ro \
-            $extra_env \
-            -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-            "$IMAGE" >/dev/null
-    else
-        docker run -d --name "$name" \
-            -v "$CONFIG_DIR":/config \
-            -e PUID=1000 -e PGID=1000 \
-            -v "$SHIM_DIR/server.js":/app/web/server.js:ro \
-            $extra_env \
-            -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-            "$IMAGE" >/dev/null
+capture_supervisor_epoch() {
+    API_PID=invalid
+    WEB_PID=invalid
+    LOG_CURSOR=invalid
+    logs=$(container_logs "$1") || return 1
+    API_PID=$(printf '%s\n' "$logs" | sed -n 's/.*API started with PID \([0-9][0-9]*\).*/\1/p' | tail -1)
+    WEB_PID=$(printf '%s\n' "$logs" | sed -n 's/.*Web started with PID \([0-9][0-9]*\).*/\1/p' | tail -1)
+    case "$API_PID:$WEB_PID" in
+        *[!0-9:]*|:*) return 1 ;;
+    esac
+    [ "$API_PID" != "$WEB_PID" ] || return 1
+    LOG_CURSOR=$(printf '%s\n' "$logs" | awk 'END { print NR }')
+}
+
+appended_logs() {
+    logs=$(container_logs "$1") || return 1
+    printf '%s\n' "$logs" | awk -v cursor="$2" 'NR > cursor'
+}
+
+wait_event() {
+    segment=$1
+    tracked_pid=$2
+    event=$(printf '%s\n' "$segment" | awk -v pid="$tracked_pid" '
+        $0 ~ ("^SUPERVISOR_WAIT_COMPLETED pid=" pid " status=[0-9]+$") {
+            count++
+            line = NR
+            sub(/^.* status=/, "", $0)
+            status = $0
+        }
+        END { if (count != 1) exit 1; print line "|" status }
+    ') || return 1
+    WAIT_LINE=${event%%|*}
+    WAIT_STATUS=${event#*|}
+    [ "$WAIT_STATUS" != 127 ] || return 1
+}
+
+assert_epoch_reaped() {
+    segment=$1
+    terminal=${2:-}
+    API_WAIT_STATUS=missing
+    WEB_WAIT_STATUS=missing
+    wait_event "$segment" "$API_PID" || return 1
+    api_line=$WAIT_LINE
+    API_WAIT_STATUS=$WAIT_STATUS
+    wait_event "$segment" "$WEB_PID" || return 1
+    web_line=$WAIT_LINE
+    WEB_WAIT_STATUS=$WAIT_STATUS
+    if [ -n "$terminal" ]; then
+        terminal_line=$(printf '%s\n' "$segment" | awk -v text="$terminal" 'index($0, text) { line = NR } END { if (!line) exit 1; print line }') || return 1
+        [ "$api_line" -lt "$terminal_line" ] && [ "$web_line" -lt "$terminal_line" ] || return 1
     fi
 }
 
-# Wait for the stubborn shim to register its SIGTERM handler.
-wait_stubborn_ready() {
-    ctr=$1
-    elapsed=0
-    while [ "$elapsed" -lt 60 ]; do
-        if docker logs "$ctr" 2>&1 | grep -q "stubborn-web.*started"; then
-            return 0
-        fi
-        sleep 1
-        elapsed=$((elapsed + 1))
-    done
-    return 1
+measure() {
+    gate=$1
+    shift
+    measure_unchecked "$@" || return 1
+    node "$SCRIPT_DIR/stop-timing-clock.cjs" check "$gate" "$ELAPSED_MS"
 }
 
-# ---------------------------------------------------------------------------
-# RED: SHUTDOWN_GRACE=10 collides with docker stop --time 10
-# ---------------------------------------------------------------------------
+measure_unchecked() {
+    if ! ELAPSED_MS=$(node "$SCRIPT_DIR/stop-timing-clock.cjs" measure "$@"); then
+        return 1
+    fi
+}
+
+strict_remove() {
+    container_name=$1
+    port_owner=$2
+    stop_timing_remove_container "$container_name" || return 1
+    active_ports=$(stop_timing_active_ports "$PORT_LEDGER") || return 2
+    if printf '%s\n' "$active_ports" | awk -F'|' -v owner="$port_owner" '
+        $1 == owner { found = 1 }
+        END { exit(found ? 0 : 1) }
+    '; then
+        stop_timing_release_ports "$PORT_LEDGER" "$port_owner" "$container_name" absent || return 1
+    fi
+    config_dir="$WORK/config-$container_name"
+    case "$config_dir" in
+        "$WORK"/config-*) ;;
+        *) return 2 ;;
+    esac
+    if [ -e "$config_dir" ]; then
+        rm -rf "$config_dir" || return 1
+    fi
+    [ ! -e "$config_dir" ]
+}
+
 case_red_collision() {
     echo ""
     echo "=== [red-collision] SHUTDOWN_GRACE=10 vs docker stop --time 10 ==="
-    ctr="${WORK##*/}-red"
-    start_stubborn "$ctr" "-e SHUTDOWN_GRACE=10" rootful
-    wait_api_health "$ctr" 60 || bad "API did not become healthy"
-    wait_stubborn_ready "$ctr" || bad "stubborn shim not ready"
-    start=$(date +%s)
-    docker stop --time 10 "$ctr" >/dev/null 2>&1 || true
-    end=$(date +%s)
-    elapsed=$((end - start))
-    code=$(docker inspect "$ctr" --format '{{.State.ExitCode}}' 2>/dev/null || echo '?')
-    logs=$(docker logs "$ctr" 2>&1 || true)
-    echo "  elapsed=${elapsed}s exit=$code"
-    echo "  internal SIGKILL logged: $(echo "$logs" | grep -c 'sending SIGKILL' || true)"
-    echo "  graceful completion logged: $(echo "$logs" | grep -c 'Services stopped gracefully' || true)"
-    # With grace=10 and docker timeout=10, the internal deadline collides with
-    # Docker's; the container may be force-killed before start.sh finishes.
-    if [ "$elapsed" -ge 9 ]; then
-        ok "demonstrated collision: elapsed ${elapsed}s (no margin below 10s)"
+    ctr="${PREFIX}red"
+    owner=$ctr
+    start_container "$ctr" rootful stubborn 10 "$owner" || { bad "red container failed to start"; strict_remove "$ctr" "$owner" || true; return; }
+    wait_health true && wait_stubborn_ready "$ctr" || { bad "red services did not become ready"; strict_remove "$ctr" "$owner" || true; return; }
+    if measure collision docker stop --time 10 "$ctr"; then
+        state=$(stop_timing_runtime_state "$ctr") || { bad "red state query failed"; return; }
+        oom=$(stop_timing_oom_killed "$ctr") || { bad "red OOM query failed"; return; }
+        logs=$(container_logs "$ctr") || { bad "red log query failed"; return; }
+        graceful=$(printf '%s\n' "$logs" | awk '/Services stopped gracefully/ { count++ } END { print count + 0 }')
+        if [ "$state" = exited ] && [ "$oom" = false ] && [ "$graceful" -eq 0 ]; then
+            ok "collision reproduced at ${ELAPSED_MS}ms without graceful completion"
+        else
+            bad "collision evidence unexpected: state=$state oom=$oom graceful=$graceful"
+        fi
     else
-        bad "unexpectedly fast (${elapsed}s) — collision not demonstrated"
+        bad "collision was not observed at ${ELAPSED_MS:-unknown}ms"
     fi
-    docker rm -f "$ctr" >/dev/null 2>&1 || true
-}
-
-# ---------------------------------------------------------------------------
-# GREEN: default grace + stubborn child + docker stop --time 10 (5 runs)
-# ---------------------------------------------------------------------------
-run_green_stubborn_once() {
-    ctr=$1
-    rootless=$2
-    start_stubborn "$ctr" "" "$rootless"
-    wait_api_health "$ctr" 60 || { echo "  (API not healthy)"; return 1; }
-    wait_stubborn_ready "$ctr" || { echo "  (shim not ready)"; return 1; }
-    start=$(date +%s)
-    docker stop --time 10 "$ctr" >/dev/null 2>&1 || true
-    end=$(date +%s)
-    elapsed=$((end - start))
-    code=$(docker inspect "$ctr" --format '{{.State.ExitCode}}' 2>/dev/null || echo '?')
-    oom=$(docker inspect "$ctr" --format '{{.State.OOMKilled}}' 2>/dev/null || echo '?')
-    state=$(docker inspect "$ctr" --format '{{.State.Status}}' 2>/dev/null || echo '?')
-    logs=$(docker logs "$ctr" 2>&1 || true)
-    sigkill=$(echo "$logs" | grep -c 'sending SIGKILL' || true)
-    graceful=$(echo "$logs" | grep -c 'Services stopped gracefully' || true)
-    echo "  run: elapsed=${elapsed}s exit=$code oom=$oom state=$state internal_sigkill=$sigkill graceful=$graceful"
-    docker rm -f "$ctr" >/dev/null 2>&1 || true
-    # Structured result: elapsed|exit|oom|sigkill|graceful|state
-    echo "${elapsed}|${code}|${oom}|${sigkill}|${graceful}|${state}"
+    strict_remove "$ctr" "$owner" || bad "red container removal was not proven"
 }
 
 case_green_stubborn() {
     echo ""
-    echo "=== [green-stubborn] default grace + stubborn child + docker stop --time 10 (5 runs) ==="
+    echo "=== [green-stubborn] bounded stubborn-child stop ==="
+    runs=5
+    [ "$QUICK" = false ] || runs=1
     for mode in rootful rootless; do
-        echo "  --- $mode ---"
-        total=0
-        min=999
-        max=0
-        allpass=1
-        runs=5
-        if [ "$QUICK" = true ]; then
-            runs=1
-        fi
+        all_pass=true
+        max_ms=0
         i=1
         while [ "$i" -le "$runs" ]; do
-            ctr="${WORK##*/}-green-${mode}-${i}"
-            raw=$(run_green_stubborn_once "$ctr" "$mode")
-            result=$(echo "$raw" | tail -1)
-            case "$result" in
-                ''|*[!0-9|]*) allpass=0; i=$((i+1)); continue ;;
-            esac
-            e=$(echo "$result" | cut -d'|' -f1)
-            rc=$(echo "$result" | cut -d'|' -f2)
-            ok_=$(echo "$result" | cut -d'|' -f3)
-            sk=$(echo "$result" | cut -d'|' -f4)
-            gc=$(echo "$result" | cut -d'|' -f5)
-            st=$(echo "$result" | cut -d'|' -f6)
-            # Assert every field, not just elapsed.
-            if [ "$e" -gt 9 ]; then
-                echo "  run $i FAIL: elapsed ${e}s > 9s"; allpass=0
+            ctr="${PREFIX}green-$mode-$i"
+            owner=$ctr
+            if ! start_container "$ctr" "$mode" stubborn "" "$owner"; then
+                all_pass=false
+                strict_remove "$ctr" "$owner" || true
+                break
             fi
-            if [ "$rc" != "0" ]; then
-                echo "  run $i FAIL: exit code $rc (expected 0)"; allpass=0
+            if ! wait_health true || ! wait_stubborn_ready "$ctr" || ! capture_supervisor_epoch "$ctr"; then
+                all_pass=false
+                strict_remove "$ctr" "$owner" || true
+                break
             fi
-            if [ "$ok_" != "false" ]; then
-                echo "  run $i FAIL: OOMKilled=$ok_ (expected false)"; allpass=0
-            fi
-            if [ "$sk" -lt 1 ]; then
-                echo "  run $i FAIL: no internal SIGKILL log"; allpass=0
-            fi
-            if [ "$gc" -lt 1 ]; then
-                echo "  run $i FAIL: no graceful-completion log"; allpass=0
-            fi
-            if [ "$st" != "exited" ]; then
-                echo "  run $i FAIL: state $st (expected exited)"; allpass=0
-            fi
-            total=$((total + e))
-            [ "$e" -lt "$min" ] && min=$e
-            [ "$e" -gt "$max" ] && max=$e
-            i=$((i+1))
+            if ! measure stubborn docker stop --time 10 "$ctr"; then all_pass=false; fi
+            [ "${ELAPSED_MS:-999999}" -gt "$max_ms" ] && max_ms=${ELAPSED_MS:-999999}
+            code=$(stop_timing_exit_code "$ctr") || all_pass=false
+            oom=$(stop_timing_oom_killed "$ctr") || all_pass=false
+            state=$(stop_timing_runtime_state "$ctr") || all_pass=false
+            segment=$(appended_logs "$ctr" "$LOG_CURSOR") || all_pass=false
+            if ! assert_epoch_reaped "$segment" "Services stopped gracefully"; then all_pass=false; fi
+            sigkill=$(printf '%s\n' "$segment" | awk '/sending SIGKILL/ { count++ } END { print count + 0 }')
+            [ "$code" = 0 ] && [ "$oom" = false ] && [ "$state" = exited ] && [ "$sigkill" -ge 1 ] || all_pass=false
+            echo "  $mode run $i: ${ELAPSED_MS}ms exit=$code oom=$oom state=$state api_wait=$API_WAIT_STATUS web_wait=$WEB_WAIT_STATUS"
+            strict_remove "$ctr" "$owner" || all_pass=false
+            i=$((i + 1))
         done
-        avg=$((total / runs))
-        echo "  $mode: min=${min}s max=${max}s avg=${avg}s (runs=$runs)"
-        if [ "$allpass" = "1" ] && [ "$max" -le 9 ]; then
-            ok "$mode stubborn stop: all fields pass (max ${max}s)"
+        if [ "$all_pass" = true ]; then
+            ok "$mode stubborn stop: $runs/$runs runs, max ${max_ms}ms, exact old PIDs reaped"
         else
-            bad "$mode stubborn stop: one or more assertions failed (max ${max}s)"
+            bad "$mode stubborn stop failed binding-faithful assertions"
+            strict_remove "${ctr:-missing}" "${owner:-missing}" >/dev/null 2>&1 || true
         fi
     done
 }
 
-# ---------------------------------------------------------------------------
-# Default normal stop (rootful + rootless)
-# ---------------------------------------------------------------------------
 case_default_normal() {
     echo ""
-    echo "=== [default-normal] default grace + normal children + docker stop ==="
+    echo "=== [default-normal] normal-child stop ==="
     for mode in rootful rootless; do
-        ctr="${WORK##*/}-normal-${mode}"
-        docker rm -f "$ctr" >/dev/null 2>&1 || true
-        if [ "$mode" = "rootless" ]; then
-            chown -R 1000:1000 "$CONFIG_DIR" 2>/dev/null || true
-            chmod 700 "$CONFIG_DIR" 2>/dev/null || true
-            docker run -d --name "$ctr" --user 1000:1000 \
-                -v "$CONFIG_DIR":/config \
-                -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-                "$IMAGE" >/dev/null
-        else
-            docker run -d --name "$ctr" \
-                -v "$CONFIG_DIR":/config -e PUID=1000 -e PGID=1000 \
-                -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-                "$IMAGE" >/dev/null
+        ctr="${PREFIX}normal-$mode"
+        owner=$ctr
+        pass=true
+        start_container "$ctr" "$mode" normal "" "$owner" || pass=false
+        if [ "$pass" = true ]; then wait_health false && capture_supervisor_epoch "$ctr" || pass=false; fi
+        if [ "$pass" = true ]; then measure_unchecked docker stop --time 10 "$ctr" || pass=false; fi
+        if [ "$pass" = true ]; then
+            code=$(stop_timing_exit_code "$ctr") || pass=false
+            oom=$(stop_timing_oom_killed "$ctr") || pass=false
+            state=$(stop_timing_runtime_state "$ctr") || pass=false
+            segment=$(appended_logs "$ctr" "$LOG_CURSOR") || pass=false
+            assert_epoch_reaped "$segment" "Services stopped gracefully" || pass=false
         fi
-        wait_health "$ctr" 60 || bad "$mode services not healthy"
-        start=$(date +%s)
-        docker stop --time 10 "$ctr" >/dev/null 2>&1 || true
-        end=$(date +%s)
-        elapsed=$((end - start))
-        code=$(docker inspect "$ctr" --format '{{.State.ExitCode}}' 2>/dev/null || echo '?')
-        echo "  $mode: elapsed=${elapsed}s exit=$code"
-        if [ "$code" = "0" ]; then
-            ok "$mode normal stop exit 0 (${elapsed}s)"
+        if [ "$pass" = true ] && [ "$code" = 0 ] && [ "$oom" = false ] && [ "$state" = exited ]; then
+            ok "$mode normal stop: ${ELAPSED_MS}ms, exact old PIDs reaped"
         else
-            bad "$mode normal stop exit $code"
+            bad "$mode normal stop failed binding-faithful assertions"
         fi
-        docker rm -f "$ctr" >/dev/null 2>&1 || true
+        strict_remove "$ctr" "$owner" || bad "$mode normal container removal was not proven"
     done
 }
 
-# ---------------------------------------------------------------------------
-# docker restart with stubborn child
-# ---------------------------------------------------------------------------
 case_docker_restart() {
     echo ""
-    echo "=== [docker-restart] default grace + stubborn child + docker restart --time 10 ==="
-    ctr="${WORK##*/}-restart"
-    start_stubborn "$ctr" "" rootful
-    wait_api_health "$ctr" 60 || bad "API not healthy before restart"
-    wait_stubborn_ready "$ctr" || bad "shim not ready"
-    start=$(date +%s)
-    docker restart --time 10 "$ctr" >/dev/null 2>&1 || true
-    end=$(date +%s)
-    restart_elapsed=$((end - start))
-    echo "  restart elapsed=${restart_elapsed}s"
-    # after restart, wait for API health (web is a stubborn shim with no /health)
-    if wait_api_health "$ctr" 120; then
-        ok "container restarted and API became healthy"
+    echo "=== [docker-restart] old supervisor epoch is isolated from restart ==="
+    ctr="${PREFIX}restart"
+    old_owner="${ctr}-generation-1"
+    new_owner="${ctr}-generation-2"
+    cleanup_owner=$old_owner
+    start_container "$ctr" rootful stubborn "" "$old_owner" || {
+        bad "restart container failed to start"
+        strict_remove "$ctr" "$old_owner" || true
+        return
+    }
+    wait_health true && wait_stubborn_ready "$ctr" && capture_supervisor_epoch "$ctr" || {
+        bad "restart preconditions failed"
+        strict_remove "$ctr" "$old_owner" || true
+        return
+    }
+    old_api=$API_PID
+    old_web=$WEB_PID
+    old_cursor=$LOG_CURSOR
+    if measure restart docker restart --time 10 "$ctr"; then
+        ok "restart completed within Docker's 10s window (${ELAPSED_MS}ms)"
     else
-        bad "API did not become healthy after restart"
+        bad "restart exceeded Docker's 10s window (${ELAPSED_MS:-unknown}ms)"
     fi
-    # the stop phase of restart must have used start.sh's internal SIGKILL
-    logs=$(docker logs "$ctr" 2>&1 || true)
-    if echo "$logs" | grep -q "sending SIGKILL"; then
-        ok "start.sh performed internal SIGKILL during restart stop phase"
+    appended=$(appended_logs "$ctr" "$old_cursor") || appended=""
+    old_segment=$(printf '%s\n' "$appended" | awk '/API started with PID [0-9]+/ { exit } { print }')
+    API_PID=$old_api
+    WEB_PID=$old_web
+    old_epoch_reaped=false
+    if assert_epoch_reaped "$old_segment" "Services stopped gracefully" && printf '%s\n' "$old_segment" | grep -q 'sending SIGKILL'; then
+        old_epoch_reaped=true
+        ok "old restart PIDs were reaped inside the old log epoch"
     else
-        bad "no internal SIGKILL during restart stop phase"
+        bad "old restart PIDs lack bounded old-epoch reaping evidence"
     fi
-    if [ "$restart_elapsed" -lt 10 ]; then
-        ok "restart completed within Docker's 10s window (${restart_elapsed}s)"
+    restart_healthy=false
+    if [ "$old_epoch_reaped" = true ] && stop_timing_release_ports "$PORT_LEDGER" "$old_owner" "$ctr" running; then
+        cleanup_owner=$new_owner
+        API_PORT=$(published_port "$ctr" "$new_owner" 3001) || { bad "restarted API port query failed"; API_PORT=invalid; }
+        WEB_PORT=$(published_port "$ctr" "$new_owner" 3000) || { bad "restarted Web port query failed"; WEB_PORT=invalid; }
+        if wait_health true; then restart_healthy=true; fi
+    fi
+    if [ "$restart_healthy" = true ] && capture_supervisor_epoch "$ctr" && [ "$LOG_CURSOR" -gt "$old_cursor" ]; then
+        ok "new supervisor epoch became healthy after the shutdown boundary"
     else
-        bad "restart took ${restart_elapsed}s (>=10s)"
+        bad "new supervisor epoch was not isolated and healthy"
     fi
-    docker rm -f "$ctr" >/dev/null 2>&1 || true
-}
-
-# ---------------------------------------------------------------------------
-# Prompt exit detection (api/web death) — rootful + rootless
-# ---------------------------------------------------------------------------
-prompt_exit_once() {
-    ctr=$1
-    service=$2
-    rootless=$3
-    rm -f "$CONFIG_DIR/.launcher-ctl" "$CONFIG_DIR/.mock-pid" \
-          "$CONFIG_DIR/.shim-api-control" "$CONFIG_DIR/.shim-web-control" 2>/dev/null || true
-    docker rm -f "$ctr" >/dev/null 2>&1 || true
-    if [ "$rootless" = "rootless" ]; then
-        chown -R 1000:1000 "$CONFIG_DIR" 2>/dev/null || true
-        chmod 700 "$CONFIG_DIR" 2>/dev/null || true
-        docker run -d --name "$ctr" --user 1000:1000 \
-            -v "$CONFIG_DIR":/config \
-            -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-            "$IMAGE" >/dev/null
-    else
-        docker run -d --name "$ctr" \
-            -v "$CONFIG_DIR":/config -e PUID=1000 -e PGID=1000 \
-            -p "$HOST_API_PORT":3001 -p "$HOST_WEB_PORT":3000 \
-            "$IMAGE" >/dev/null
-    fi
-    wait_health "$ctr" 60 || { echo "  (not healthy)"; return 1; }
-    pid=$(docker logs "$ctr" 2>&1 | sed -n "s/.*$service started with PID \([0-9][0-9]*\).*/\1/p" | tail -1)
-    [ -n "$pid" ] || { echo "  (no tracked pid)"; return 1; }
-    start=$(date +%s)
-    docker exec "$ctr" sh -c "kill -KILL $pid 2>/dev/null || true"
-    # wait for container exit
-    pe_elapsed=0
-    while [ "$pe_elapsed" -lt 30 ]; do
-        state=$(docker inspect "$ctr" --format '{{.State.Status}}' 2>/dev/null || echo missing)
-        [ "$state" != "running" ] && break
-        sleep 1
-        pe_elapsed=$((pe_elapsed + 1))
-    done
-    end=$(date +%s)
-    wall=$((end - start))
-    code=$(docker inspect "$ctr" --format '{{.State.ExitCode}}' 2>/dev/null || echo '?')
-    oom=$(docker inspect "$ctr" --format '{{.State.OOMKilled}}' 2>/dev/null || echo '?')
-    logs=$(docker logs "$ctr" 2>&1 || true)
-    fatal_log=$(echo "$logs" | grep -c "$service service exited unexpectedly" || true)
-    term_log=$(echo "$logs" | grep -c "Terminating" || true)
-    # Check no matching service process remains alive.
-    case "$service" in
-        API)   match="launcher.js" ;;
-        Web)   match="server.js" ;;
-    esac
-    survivors=$(docker exec "$ctr" sh -c "for p in /proc/[0-9]*; do c=\$(tr '\0' ' ' < \"\$p/cmdline\" 2>/dev/null); case \"\$c\" in *\"$match\"*) echo found;; esac; done" 2>/dev/null | grep -c found || true)
-    echo "  $rootless $service death: wall=${wall}s exit=$code oom=$oom fatal_log=$fatal_log term_log=$term_log survivors=$survivors"
-    docker rm -f "$ctr" >/dev/null 2>&1 || true
-    # Structured result: wall|exit|oom|fatal_log|term_log|survivors
-    echo "${wall}|${code}|${oom}|${fatal_log}|${term_log}|${survivors}"
+    strict_remove "$ctr" "$cleanup_owner" || bad "restart container removal was not proven"
 }
 
 case_prompt_exit() {
     echo ""
-    echo "=== [prompt-exit] api/web death detection timing (<=4s) ==="
+    echo "=== [prompt-exit] unexpected API/web death is detected within 4000ms ==="
     for mode in rootful rootless; do
-        for svc in API Web; do
-            ctr="${WORK##*/}-prompt-${mode}-${svc}"
-            raw=$(prompt_exit_once "$ctr" "$svc" "$mode")
-            result=$(echo "$raw" | tail -1)
-            case "$result" in
-                ''|*[!0-9|]*) bad "$mode $svc death: no result"; continue ;;
-            esac
-            w=$(echo "$result" | cut -d'|' -f1)
-            rc=$(echo "$result" | cut -d'|' -f2)
-            ok_=$(echo "$result" | cut -d'|' -f3)
-            fl=$(echo "$result" | cut -d'|' -f4)
-            tl=$(echo "$result" | cut -d'|' -f5)
-            sv=$(echo "$result" | cut -d'|' -f6)
-            pass=1
-            if [ "$w" -gt 4 ]; then echo "  FAIL: ${w}s > 4s"; pass=0; fi
-            if [ "$rc" = "0" ]; then echo "  FAIL: exit code 0 (expected nonzero)"; pass=0; fi
-            if [ "$ok_" != "false" ]; then echo "  FAIL: OOMKilled=$ok_"; pass=0; fi
-            if [ "$fl" -lt 1 ]; then echo "  FAIL: no fatal service exit log"; pass=0; fi
-            if [ "$tl" -lt 1 ]; then echo "  FAIL: no sibling termination log"; pass=0; fi
-            if [ "$sv" != "0" ]; then echo "  FAIL: $sv matching service process(es) survived"; pass=0; fi
-            if [ "$pass" = "1" ]; then
-                ok "$mode $svc death: all assertions pass (${w}s)"
-            else
-                bad "$mode $svc death: one or more assertions failed"
+        for service in API Web; do
+            ctr="${PREFIX}prompt-$mode-$service"
+            owner=$ctr
+            pass=true
+            start_container "$ctr" "$mode" normal "" "$owner" || pass=false
+            if [ "$pass" = true ]; then wait_health false && capture_supervisor_epoch "$ctr" || pass=false; fi
+            if [ "$pass" = true ]; then
+                case "$service" in API) target_pid=$API_PID ;; Web) target_pid=$WEB_PID ;; esac
+                measure prompt "$SCRIPT_DIR/stop-timing-query.sh" trigger-exit "$ctr" "$target_pid" || pass=false
             fi
+            if [ "$pass" = true ]; then
+                code=$(stop_timing_exit_code "$ctr") || pass=false
+                oom=$(stop_timing_oom_killed "$ctr") || pass=false
+                state=$(stop_timing_runtime_state "$ctr") || pass=false
+                segment=$(appended_logs "$ctr" "$LOG_CURSOR") || pass=false
+                assert_epoch_reaped "$segment" || pass=false
+                fatal_count=$(printf '%s\n' "$segment" | awk -v service="$service" 'index($0, "ERROR: " service " service exited unexpectedly") { count++ } END { print count + 0 }')
+                term_count=$(printf '%s\n' "$segment" | awk '/Terminating (API|Web) service/ { count++ } END { print count + 0 }')
+            fi
+            if [ "$pass" = true ] && [ "$code" -ne 0 ] && [ "$oom" = false ] && [ "$state" = exited ] && [ "$fatal_count" -eq 1 ] && [ "$term_count" -eq 1 ]; then
+                ok "$mode $service death: ${ELAPSED_MS}ms, nonzero exit, both old PIDs reaped"
+            else
+                bad "$mode $service death failed binding-faithful assertions"
+            fi
+            strict_remove "$ctr" "$owner" || bad "$mode $service container removal was not proven"
         done
     done
 }
 
-# ---------------------------------------------------------------------------
-# Runner
-# ---------------------------------------------------------------------------
+case_negative_control() {
+    echo ""
+    echo "=== [negative-control] no supervisor wait event without start-combined.sh ==="
+    ctr="${PREFIX}negative"
+    owner=$ctr
+    docker run --name "$ctr" --entrypoint sh "$IMAGE" -c 'echo negative-control; exit 0' >/dev/null
+    logs=$(container_logs "$ctr") || { bad "negative-control log query failed"; return; }
+    count=$(printf '%s\n' "$logs" | awk '/^SUPERVISOR_WAIT_COMPLETED pid=[0-9]+ status=[0-9]+$/ { count++ } END { print count + 0 }')
+    if [ "$count" -ne 0 ]; then
+        bad "negative control emitted $count supervisor wait event(s)"
+    else
+        echo "  PROOF: negative control emitted no supervisor wait event"
+    fi
+    strict_remove "$ctr" "$owner" || bad "negative-control removal was not proven"
+}
+
 run_case() {
     name=$1
     fn=$2
-    if [ -n "$CASE" ] && [ "$CASE" != "$name" ]; then
-        return
+    if [ -z "$CASE" ] || [ "$CASE" = "$name" ]; then
+        echo "########## CASE: $name ##########"
+        "$fn"
     fi
-    echo "########## CASE: $name ##########"
-    $fn
 }
 
 run_case red-collision case_red_collision
@@ -422,12 +431,26 @@ run_case green-stubborn case_green_stubborn
 run_case default-normal case_default_normal
 run_case docker-restart case_docker_restart
 run_case prompt-exit case_prompt_exit
+run_case negative-control case_negative_control
+
+owned=$(stop_timing_owned_names "$PREFIX") || { echo "QUERY_ERROR while proving suite cleanup" >&2; exit 1; }
+if [ -n "$owned" ]; then
+    echo "owned containers remain: $owned" >&2
+    exit 1
+fi
+active_ports=$(stop_timing_active_ports "$PORT_LEDGER") || { echo "QUERY_ERROR while proving port cleanup" >&2; exit 1; }
+if [ -n "$active_ports" ]; then
+    echo "active port owners remain: $active_ports" >&2
+    exit 1
+fi
+if ! rm -rf "$WORK" || [ -e "$WORK" ]; then
+    echo "suite work directory cleanup was not proven: $WORK" >&2
+    exit 1
+fi
+trap - EXIT
 
 echo ""
 echo "=========================================="
 echo "stop-timing results: PASS=$PASS FAIL=$FAIL"
 echo "=========================================="
-if [ "$FAIL" -gt 0 ]; then
-    exit 1
-fi
-exit 0
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Replace whole-second stop-timing assertions with monotonic millisecond measurements and make the Docker harness prove exact process epochs, Docker query outcomes, and active resource ownership.

The only production change emits `SUPERVISOR_WAIT_COMPLETED pid=<pid> status=<status>` immediately after the existing tracked-child `wait`. It does not change shutdown control flow.

## Related issue

Closes #831

## Scope

- Add the monotonic clock and strict Docker query helpers.
- Make the stop-timing harness use exact PID, log-epoch, Docker-state, and active-resource evidence.
- Add focused helper regressions and run them in Docker Smoke.
- Add one static, content-free wait-completion event to `docker/start-combined.sh`.

## Non-goals

- No shutdown sequencing, grace, escalation, restart, launcher, lifecycle, or exit-code changes.
- No timing tolerance, averaging, retry, flaky marking, or skipped test.
- No runtime lease, distributed coordination, schema, provider, release, deployment, or `next` work.

## Acceptance criteria

- [x] Timing gates use one-process monotonic milliseconds with exact boundaries: collision `>=9000`, stubborn `<9000`, restart `<10000`, prompt fatal exit `<=4000`.
- [x] Exact old API and Web PIDs require numeric wait-completion events from the correct appended log epoch; status 127 is rejected.
- [x] Docker `PRESENT`, `ABSENT`, and `QUERY_ERROR` outcomes remain distinct and fail closed.
- [x] Port ownership is active-only and bound to the exact generation and container; failed, unknown, or mismatched release retains ownership.
- [x] Every individual case passes, three complete epochs pass 12/12 each, and the harness leaves zero owned resources.
- [x] The broader supervision, launcher, restart, and shutdown-grace contracts pass unchanged.

## Changes

- Added `stop-timing-clock.cjs` for monotonic command measurement and exact threshold predicates.
- Added `stop-timing-query.sh` for strict Docker classification, PID signaling, and owner-scoped active port records.
- Reworked `test-stop-timing.sh` around exact log cursors, tracked PIDs, restart generations, and strict cleanup proofs.
- Added 18 focused helper tests, including false pass/fail controls, Docker query failures, port reuse, live conflict, mismatched release, corrupt ledger, and final-zero cases.
- Wired the helper suite into Docker Smoke before the real timing harness.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable: not applicable; this is a Docker/process harness change
- [x] New queries use centralized query keys and polling constants, when applicable: not applicable
- [x] New sensitive displays preserve incognito behavior, when applicable: not applicable
- [x] New Prisma queries for user-owned resources include `userId`, when applicable: not applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable: not applicable
- [x] User-facing counts are precise rather than proxies, when applicable: not applicable
- [x] Action links reach the correct page with required parameters, when applicable: not applicable
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable: not applicable

Additional exact-head evidence:

- Helper regressions: 20/20 on current head, including numeric host identity and malformed identity rejection.
- Individual cases: collision 1/1; stubborn rootful/rootless 10/10 runs; normal 2/2; restart 3/3; prompt fatal exit 4/4; negative control emitted no wait event.
- Complete stop-timing epochs on the reviewed single-commit tree: 12/12, 12/12, 12/12; 36/36 total. Current correction head quick matrix: 12/12.
- Combined supervision 34/34; launcher 15/15; restart 14/14; shutdown grace 15/15.
- `pnpm run check:prisma-generated`; Prisma checker tests 17/17; `CI=true pnpm run validate:pr`; provider-cache heap 7/7; `git diff --check`.
- Final owned-container and stop-timing work-directory scans were empty.

## Review plan

- Initial broad-reviewed head: `7c573279bc1224f359de9eec4723b85909959437`
- Correction head: current published head `8f6649d9054eecf17f7dc0f73f7423d9e5bbde08`; the reviewed unpublished head `d9a744bda426a2312bdacae0cf5880be248488ad` and initial published single-commit head `cf584ee63a76c389187f0bbcf9d90609c7d2e31a` shared tree `bee3e1ef782be5ddb3f9518bb21252490ea4a410`
- Targeted delta range: `7c573279bc1224f359de9eec4723b85909959437..5a3c37dcafc8e6c56aa522b41256a4df13d8c94e`, `5a3c37dcafc8e6c56aa522b41256a4df13d8c94e..d309b2db92ef184aa15c2ad58c463f192d5c6a77`, `d309b2db92ef184aa15c2ad58c463f192d5c6a77..d9a744bda426a2312bdacae0cf5880be248488ad`, and `cf584ee63a76c389187f0bbcf9d90609c7d2e31a..8f6649d9054eecf17f7dc0f73f7423d9e5bbde08`
- Material-scope change declared? No
- Independent regression reviewer: timing/determinism reviewer PASS on the complete final tree
- Independent data-safety reviewer, when required: process/resource-safety reviewer PASS; no database, filesystem application mutation, or upstream mutation path changed
- GitHub Codex review head: pending
- Maintainer decision: pending exact-head CI and GitHub review

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| F1 | P2 | contract violation | Whole-second subtraction false-failed a 9,999 ms restart and false-passed a 9,999 ms stubborn stop | Fixed with one-process monotonic millisecond measurement and boundary regressions | None |
| F2 | P2 | introduced regression | Restart could leave an inactive old port mapping in the conflict ledger | Fixed with active-only generation ownership and verified exact release | None |
| F3 | P2 | contract violation | An existing owner could be released using proof from an unrelated container name | Fixed by persisting and requiring the exact owner plus container pair | None |
| F4 | P3 | validation gap | Combined numeric validation accepted embedded colons before a later parse failure | Fixed with separate decimal validation and RED/GREEN coverage | None |
| F5 | P3 | diagnostic regression | Nested corrupt-ledger parsing returned status 2 but swallowed `QUERY_ERROR` | Fixed and covered through both record and release commands | None |
| F6 | P2 | unreproduced | A generic interrupted live-child `wait` example did not match any production `reap_tracked` caller precondition | Rejected after exact call-path review; three final reviewers confirmed unchanged production control flow | None |
| F7 | P2 | CI integration defect | GitHub runner could not remove container-owned log files because the harness hardcoded runtime UID/GID 1000 | Fixed by validating the host numeric identity and using it for both PUID/PGID and rootless `--user`; two targeted reviewers passed the correction | None |

## Final merge gate

- [ ] Exact-head CI is green
- [x] Acceptance criteria passed
- [ ] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [ ] Maintainer approved merge
- [x] Post-merge verification is planned: merge-SHA workflows, helper regressions, and three complete 12/12 timing epochs
