### PR TITLE
fix(jellyfin): preserve BoxSet cache completeness

### DIFF
--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -130,6 +130,26 @@ function makeSeriesItem(overrides: Partial<JellyfinItem> = {}): JellyfinItem {
 	};
 }
 
+function makeMovieItem(overrides: Partial<JellyfinItem> = {}): JellyfinItem {
+	return makeSeriesItem({
+		id: "jf-movie-1",
+		name: "Amadeus",
+		type: "Movie",
+		tmdbId: 279,
+		...overrides,
+	});
+}
+
+function makeBoxSetItem(overrides: Partial<JellyfinItem> = {}): JellyfinItem {
+	return makeSeriesItem({
+		id: "jf-boxset-1",
+		name: "Favorites",
+		type: "BoxSet",
+		tmdbId: undefined,
+		...overrides,
+	});
+}
+
 const oneUser: JellyfinUser[] = [{ id: "user-1", name: "Alice" }];
 const oneLibrary: JellyfinLibrary[] = [
 	{ id: "lib-1", name: "TV Shows", collectionType: "tvshows" },
@@ -528,14 +548,8 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(deleteMany).not.toHaveBeenCalled();
 	});
 
-	it("ignores BoxSet collection entries without blocking cache publication", async () => {
-		const collection = makeSeriesItem({
-			id: "jf-boxset-1",
-			name: "Favorites",
-			type: "BoxSet",
-			tmdbId: undefined,
-		});
-		const client = makeMockClient([makeSeriesItem(), collection]);
+	it("ignores a BoxSet alongside a Series without blocking cache publication", async () => {
+		const client = makeMockClient([makeSeriesItem(), makeBoxSetItem()]);
 		const { stub, upserts } = makeMockPrisma();
 
 		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
@@ -543,6 +557,75 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
 		expect(upserts).toHaveLength(1);
 		expect(upserts[0]).toMatchObject({ create: { jellyfinId: "jf-series-1" } });
+	});
+
+	it("ignores a BoxSet alongside a Movie without blocking cache publication", async () => {
+		const movieLibrary: JellyfinLibrary[] = [
+			{ id: "lib-movies", name: "Movies", collectionType: "movies" },
+		];
+		const client = {
+			...makeMockClient([]),
+			getLibraries: vi.fn().mockResolvedValue(movieLibrary),
+			getLibraryItems: vi.fn().mockResolvedValue([makeMovieItem(), makeBoxSetItem()]),
+		} as unknown as JellyfinClient;
+		const { stub, upserts } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		expect(client.getLibraryItems).toHaveBeenCalledWith("user-1", "lib-movies", {
+			includeItemTypes: "Movie",
+		});
+		expect(upserts).toHaveLength(1);
+		expect(upserts[0]).toMatchObject({ create: { jellyfinId: "jf-movie-1" } });
+	});
+
+	it("publishes an authoritative empty cache when a library contains only BoxSets", async () => {
+		const client = makeMockClient([
+			makeBoxSetItem(),
+			makeBoxSetItem({ id: "jf-boxset-2", name: "Favorites 2" }),
+		]);
+		const { stub, tx } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 0 });
+		expect(tx.jellyfinCache.deleteMany).toHaveBeenCalledWith({ where: { instanceId: "inst-1" } });
+		expect(tx.jellyfinCache.createMany).not.toHaveBeenCalled();
+		expect(tx.cacheRefreshStatus.upsert).toHaveBeenCalledOnce();
+	});
+
+	it("ignores several BoxSets across independently scanned libraries", async () => {
+		const libraries: JellyfinLibrary[] = [
+			{ id: "lib-movies", name: "Movies", collectionType: "movies" },
+			{ id: "lib-series", name: "Series", collectionType: "tvshows" },
+		];
+		const client = {
+			...makeMockClient([]),
+			getLibraries: vi.fn().mockResolvedValue(libraries),
+			getLibraryItems: vi.fn(async (_userId: string, libraryId: string) =>
+				libraryId === "lib-movies"
+					? [
+							makeMovieItem(),
+							makeBoxSetItem(),
+							makeBoxSetItem({ id: "jf-boxset-2", name: "Favorites 2" }),
+						]
+					: [makeSeriesItem(), makeBoxSetItem({ id: "jf-boxset-3", name: "Favorites 3" })],
+			),
+		} as unknown as JellyfinClient;
+		const { stub, upserts } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 2 });
+		expect(client.getLibraryItems).toHaveBeenCalledTimes(2);
+		expect(upserts).toHaveLength(2);
+		expect(upserts).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ create: expect.objectContaining({ jellyfinId: "jf-movie-1" }) }),
+				expect.objectContaining({ create: expect.objectContaining({ jellyfinId: "jf-series-1" }) }),
+			]),
+		);
 	});
 
 	it("continues to fail closed for unexpected non-BoxSet library item types", async () => {

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -528,6 +528,40 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(deleteMany).not.toHaveBeenCalled();
 	});
 
+	it("ignores BoxSet collection entries without blocking cache publication", async () => {
+		const collection = makeSeriesItem({
+			id: "jf-boxset-1",
+			name: "Favorites",
+			type: "BoxSet",
+			tmdbId: undefined,
+		});
+		const client = makeMockClient([makeSeriesItem(), collection]);
+		const { stub, upserts } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		expect(upserts).toHaveLength(1);
+		expect(upserts[0]).toMatchObject({ create: { jellyfinId: "jf-series-1" } });
+	});
+
+	it("continues to fail closed for unexpected non-BoxSet library item types", async () => {
+		const unexpected = makeSeriesItem({
+			id: "jf-playlist-1",
+			name: "Unexpected playlist",
+			type: "Playlist",
+			tmdbId: undefined,
+		});
+		const client = makeMockClient([makeSeriesItem(), unexpected]);
+		const { stub, tx } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: false, errors: 0, upserted: 0 });
+		expect(tx.jellyfinCache.deleteMany).not.toHaveBeenCalled();
+		expect(stub.$transaction).not.toHaveBeenCalled();
+	});
+
 	it("fails closed without evicting when a relevant item has no TMDb mapping", async () => {
 		const client = makeMockClient([makeSeriesItem({ tmdbId: undefined })]);
 		const deleteMany = vi.fn();

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-client-completeness.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-client-completeness.test.ts
@@ -115,6 +115,7 @@ describe("JellyfinClient authoritative inventory completeness", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		for (const call of fetchMock.mock.calls) {
 			expect(String(call[0])).toContain("IncludeItemTypes=Movie%2CSeries");
+			expect(String(call[0])).toContain("CollapseBoxSetItems=false");
 		}
 	});
 

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-client-completeness.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-client-completeness.test.ts
@@ -21,6 +21,15 @@ function episode(index: number) {
 	};
 }
 
+function movie(index: number) {
+	return {
+		Id: `movie-${index}`,
+		Name: `Movie ${index}`,
+		Type: "Movie",
+		ProviderIds: { Tmdb: String(index) },
+	};
+}
+
 describe("JellyfinClient authoritative inventory completeness", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
@@ -83,5 +92,46 @@ describe("JellyfinClient authoritative inventory completeness", () => {
 		await expect(client.getEpisodes("user-1", "series-1")).rejects.toThrow(
 			/safe 100000-row limit/i,
 		);
+	});
+
+	it("preserves BoxSet rows while paginating the complete filtered library inventory", async () => {
+		const firstPage = [
+			...Array.from({ length: 999 }, (_, index) => movie(index + 1)),
+			{ Id: "boxset-1", Name: "Favorites", Type: "BoxSet" },
+		];
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(response({ Items: firstPage, TotalRecordCount: 1_001 }))
+			.mockResolvedValueOnce(response({ Items: [movie(1_000)], TotalRecordCount: 1_001 }));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new JellyfinClient("http://jellyfin.test", "api-key", log);
+
+		const result = await client.getLibraryItems("user-1", "library-1", {
+			includeItemTypes: "Movie,Series",
+		});
+
+		expect(result).toHaveLength(1_001);
+		expect(result[999]).toMatchObject({ id: "boxset-1", type: "BoxSet", tmdbId: undefined });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		for (const call of fetchMock.mock.calls) {
+			expect(String(call[0])).toContain("IncludeItemTypes=Movie%2CSeries");
+		}
+	});
+
+	it("rejects a malformed library item before exposing a partial inventory", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				response({
+					Items: [movie(1), { Id: "malformed-1", Name: "Missing type" }],
+					TotalRecordCount: 2,
+				}),
+			),
+		);
+		const client = new JellyfinClient("http://jellyfin.test", "api-key", log);
+
+		await expect(
+			client.getLibraryItems("user-1", "library-1", { includeItemTypes: "Movie" }),
+		).rejects.toThrow(/Upstream validation failed.*Items\.1\.Type/i);
 	});
 });

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -289,6 +289,7 @@ export async function collectJellyfinCacheLiveEvidence(
 					});
 
 					for (const item of items) {
+						if (item.type === "BoxSet") continue;
 						if (item.type !== "Movie" && item.type !== "Series") {
 							complete = false;
 							continue;

--- a/apps/api/src/lib/jellyfin/jellyfin-client.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-client.ts
@@ -188,6 +188,7 @@ export class JellyfinClient {
 			ParentId: libraryId,
 			Fields: "ProviderIds,DateCreated,ImageTags",
 			Recursive: "true",
+			CollapseBoxSetItems: "false",
 		});
 		if (options?.includeItemTypes) {
 			params.set("IncludeItemTypes", options.includeItemTypes);


### PR DESCRIPTION
## Summary

Keep Jellyfin base-cache publication available when supported servers return `BoxSet` collection containers, without weakening fail-closed handling for unknown or malformed library items.

## Related issue

Related to #804

## Scope

- Request uncollapsed Movie and Series library items from Jellyfin.
- Exclude known non-target `BoxSet` containers from cache rows.
- Preserve current provider identity, pagination, count, malformed-item, and unknown-type completeness gates.
- Add regression coverage at the client and cache-publication boundaries.

## Non-goals

- No title/year fallback or case-insensitive/wildcard type acceptance.
- No change to Jellyfin label mutation, provider ownership, or execution-time authorization.
- No schema, UI, route, configuration, or `next`-branch change.

## Acceptance criteria

- [x] Movie and Series rows remain publishable when their raw library responses also contain `BoxSet` items.
- [x] A response containing only `BoxSet` items is an authoritative empty result, not an incomplete refresh.
- [x] Several `BoxSet` items across libraries do not corrupt row identity, counts, or pagination.
- [x] Unknown non-`BoxSet` types and malformed items still fail closed.
- [x] Every paginated library request disables Jellyfin collection collapsing so underlying Movie/Series items remain visible.
- [x] Real Jellyfin 10.11.11 evidence reproduces the current-main failure and verifies the candidate behavior.

## Changes

- Add `CollapseBoxSetItems=false` to authoritative Jellyfin library-item requests.
- Skip only exact `BoxSet` items before the existing Movie/Series type gate.
- Cover mixed Movie/BoxSet, mixed Series/BoxSet, BoxSet-only, multi-library, unknown-type, malformed-item, and page-boundary behavior.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

This refresh atomically replaces cache rows, so a falsely complete inventory could delete valid cached identities.

## Validation

- [x] Relevant deterministic validation passed: `pnpm run validate:pr`
- [x] Focused tests passed, when applicable: 28/28 across the Jellyfin refresher and client-completeness suites
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed: run by the full validation gate; shared was unchanged
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: API 4,745 passed / 54 skipped; web 678 passed; shared 89 passed
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable: backend behavior verified against a disposable Jellyfin 10.11.11 instance
- [x] New queries use centralized query keys and polling constants, when applicable: N/A, no frontend query added
- [x] New sensitive displays preserve incognito behavior, when applicable: N/A, no display added
- [x] New Prisma queries for user-owned resources include `userId`, when applicable: N/A, no Prisma query added
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable: N/A, no UI surface added
- [x] User-facing counts are precise rather than proxies, when applicable: raw `TotalRecordCount` pagination is retained and page-boundary tested
- [x] Action links reach the correct page with required parameters, when applicable: N/A, no action link added
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable: no duplicate behavior surface added

Live Jellyfin 10.11.11 evidence with collection grouping enabled:

- Current `main`: the provider returned `BoxSet` containers and the collector failed closed (`complete=false`, zero published rows).
- Candidate head: the client requested uncollapsed items and the collector completed with one Movie and one Series row, both mapped to TMDb identities.
- The disposable provider is retained for exact-merge-SHA verification and will be removed afterward.

## Review plan

- Initial broad-reviewed head: `bc07e3f7c4f0cc5d4d86d34381800958faeb0c07`
- Correction head: `67752ba7ad59c9d4346f7da708c397e7104af47e`
- Targeted delta range: `bc07e3f7..7f1669a0` and `7f1669a0..67752ba7`
- Material-scope change declared? No; the correction enforces the existing complete-inventory contract at the provider request boundary
- Independent regression reviewer: PASS on the assembled head and both targeted deltas
- Independent data-safety reviewer, when required: PASS on the assembled head and both targeted deltas
- GitHub Codex review head: `67752ba7ad59c9d4346f7da708c397e7104af47e` — completed with no findings
- Maintainer decision: Merge after exact-head gates pass under the standing convergence authorization

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| C1 | P1 | In scope | Jellyfin 10.11.11 with collection grouping returned only `BoxSet` containers for an `IncludeItemTypes=Movie` request, so a skip-only implementation could publish an incomplete inventory | Fixed at `67752ba7` by requesting `CollapseBoxSetItems=false`; focused tests, real-provider verification, and targeted independent reviews pass | Exact-merge-SHA provider verification before closing #804 |

## Final merge gate

- [x] Exact-head CI is green: 14/14 checks passed on `67752ba7ad59c9d4346f7da708c397e7104af47e`
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain: zero GitHub review threads and no submitted change-request review
- [x] Valid out-of-scope findings are linked or dispositioned: none
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed: exact `main` is `a12182675f7f851631eeb910dcd330cf0362a5b5`; no open PR overlaps the changed files
- [x] Maintainer approved merge under the standing convergence authorization, conditional on the remaining exact-head gates
- [x] Post-merge verification is planned against the retained disposable Jellyfin 10.11.11 provider
