### PR TITLE
fix(label-sync): fail closed for Jellyfin destinations

### DIFF
--- a/apps/api/src/lib/label-sync/__tests__/destination-capability.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/destination-capability.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+	DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE,
+	DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE_MESSAGE,
+	getLabelSyncDestinationMutationCapability,
+} from "../destination-capability.js";
+
+describe("label-sync destination mutation capability", () => {
+	it.each(["sonarr", "radarr", "plex"])("keeps %s destination mutation supported", (service) => {
+		expect(getLabelSyncDestinationMutationCapability(service)).toEqual({ supported: true });
+	});
+
+	it.each(["jellyfin", "emby"])("fails closed for the %s destination", (service) => {
+		expect(getLabelSyncDestinationMutationCapability(service)).toEqual({
+			supported: false,
+			code: DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE,
+			message: DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE_MESSAGE,
+		});
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/destination-containment-entrypoints.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/destination-containment-entrypoints.test.ts
@@ -1,0 +1,417 @@
+import Fastify, { type FastifyBaseLogger, type FastifyInstance } from "fastify";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerLabelSyncRoutes } from "../../../routes/label-sync.js";
+import { Encryptor } from "../../auth/encryption.js";
+import type { ServiceInstance } from "../../prisma.js";
+import { LabelSyncScheduler } from "../label-sync-scheduler.js";
+import { triggerLabelSyncForItem } from "../trigger-for-item.js";
+
+const UNAVAILABLE_MESSAGE =
+	"Jellyfin and Emby label destinations are temporarily unavailable because the provider cannot yet be re-authorized safely at execution time.";
+
+const PRIVATE = {
+	ruleId: "CANARY_RULE_ID_836",
+	ruleName: "CANARY_RULE_NAME_836",
+	sourceInstanceId: "CANARY_SOURCE_INSTANCE_836",
+	destInstanceId: "CANARY_DEST_INSTANCE_836",
+	sourceTag: "CANARY_PRIVATE_SOURCE_TAG_836",
+	destTag: "CANARY_PRIVATE_DEST_TAG_836",
+	tmdbId: 836123,
+	providerItemId: "CANARY_PROVIDER_ITEM_ID_836",
+	libraryId: "CANARY_LIBRARY_ID_836",
+	libraryTitle: "CANARY_LIBRARY_TITLE_836",
+	mediaTitle: "CANARY_MEDIA_TITLE_836",
+	baseUrl: "http://CANARY_PROVIDER_HOST_836.invalid",
+	username: "CANARY_PROVIDER_USER_836",
+	token: "CANARY_PROVIDER_TOKEN_836",
+	rawError: "CANARY_RAW_PROVIDER_ERROR_836",
+	requestPath: "/Items/CANARY_PROVIDER_ITEM_ID_836",
+	responseBody: "CANARY_RAW_PROVIDER_BODY_836",
+} as const;
+
+const encryptor = new Encryptor("0123456789abcdef0123456789abcdef");
+const encrypted = encryptor.encrypt(PRIVATE.token);
+
+type DestService = "jellyfin" | "emby";
+type PrismaDestService = "JELLYFIN" | "EMBY";
+
+function makeRule(destService: DestService) {
+	return {
+		id: PRIVATE.ruleId,
+		userId: "user-836",
+		name: PRIVATE.ruleName,
+		enabled: true,
+		sourceService: "sonarr",
+		sourceInstanceId: PRIVATE.sourceInstanceId,
+		sourceTagName: PRIVATE.sourceTag,
+		destService,
+		destInstanceId: PRIVATE.destInstanceId,
+		destTagName: PRIVATE.destTag,
+		lastRunAt: null,
+		lastRunStatus: null,
+		lastRunMessage: null,
+		createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-31T00:00:00.000Z"),
+	};
+}
+
+function makeInstance(
+	id: string,
+	service: "SONARR" | PrismaDestService,
+	baseUrl: string,
+): ServiceInstance {
+	return {
+		id,
+		userId: "user-836",
+		service,
+		label: service === "SONARR" ? "Synthetic Sonarr" : PRIVATE.libraryTitle,
+		baseUrl,
+		externalUrl: null,
+		encryptedApiKey: encrypted.value,
+		encryptionIv: encrypted.iv,
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-31T00:00:00.000Z"),
+	} as ServiceInstance;
+}
+
+function createPinoCapture(): { log: FastifyBaseLogger; serialized: () => string } {
+	const lines: string[] = [];
+	const log = pino(
+		{ level: "trace", base: null, timestamp: false },
+		{ write: (line: string) => lines.push(line) },
+	) as unknown as FastifyBaseLogger;
+	return { log, serialized: () => lines.join("") };
+}
+
+function expectNoSensitiveCanary(value: string): void {
+	for (const canary of [
+		PRIVATE.sourceTag,
+		PRIVATE.destTag,
+		PRIVATE.tmdbId,
+		PRIVATE.providerItemId,
+		PRIVATE.libraryId,
+		PRIVATE.libraryTitle,
+		PRIVATE.mediaTitle,
+		PRIVATE.baseUrl,
+		PRIVATE.username,
+		PRIVATE.token,
+		PRIVATE.rawError,
+		PRIVATE.requestPath,
+		PRIVATE.responseBody,
+	]) {
+		expect(value).not.toContain(String(canary));
+	}
+}
+
+function installUnsafeProviderCapture(requests: Array<{ path: string; method: string }>): void {
+	vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+		const url = new URL(
+			typeof input === "string" ? input : input instanceof URL ? input : input.url,
+		);
+		requests.push({ path: url.pathname, method: init?.method ?? "GET" });
+		if (url.pathname === "/Users") {
+			return Response.json([{ Id: PRIVATE.username, Name: PRIVATE.username }]);
+		}
+		if (url.pathname === `/Users/${PRIVATE.username}/Items/${PRIVATE.providerItemId}`) {
+			return Response.json({
+				Id: PRIVATE.providerItemId,
+				Name: PRIVATE.mediaTitle,
+				Type: "Movie",
+				ParentId: PRIVATE.libraryId,
+				ProviderIds: { Tmdb: String(PRIVATE.tmdbId) },
+				Tags: [],
+			});
+		}
+		if (url.pathname === PRIVATE.requestPath && init?.method === "POST") {
+			return new Response(null, { status: 204 });
+		}
+		throw new Error(`${PRIVATE.rawError}: ${url.pathname}: ${PRIVATE.responseBody}`);
+	});
+}
+
+function makeArrClientFactory() {
+	return {
+		create: vi.fn(() => ({
+			tag: { getAll: vi.fn().mockResolvedValue([{ id: 8, label: PRIVATE.sourceTag }]) },
+			series: {
+				getAll: vi.fn().mockResolvedValue([
+					{
+						tmdbId: PRIVATE.tmdbId,
+						tags: [8],
+						title: PRIVATE.mediaTitle,
+					},
+				]),
+			},
+		})),
+	};
+}
+
+function makePrisma(destService: DestService, prismaDestService: PrismaDestService) {
+	const rule = makeRule(destService);
+	const sourceInstance = makeInstance(
+		PRIVATE.sourceInstanceId,
+		"SONARR",
+		"http://synthetic-sonarr.invalid",
+	);
+	const destInstance = makeInstance(PRIVATE.destInstanceId, prismaDestService, PRIVATE.baseUrl);
+	const update = vi.fn().mockImplementation(({ data }) => {
+		const persistedData = Object.fromEntries(
+			Object.entries(data).filter(([, value]) => value !== undefined),
+		);
+		return Promise.resolve({
+			...rule,
+			...persistedData,
+			updatedAt: new Date("2026-08-31T00:01:00.000Z"),
+		});
+	});
+	const create = vi.fn().mockImplementation(({ data }) =>
+		Promise.resolve({
+			...rule,
+			...data,
+			id: "created-rule-836",
+			lastRunAt: null,
+			lastRunStatus: null,
+			lastRunMessage: null,
+		}),
+	);
+	return {
+		serviceInstance: {
+			findMany: vi.fn().mockResolvedValue([sourceInstance]),
+			findFirst: vi
+				.fn()
+				.mockImplementation(({ where }) =>
+					Promise.resolve(where.id === PRIVATE.sourceInstanceId ? sourceInstance : destInstance),
+				),
+		},
+		labelSyncRule: {
+			findMany: vi.fn().mockResolvedValue([rule]),
+			findFirst: vi.fn().mockResolvedValue(rule),
+			create,
+			update,
+		},
+		libraryCache: { findFirst: vi.fn().mockResolvedValue(null) },
+		jellyfinCache: {
+			findMany: vi.fn().mockResolvedValue([
+				{
+					jellyfinId: PRIVATE.providerItemId,
+					title: PRIVATE.mediaTitle,
+					tmdbId: PRIVATE.tmdbId,
+					mediaType: "movie",
+					libraryId: PRIVATE.libraryId,
+				},
+			]),
+		},
+	};
+}
+
+async function buildManualApp(
+	prisma: ReturnType<typeof makePrisma>,
+	arrClientFactory: ReturnType<typeof makeArrClientFactory>,
+	log: FastifyBaseLogger,
+): Promise<FastifyInstance> {
+	const app = Fastify({ loggerInstance: log });
+	app.decorate("prisma", prisma as never);
+	app.decorate("arrClientFactory", arrClientFactory as never);
+	app.decorate("encryptor", encryptor as never);
+	app.decorateRequest("currentUser", null);
+	app.addHook("preHandler", async (request) => {
+		(request as { currentUser: { id: string; username: string } }).currentUser = {
+			id: "user-836",
+			username: "admin",
+		};
+	});
+	await app.register(registerLabelSyncRoutes, { prefix: "/api/label-sync" });
+	await app.ready();
+	return app;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe.each([
+	["Jellyfin", "jellyfin", "JELLYFIN"],
+	["Emby", "emby", "EMBY"],
+] as const)("%s destination entrypoints", (_label, destService, prismaDestService) => {
+	it("keeps existing rules visible and editable without provider I/O or destination rewrites", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		installUnsafeProviderCapture(requests);
+		const prisma = makePrisma(destService, prismaDestService);
+		const app = await buildManualApp(prisma, makeArrClientFactory(), createPinoCapture().log);
+
+		try {
+			const listed = await app.inject({ method: "GET", url: "/api/label-sync/rules" });
+			const updated = await app.inject({
+				method: "PATCH",
+				url: `/api/label-sync/rules/${PRIVATE.ruleId}`,
+				payload: { name: "Updated contained rule" },
+			});
+			const listedBody = JSON.parse(listed.payload) as {
+				rules: Array<{ id: string; destService: string }>;
+			};
+			const updatedBody = JSON.parse(updated.payload) as {
+				rule: { name: string; destService: string; destInstanceId: string };
+			};
+
+			expect(listed.statusCode).toBe(200);
+			expect(listedBody.rules).toEqual([
+				expect.objectContaining({ id: PRIVATE.ruleId, destService }),
+			]);
+			expect(updated.statusCode).toBe(200);
+			expect(updatedBody.rule).toEqual(
+				expect.objectContaining({
+					name: "Updated contained rule",
+					destService,
+					destInstanceId: PRIVATE.destInstanceId,
+				}),
+			);
+			expect(prisma.labelSyncRule.update).toHaveBeenCalledWith({
+				where: { id: PRIVATE.ruleId },
+				data: expect.objectContaining({
+					name: "Updated contained rule",
+					destService: undefined,
+					destInstanceId: undefined,
+					destTagName: undefined,
+				}),
+			});
+			expect(requests).toEqual([]);
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("keeps new rule storage backward compatible while execution remains authoritative", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		installUnsafeProviderCapture(requests);
+		const prisma = makePrisma(destService, prismaDestService);
+		const app = await buildManualApp(prisma, makeArrClientFactory(), createPinoCapture().log);
+
+		try {
+			const response = await app.inject({
+				method: "POST",
+				url: "/api/label-sync/rules",
+				payload: {
+					name: "Stored contained destination",
+					sourceService: "sonarr",
+					sourceInstanceId: PRIVATE.sourceInstanceId,
+					sourceTagName: PRIVATE.sourceTag,
+					destService,
+					destInstanceId: PRIVATE.destInstanceId,
+					destTagName: PRIVATE.destTag,
+				},
+			});
+
+			expect(response.statusCode).toBe(201);
+			expect(prisma.labelSyncRule.create).toHaveBeenCalledWith({
+				data: expect.objectContaining({ destService, destInstanceId: PRIVATE.destInstanceId }),
+			});
+			expect(requests).toEqual([]);
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("manual execution persists and returns a bounded failed result before provider I/O", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		installUnsafeProviderCapture(requests);
+		const capture = createPinoCapture();
+		const prisma = makePrisma(destService, prismaDestService);
+		const app = await buildManualApp(prisma, makeArrClientFactory(), capture.log);
+
+		try {
+			const response = await app.inject({
+				method: "POST",
+				url: `/api/label-sync/rules/${PRIVATE.ruleId}/run`,
+			});
+			const body = JSON.parse(response.payload) as {
+				rule: { lastRunStatus: string; lastRunMessage: string };
+			};
+
+			expect(response.statusCode).toBe(200);
+			expect(requests).toEqual([]);
+			expect(body.rule.lastRunStatus).toBe("failed");
+			expect(body.rule.lastRunMessage).toBe(UNAVAILABLE_MESSAGE);
+			expect(prisma.labelSyncRule.update).toHaveBeenCalledWith({
+				where: { id: PRIVATE.ruleId },
+				data: {
+					lastRunAt: expect.any(Date),
+					lastRunStatus: "failed",
+					lastRunMessage: UNAVAILABLE_MESSAGE,
+				},
+			});
+			expectNoSensitiveCanary(body.rule.lastRunMessage);
+			expectNoSensitiveCanary(capture.serialized());
+		} finally {
+			await app.close();
+		}
+	});
+
+	it("scheduled execution records failure and never retries a provider mutation", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		installUnsafeProviderCapture(requests);
+		const capture = createPinoCapture();
+		const prisma = makePrisma(destService, prismaDestService);
+		const scheduler = new LabelSyncScheduler(
+			prisma as never,
+			makeArrClientFactory() as never,
+			encryptor,
+			capture.log,
+		);
+
+		await (scheduler as unknown as { tick(): Promise<void> }).tick();
+		await (scheduler as unknown as { tick(): Promise<void> }).tick();
+
+		expect(requests).toEqual([]);
+		expect(prisma.labelSyncRule.update).toHaveBeenCalledTimes(2);
+		for (const call of prisma.labelSyncRule.update.mock.calls) {
+			expect(call[0]?.data).toEqual({
+				lastRunAt: expect.any(Date),
+				lastRunStatus: "failed",
+				lastRunMessage: UNAVAILABLE_MESSAGE,
+			});
+		}
+		expectNoSensitiveCanary(capture.serialized());
+	});
+
+	it("event-triggered execution is acknowledged with no false success or provider I/O", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		installUnsafeProviderCapture(requests);
+		const capture = createPinoCapture();
+		const prisma = makePrisma(destService, prismaDestService);
+
+		const result = await triggerLabelSyncForItem({
+			userId: "user-836",
+			sourceService: "SONARR",
+			sourceInstanceId: PRIVATE.sourceInstanceId,
+			arrItemId: 836,
+			itemType: "series",
+			tagName: PRIVATE.sourceTag,
+			tmdbId: PRIVATE.tmdbId,
+			prisma: prisma as never,
+			arrClientFactory: makeArrClientFactory() as never,
+			encryptor,
+			log: capture.log,
+		});
+
+		expect(requests).toEqual([]);
+		expect(result.rulesFired).toBe(1);
+		expect(result.totals).toEqual({ labelsApplied: 0, failures: 1 });
+		expect(result.results[0]?.outcome).toEqual({
+			status: "failed",
+			message: UNAVAILABLE_MESSAGE,
+			totals: {
+				sourceInstancesScanned: 0,
+				taggedItemsFound: 0,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: 0,
+			},
+		});
+		expectNoSensitiveCanary(result.results[0]?.outcome.message ?? "");
+		expectNoSensitiveCanary(capture.serialized());
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/destination-containment-entrypoints.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/destination-containment-entrypoints.test.ts
@@ -377,7 +377,7 @@ describe.each([
 		expectNoSensitiveCanary(capture.serialized());
 	});
 
-	it("event-triggered execution is acknowledged with no false success or provider I/O", async () => {
+	it("event-triggered execution is acknowledged before TMDb resolution or provider I/O", async () => {
 		const requests: Array<{ path: string; method: string }> = [];
 		installUnsafeProviderCapture(requests);
 		const capture = createPinoCapture();
@@ -390,7 +390,6 @@ describe.each([
 			arrItemId: 836,
 			itemType: "series",
 			tagName: PRIVATE.sourceTag,
-			tmdbId: PRIVATE.tmdbId,
 			prisma: prisma as never,
 			arrClientFactory: makeArrClientFactory() as never,
 			encryptor,
@@ -398,8 +397,9 @@ describe.each([
 		});
 
 		expect(requests).toEqual([]);
+		expect(prisma.libraryCache.findFirst).not.toHaveBeenCalled();
 		expect(result.rulesFired).toBe(1);
-		expect(result.totals).toEqual({ labelsApplied: 0, failures: 1 });
+		expect(result.totals).toEqual({ labelsApplied: 0, failures: 0 });
 		expect(result.results[0]?.outcome).toEqual({
 			status: "failed",
 			message: UNAVAILABLE_MESSAGE,

--- a/apps/api/src/lib/label-sync/__tests__/execute-rule.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/execute-rule.test.ts
@@ -27,15 +27,25 @@ type Spy = ReturnType<typeof vi.fn<(arg: unknown) => void>>;
 const mockState: {
 	sonarrReadResult: SourceReadResult;
 	plexReadResult: SourceReadResult;
+	jellyfinReadResult: SourceReadResult;
+	embyReadResult: SourceReadResult;
 	plexWriteResult: DestWriteResult;
 	sonarrWriteResult: DestWriteResult;
+	radarrWriteResult: DestWriteResult;
+	jellyfinWriteResult: DestWriteResult;
+	embyWriteResult: DestWriteResult;
 	sourceReaderSpy: Spy;
 	destWriterSpy: Spy;
 } = {
 	sonarrReadResult: { matches: [], failed: false },
 	plexReadResult: { matches: [], failed: false },
+	jellyfinReadResult: { matches: [], failed: false },
+	embyReadResult: { matches: [], failed: false },
 	plexWriteResult: { matchesFound: 0, labelsApplied: 0, failures: 0 },
 	sonarrWriteResult: { matchesFound: 0, labelsApplied: 0, failures: 0 },
+	radarrWriteResult: { matchesFound: 0, labelsApplied: 0, failures: 0 },
+	jellyfinWriteResult: { matchesFound: 0, labelsApplied: 0, failures: 0 },
+	embyWriteResult: { matchesFound: 0, labelsApplied: 0, failures: 0 },
 	sourceReaderSpy: vi.fn<(arg: unknown) => void>(),
 	destWriterSpy: vi.fn<(arg: unknown) => void>(),
 };
@@ -55,6 +65,20 @@ vi.mock("../strategy-registry.js", () => {
 			return mockState.plexReadResult;
 		}),
 	};
+	const jellyfinReader: SourceReader = {
+		prismaService: "JELLYFIN",
+		readTaggedItems: vi.fn(async (opts) => {
+			mockState.sourceReaderSpy(opts);
+			return mockState.jellyfinReadResult;
+		}),
+	};
+	const embyReader: SourceReader = {
+		prismaService: "EMBY",
+		readTaggedItems: vi.fn(async (opts) => {
+			mockState.sourceReaderSpy(opts);
+			return mockState.embyReadResult;
+		}),
+	};
 	const plexWriter: DestWriter = {
 		prismaService: "PLEX",
 		applyLabels: vi.fn(async (opts) => {
@@ -69,9 +93,41 @@ vi.mock("../strategy-registry.js", () => {
 			return mockState.sonarrWriteResult;
 		}),
 	};
+	const radarrWriter: DestWriter = {
+		prismaService: "RADARR",
+		applyLabels: vi.fn(async (opts) => {
+			mockState.destWriterSpy(opts);
+			return mockState.radarrWriteResult;
+		}),
+	};
+	const jellyfinWriter: DestWriter = {
+		prismaService: "JELLYFIN",
+		applyLabels: vi.fn(async (opts) => {
+			mockState.destWriterSpy(opts);
+			return mockState.jellyfinWriteResult;
+		}),
+	};
+	const embyWriter: DestWriter = {
+		prismaService: "EMBY",
+		applyLabels: vi.fn(async (opts) => {
+			mockState.destWriterSpy(opts);
+			return mockState.embyWriteResult;
+		}),
+	};
 	return {
-		SOURCE_READERS: { sonarr: sonarrReader, plex: plexReader },
-		DEST_WRITERS: { plex: plexWriter, sonarr: sonarrWriter },
+		SOURCE_READERS: {
+			sonarr: sonarrReader,
+			plex: plexReader,
+			jellyfin: jellyfinReader,
+			emby: embyReader,
+		},
+		DEST_WRITERS: {
+			plex: plexWriter,
+			sonarr: sonarrWriter,
+			radarr: radarrWriter,
+			jellyfin: jellyfinWriter,
+			emby: embyWriter,
+		},
 	};
 });
 
@@ -128,8 +184,13 @@ describe("executeLabelSyncRule (orchestration)", () => {
 	beforeEach(() => {
 		mockState.sonarrReadResult = { matches: [], failed: false };
 		mockState.plexReadResult = { matches: [], failed: false };
+		mockState.jellyfinReadResult = { matches: [], failed: false };
+		mockState.embyReadResult = { matches: [], failed: false };
 		mockState.plexWriteResult = { matchesFound: 0, labelsApplied: 0, failures: 0 };
 		mockState.sonarrWriteResult = { matchesFound: 0, labelsApplied: 0, failures: 0 };
+		mockState.radarrWriteResult = { matchesFound: 0, labelsApplied: 0, failures: 0 };
+		mockState.jellyfinWriteResult = { matchesFound: 0, labelsApplied: 0, failures: 0 };
+		mockState.embyWriteResult = { matchesFound: 0, labelsApplied: 0, failures: 0 };
 		mockState.sourceReaderSpy.mockClear();
 		mockState.destWriterSpy.mockClear();
 	});
@@ -214,6 +275,94 @@ describe("executeLabelSyncRule (orchestration)", () => {
 			where: expect.objectContaining({ service: "PLEX" }),
 		});
 	});
+
+	it.each([
+		["jellyfin", "JELLYFIN"],
+		["emby", "EMBY"],
+	] as const)(
+		"blocks a %s destination before database, source-reader, or writer activity",
+		async (destService, prismaService) => {
+			mockState.sonarrReadResult = { matches: [makeMatch(123)], failed: false };
+			if (destService === "jellyfin") {
+				mockState.jellyfinWriteResult = { matchesFound: 1, labelsApplied: 1, failures: 0 };
+			} else {
+				mockState.embyWriteResult = { matchesFound: 1, labelsApplied: 1, failures: 0 };
+			}
+			const findMany = vi.fn().mockResolvedValue([makeInstance()]);
+			const findFirst = vi
+				.fn()
+				.mockResolvedValue(makeInstance({ id: "private-destination", service: prismaService }));
+
+			const result = await executeLabelSyncRule({
+				rule: makeRule({
+					id: "private-rule-id",
+					sourceTagName: "private-source-tag",
+					destService,
+					destInstanceId: "private-destination",
+					destTagName: "private-destination-tag",
+				}),
+				prisma: { serviceInstance: { findMany, findFirst } } as never,
+				arrClientFactory: {} as never,
+				encryptor: {} as never,
+				log: fakeLogger,
+			});
+
+			expect(result).toEqual({
+				status: "failed",
+				message:
+					"Jellyfin and Emby label destinations are temporarily unavailable because the provider cannot yet be re-authorized safely at execution time.",
+				totals: {
+					sourceInstancesScanned: 0,
+					taggedItemsFound: 0,
+					destMatchesFound: 0,
+					labelsApplied: 0,
+					failures: 0,
+				},
+			});
+			expect(result.message).not.toMatch(/private|123/i);
+			expect(findMany).not.toHaveBeenCalled();
+			expect(findFirst).not.toHaveBeenCalled();
+			expect(mockState.sourceReaderSpy).not.toHaveBeenCalled();
+			expect(mockState.destWriterSpy).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		["jellyfin", "JELLYFIN", "sonarr", "SONARR"],
+		["emby", "EMBY", "radarr", "RADARR"],
+	] as const)(
+		"keeps %s source reads available for a supported %s destination",
+		async (sourceService, prismaService, destService, destPrismaService) => {
+			const sourceResult = { matches: [makeMatch(836, "movie")], failed: false };
+			if (sourceService === "jellyfin") mockState.jellyfinReadResult = sourceResult;
+			else mockState.embyReadResult = sourceResult;
+			if (destService === "sonarr") {
+				mockState.sonarrWriteResult = { matchesFound: 1, labelsApplied: 1, failures: 0 };
+			} else {
+				mockState.radarrWriteResult = { matchesFound: 1, labelsApplied: 1, failures: 0 };
+			}
+			const findMany = vi.fn().mockResolvedValue([makeInstance({ service: prismaService })]);
+			const findFirst = vi
+				.fn()
+				.mockResolvedValue(makeInstance({ id: "inst-dest", service: destPrismaService }));
+
+			const result = await executeLabelSyncRule({
+				rule: makeRule({ sourceService, destService }),
+				prisma: { serviceInstance: { findMany, findFirst } } as never,
+				arrClientFactory: {} as never,
+				encryptor: {} as never,
+				log: fakeLogger,
+			});
+
+			expect(result.status).toBe("success");
+			expect(result.totals.labelsApplied).toBe(1);
+			expect(findMany).toHaveBeenCalledWith({
+				where: expect.objectContaining({ service: prismaService }),
+			});
+			expect(mockState.sourceReaderSpy).toHaveBeenCalledOnce();
+			expect(mockState.destWriterSpy).toHaveBeenCalledOnce();
+		},
+	);
 
 	it("unsupported sourceService returns a failed result with structured message", async () => {
 		const result = await executeLabelSyncRule({

--- a/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
@@ -186,9 +186,9 @@ describe("triggerLabelSyncForItem", () => {
 				},
 			],
 		});
-		executeMock
-			.mockResolvedValueOnce({ ...okOutcome })
-			.mockRejectedValueOnce(new Error("plex unreachable"));
+		executeMock.mockImplementation(({ rule }) =>
+			rule.id === "r2" ? Promise.reject(new Error("destination unreachable")) : okOutcome,
+		);
 
 		const result = await triggerLabelSyncForItem(makeArgs({ prisma, tmdbId: 100 }));
 
@@ -200,7 +200,7 @@ describe("triggerLabelSyncForItem", () => {
 		expect(result.totals.labelsApplied).toBe(1);
 	});
 
-	it("counts a failed zero-attempt preflight as one aggregate rule failure", async () => {
+	it("keeps zero-attempt rule failures out of the item-attempt failure total", async () => {
 		const prisma = makePrisma({
 			rules: [
 				{
@@ -233,7 +233,62 @@ describe("triggerLabelSyncForItem", () => {
 		expect(result.rulesFired).toBe(1);
 		expect(result.results[0]?.outcome.status).toBe("failed");
 		expect(result.results[0]?.outcome.totals.failures).toBe(0);
-		expect(result.totals).toEqual({ labelsApplied: 0, failures: 1 });
+		expect(result.totals).toEqual({ labelsApplied: 0, failures: 0 });
+	});
+
+	it("surfaces blocked rules before an unresolved TMDb id skips supported rules", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "contained-rule",
+					name: "contained destination",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "jellyfin",
+					destInstanceId: "jellyfin-1",
+					destTagName: "kids",
+				},
+				{
+					id: "supported-rule",
+					name: "supported destination",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "plex",
+					destInstanceId: "plex-1",
+					destTagName: "kids",
+				},
+			],
+			cacheData: null,
+		});
+		executeMock.mockResolvedValue({
+			status: "failed",
+			message: "Destination mutation authority unavailable.",
+			totals: {
+				sourceInstancesScanned: 0,
+				taggedItemsFound: 0,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: 0,
+			},
+		});
+
+		const result = await triggerLabelSyncForItem(makeArgs({ prisma }));
+
+		expect(executeMock).toHaveBeenCalledOnce();
+		expect(executeMock.mock.calls[0]?.[0]).toEqual(
+			expect.objectContaining({
+				rule: expect.objectContaining({ id: "contained-rule" }),
+				targetTmdbId: undefined,
+			}),
+		);
+		expect(result.rulesFired).toBe(1);
+		expect(result.results.map((entry) => entry.ruleId)).toEqual(["contained-rule"]);
+		expect(result.results[0]?.outcome.status).toBe("failed");
+		expect(result.totals).toEqual({ labelsApplied: 0, failures: 0 });
 	});
 
 	it("includes rules with sourceInstanceId=null (match-all-instances rules)", async () => {

--- a/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
@@ -200,6 +200,42 @@ describe("triggerLabelSyncForItem", () => {
 		expect(result.totals.labelsApplied).toBe(1);
 	});
 
+	it("counts a failed zero-attempt preflight as one aggregate rule failure", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "contained-rule",
+					name: "contained destination",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "jellyfin",
+					destInstanceId: "jellyfin-1",
+					destTagName: "kids",
+				},
+			],
+		});
+		executeMock.mockResolvedValue({
+			status: "failed",
+			message: "Destination mutation authority unavailable.",
+			totals: {
+				sourceInstancesScanned: 0,
+				taggedItemsFound: 0,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: 0,
+			},
+		});
+
+		const result = await triggerLabelSyncForItem(makeArgs({ prisma, tmdbId: 100 }));
+
+		expect(result.rulesFired).toBe(1);
+		expect(result.results[0]?.outcome.status).toBe("failed");
+		expect(result.results[0]?.outcome.totals.failures).toBe(0);
+		expect(result.totals).toEqual({ labelsApplied: 0, failures: 1 });
+	});
+
 	it("includes rules with sourceInstanceId=null (match-all-instances rules)", async () => {
 		// Schema allows null sourceInstanceId meaning "match every enabled
 		// instance of the source service". The trigger lookup must include

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/jellyfin-writer-containment.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/jellyfin-writer-containment.test.ts
@@ -1,0 +1,199 @@
+import type { FastifyBaseLogger } from "fastify";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Encryptor } from "../../../auth/encryption.js";
+import type { ServiceInstance } from "../../../prisma.js";
+import type { LabelSyncRuleInput } from "../../execute-rule.js";
+import type { DestWriter, MatchCandidate } from "../../strategy-types.js";
+import { embyDestWriter, jellyfinDestWriter } from "../jellyfin-writer.js";
+
+const PRIVATE = {
+	tag: "CANARY_PRIVATE_DEST_TAG_836",
+	tmdbId: 123,
+	providerItemId: "CANARY_PROVIDER_ITEM_836",
+	libraryId: "CANARY_LIBRARY_ID_836",
+	libraryTitle: "CANARY_LIBRARY_TITLE_836",
+	mediaTitle: "CANARY_MEDIA_TITLE_836",
+	baseUrl: "http://CANARY_PRIVATE_PROVIDER_836.invalid",
+	username: "CANARY_PRIVATE_USER_836",
+	token: "CANARY_PRIVATE_TOKEN_836",
+	rawError: "CANARY_RAW_PROVIDER_ERROR_836",
+	requestPath: "/Items/CANARY_PROVIDER_ITEM_836",
+	responseBody: "CANARY_RAW_RESPONSE_BODY_836",
+} as const;
+
+const encryptor = new Encryptor("0123456789abcdef0123456789abcdef");
+const encrypted = encryptor.encrypt(PRIVATE.token);
+
+function makeRule(destService: "jellyfin" | "emby"): LabelSyncRuleInput {
+	return {
+		id: "CANARY_PRIVATE_RULE_ID_836",
+		userId: "user-836",
+		sourceService: "sonarr",
+		sourceInstanceId: "source-836",
+		sourceTagName: "CANARY_PRIVATE_SOURCE_TAG_836",
+		destService,
+		destInstanceId: "CANARY_PRIVATE_DEST_INSTANCE_836",
+		destTagName: PRIVATE.tag,
+	};
+}
+
+function makeInstance(service: "JELLYFIN" | "EMBY"): ServiceInstance {
+	return {
+		id: "CANARY_PRIVATE_DEST_INSTANCE_836",
+		userId: "user-836",
+		service,
+		label: PRIVATE.libraryTitle,
+		baseUrl: PRIVATE.baseUrl,
+		externalUrl: null,
+		encryptedApiKey: encrypted.value,
+		encryptionIv: encrypted.iv,
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-31T00:00:00.000Z"),
+	} as ServiceInstance;
+}
+
+function candidate(tmdbId: number = PRIVATE.tmdbId): MatchCandidate {
+	return { tmdbId, title: PRIVATE.mediaTitle, mediaType: "movie" };
+}
+
+function createPinoCapture(): { log: FastifyBaseLogger; serialized: () => string } {
+	const lines: string[] = [];
+	const log = pino(
+		{ level: "trace", base: null, timestamp: false },
+		{ write: (line: string) => lines.push(line) },
+	) as unknown as FastifyBaseLogger;
+	return { log, serialized: () => lines.join("") };
+}
+
+function expectNoPrivateCanary(value: string): void {
+	for (const canary of Object.values(PRIVATE)) {
+		expect(value).not.toContain(String(canary));
+	}
+}
+
+async function runWriter(
+	writer: DestWriter,
+	service: "jellyfin" | "emby",
+	prismaService: "JELLYFIN" | "EMBY",
+	candidates: MatchCandidate[],
+	log: FastifyBaseLogger,
+) {
+	const cacheRead = vi.fn().mockResolvedValue([
+		{
+			jellyfinId: PRIVATE.providerItemId,
+			title: PRIVATE.mediaTitle,
+			tmdbId: PRIVATE.tmdbId,
+			mediaType: "movie",
+			libraryId: PRIVATE.libraryId,
+		},
+	]);
+	const result = await writer.applyLabels({
+		rule: makeRule(service),
+		destInstance: makeInstance(prismaService),
+		candidates,
+		prisma: {
+			jellyfinCache: {
+				findMany: cacheRead,
+			},
+		} as never,
+		arrClientFactory: {} as never,
+		encryptor,
+		log,
+	});
+	return { result, cacheRead };
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe.each([
+	["Jellyfin", "jellyfin", "JELLYFIN", jellyfinDestWriter],
+	["Emby", "emby", "EMBY", embyDestWriter],
+] as const)("%s destination containment", (_label, service, prismaService, writer) => {
+	it("contains the stale-cache/reused-item mutation before any provider request", async () => {
+		const requests: Array<{ path: string; method: string }> = [];
+		vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+			const url = new URL(
+				typeof input === "string" ? input : input instanceof URL ? input : input.url,
+			);
+			requests.push({ path: url.pathname, method: init?.method ?? "GET" });
+			if (url.pathname === "/Users") {
+				return Response.json([{ Id: PRIVATE.username, Name: PRIVATE.username }]);
+			}
+			if (url.pathname === `/Users/${PRIVATE.username}/Items/${PRIVATE.providerItemId}`) {
+				return Response.json({
+					Id: PRIVATE.providerItemId,
+					Name: "CANARY_REUSED_MEDIA_TITLE_836",
+					Type: "Movie",
+					ParentId: "CANARY_DIFFERENT_LIBRARY_836",
+					ProviderIds: { Tmdb: "999" },
+					Tags: [],
+				});
+			}
+			if (url.pathname === PRIVATE.requestPath && init?.method === "POST") {
+				return new Response(null, { status: 204 });
+			}
+			throw new Error(`${PRIVATE.rawError}: ${url.pathname}: ${PRIVATE.responseBody}`);
+		});
+		const capture = createPinoCapture();
+
+		const { result, cacheRead } = await runWriter(
+			writer,
+			service,
+			prismaService,
+			[candidate()],
+			capture.log,
+		);
+
+		expect(requests).toEqual([]);
+		expect(cacheRead).not.toHaveBeenCalled();
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
+		expectNoPrivateCanary(capture.serialized());
+	});
+
+	it("does not double-count mixed or duplicate blocked candidates", async () => {
+		const fetchSpy = vi.fn(() => {
+			throw new Error(PRIVATE.rawError);
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+		const capture = createPinoCapture();
+		const candidates = [candidate(123), candidate(123), candidate(456)];
+
+		const { result, cacheRead } = await runWriter(
+			writer,
+			service,
+			prismaService,
+			candidates,
+			capture.log,
+		);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(cacheRead).not.toHaveBeenCalled();
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: candidates.length });
+		expectNoPrivateCanary(capture.serialized());
+	});
+
+	it("preserves the empty-candidate no-op without constructing a client", async () => {
+		const fetchSpy = vi.fn(() => {
+			throw new Error(PRIVATE.rawError);
+		});
+		vi.stubGlobal("fetch", fetchSpy);
+
+		const { result, cacheRead } = await runWriter(
+			writer,
+			service,
+			prismaService,
+			[],
+			createPinoCapture().log,
+		);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(cacheRead).not.toHaveBeenCalled();
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 0 });
+	});
+});

--- a/apps/api/src/lib/label-sync/dest-writers/jellyfin-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/jellyfin-writer.ts
@@ -1,108 +1,47 @@
 /**
  * Destination writer for Jellyfin / Emby instances.
  *
- * Resolves match candidates against JellyfinCache (keyed on tmdbId) to find
- * each item's `jellyfinId`, then calls `addItemTag` on the live API. Unlike
- * Plex, Jellyfin/Emby don't distinguish "label" vs "tag" — the single Tags
- * collection plays both roles.
+ * Stable containment: Jellyfin / Emby remain source integrations, but their
+ * destination mutation path is disabled until issue #836 receives durable
+ * mutation claims, outcomes, and reconciliation.
  */
 
-import { createJellyfinClient, type JellyfinClient } from "../../jellyfin/jellyfin-client.js";
 import type { ServiceType } from "../../prisma.js";
-import type {
-	DestWriteResult,
-	DestWriter,
-	DestWriterOpts,
-	MatchCandidate,
-} from "../strategy-types.js";
+import { getLabelSyncDestinationMutationCapability } from "../destination-capability.js";
+import type { DestWriteResult, DestWriter, DestWriterOpts } from "../strategy-types.js";
 
 interface JellyfinWriterConfig {
 	prismaService: Extract<ServiceType, "JELLYFIN" | "EMBY">;
+	destService: "jellyfin" | "emby";
 }
 
-export const jellyfinDestWriter: DestWriter = createWriter({ prismaService: "JELLYFIN" });
-export const embyDestWriter: DestWriter = createWriter({ prismaService: "EMBY" });
+export const jellyfinDestWriter: DestWriter = createWriter({
+	prismaService: "JELLYFIN",
+	destService: "jellyfin",
+});
+export const embyDestWriter: DestWriter = createWriter({
+	prismaService: "EMBY",
+	destService: "emby",
+});
 
 function createWriter(config: JellyfinWriterConfig): DestWriter {
 	return {
 		prismaService: config.prismaService,
 		async applyLabels(opts: DestWriterOpts): Promise<DestWriteResult> {
-			const { rule, destInstance, candidates, prisma, encryptor, log } = opts;
+			const { candidates } = opts;
 
 			if (candidates.length === 0) {
 				return { matchesFound: 0, labelsApplied: 0, failures: 0 };
 			}
 
-			let client: JellyfinClient;
-			try {
-				client = createJellyfinClient(encryptor, destInstance, log);
-			} catch (err) {
-				log.warn({ err }, "Failed to initialize destination Jellyfin/Emby client");
+			const capability = getLabelSyncDestinationMutationCapability(config.destService);
+			if (!capability.supported) {
 				return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
 			}
 
-			let userId: string;
-			try {
-				userId = await pickUserId(client);
-			} catch (err) {
-				log.warn({ err }, "Failed to resolve a Jellyfin/Emby user id for write");
-				return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
-			}
-
-			const tmdbIds = unique(candidates.map((c) => c.tmdbId));
-			const candidatesByTmdb = new Map<number, MatchCandidate>();
-			for (const c of candidates) {
-				candidatesByTmdb.set(c.tmdbId, c);
-			}
-
-			const cacheRows = await prisma.jellyfinCache.findMany({
-				where: {
-					instanceId: rule.destInstanceId,
-					tmdbId: { in: tmdbIds },
-				},
-				select: { jellyfinId: true, title: true, tmdbId: true, mediaType: true },
-			});
-
-			const matched = cacheRows.filter((row) => {
-				const candidate = candidatesByTmdb.get(row.tmdbId);
-				return candidate && candidate.mediaType === row.mediaType;
-			});
-
-			let labelsApplied = 0;
-			let failures = 0;
-			for (const row of matched) {
-				if (!row.jellyfinId) {
-					log.warn(
-						{ tmdbId: row.tmdbId, title: row.title },
-						"Cached row missing jellyfinId; cannot apply tag",
-					);
-					failures++;
-					continue;
-				}
-
-				try {
-					await client.addItemTag(userId, row.jellyfinId, rule.destTagName);
-					labelsApplied++;
-				} catch (err) {
-					log.warn({ jellyfinId: row.jellyfinId, err }, "Failed to apply Jellyfin/Emby tag");
-					failures++;
-				}
-			}
-
-			return { matchesFound: matched.length, labelsApplied, failures };
+			// If the centralized table is changed without a replacement writer,
+			// this stable implementation still fails closed instead of restoring I/O.
+			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
 		},
 	};
-}
-
-async function pickUserId(client: JellyfinClient): Promise<string> {
-	const users = await client.getUsers();
-	const first = users[0];
-	if (!first) {
-		throw new Error("No Jellyfin/Emby users available");
-	}
-	return first.id;
-}
-
-function unique<T>(items: T[]): T[] {
-	return Array.from(new Set(items));
 }

--- a/apps/api/src/lib/label-sync/destination-capability.ts
+++ b/apps/api/src/lib/label-sync/destination-capability.ts
@@ -1,0 +1,28 @@
+export const DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE =
+	"destination_mutation_authority_unavailable" as const;
+
+export const DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE_MESSAGE =
+	"Jellyfin and Emby label destinations are temporarily unavailable because the provider cannot yet be re-authorized safely at execution time.";
+
+export type LabelSyncDestinationMutationCapability =
+	| { supported: true }
+	| {
+			supported: false;
+			code: typeof DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE;
+			message: typeof DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE_MESSAGE;
+	  };
+
+/** Stable containment for destination mutations; source capabilities are intentionally unrelated. */
+export function getLabelSyncDestinationMutationCapability(
+	service: string,
+): LabelSyncDestinationMutationCapability {
+	if (service === "jellyfin" || service === "emby") {
+		return {
+			supported: false,
+			code: DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE,
+			message: DESTINATION_MUTATION_AUTHORITY_UNAVAILABLE_MESSAGE,
+		};
+	}
+
+	return { supported: true };
+}

--- a/apps/api/src/lib/label-sync/execute-rule.ts
+++ b/apps/api/src/lib/label-sync/execute-rule.ts
@@ -21,6 +21,7 @@ import type { FastifyBaseLogger } from "fastify";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
 import type { PrismaClient } from "../prisma.js";
+import { getLabelSyncDestinationMutationCapability } from "./destination-capability.js";
 import { DEST_WRITERS, SOURCE_READERS } from "./strategy-registry.js";
 import type { MatchCandidate } from "./strategy-types.js";
 
@@ -82,6 +83,11 @@ const ZERO_TOTALS: LabelSyncRunResult["totals"] = {
  */
 export async function executeLabelSyncRule(opts: ExecuteOpts): Promise<LabelSyncRunResult> {
 	const { rule, prisma, arrClientFactory, encryptor, log } = opts;
+	const destinationCapability = getLabelSyncDestinationMutationCapability(rule.destService);
+	if (!destinationCapability.supported) {
+		return failure(destinationCapability.message);
+	}
+
 	const childLog = log.child({
 		ruleId: rule.id,
 		sourceService: rule.sourceService,

--- a/apps/api/src/lib/label-sync/trigger-for-item.ts
+++ b/apps/api/src/lib/label-sync/trigger-for-item.ts
@@ -23,6 +23,7 @@ import type { FastifyBaseLogger } from "fastify";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
 import type { LibraryItemType, PrismaClient, ServiceType } from "../prisma.js";
+import { getLabelSyncDestinationMutationCapability } from "./destination-capability.js";
 import { executeLabelSyncRule, type LabelSyncRunResult } from "./execute-rule.js";
 
 export interface TriggerLabelSyncForItemArgs {
@@ -136,31 +137,20 @@ export async function triggerLabelSyncForItem(
 		return ZERO_RESULT;
 	}
 
-	// 2. Resolve tmdbId — use the explicit value when supplied (cheap), else
-	//    look up from cache. If unresolvable we can't proceed safely.
-	const tmdbId =
-		args.tmdbId ??
-		(await resolveTmdbId(
-			args.prisma,
-			args.sourceInstanceId,
-			args.arrItemId,
-			args.itemType,
-			childLog,
-		));
-
-	if (tmdbId === null) {
-		childLog.debug(
-			"Skipping Label Sync trigger: tmdbId unresolvable (item not in cache or missing tmdbId)",
-		);
-		return { rulesFired: 0, results: [], totals: { labelsApplied: 0, failures: 0 } };
-	}
-
-	// 3. Fire each matching rule with targetTmdbId set. Failures isolated.
-	const results: TriggerLabelSyncForItemResult["results"] = [];
+	const indexedRules = rules.map((rule, index) => ({
+		rule,
+		index,
+		blocked: !getLabelSyncDestinationMutationCapability(rule.destService).supported,
+	}));
+	const results: Array<TriggerLabelSyncForItemResult["results"][number] & { index: number }> = [];
 	let labelsApplied = 0;
 	let failures = 0;
 
-	for (const rule of rules) {
+	const runRule = async (
+		entry: (typeof indexedRules)[number],
+		targetTmdbId: number | undefined,
+	): Promise<void> => {
+		const { rule, index } = entry;
 		try {
 			const outcome = await executeLabelSyncRule({
 				rule: {
@@ -177,15 +167,11 @@ export async function triggerLabelSyncForItem(
 				arrClientFactory: args.arrClientFactory,
 				encryptor: args.encryptor,
 				log: childLog,
-				targetTmdbId: tmdbId,
+				targetTmdbId,
 			});
 			labelsApplied += outcome.totals.labelsApplied;
-			// Preflight containment can fail a rule before any candidate operation
-			// exists to count. Preserve the outcome's attempt counters while making
-			// the event-level summary truthful for callers that choose UI severity.
-			failures +=
-				outcome.totals.failures > 0 ? outcome.totals.failures : outcome.status === "failed" ? 1 : 0;
-			results.push({ ruleId: rule.id, ruleName: rule.name, outcome });
+			failures += outcome.totals.failures;
+			results.push({ index, ruleId: rule.id, ruleName: rule.name, outcome });
 		} catch (err) {
 			childLog.warn(
 				{ err, ruleId: rule.id, ruleName: rule.name },
@@ -193,6 +179,7 @@ export async function triggerLabelSyncForItem(
 			);
 			failures++;
 			results.push({
+				index,
 				ruleId: rule.id,
 				ruleName: rule.name,
 				outcome: {
@@ -208,11 +195,52 @@ export async function triggerLabelSyncForItem(
 				},
 			});
 		}
+	};
+
+	const buildResult = (): TriggerLabelSyncForItemResult => ({
+		rulesFired: results.length,
+		results: [...results]
+			.sort((a, b) => a.index - b.index)
+			.map(({ index: _index, ...result }) => result),
+		totals: { labelsApplied, failures },
+	});
+
+	// 2. Blocked destinations do not need item correlation. Run them through
+	//    the authoritative executor before any cache lookup so their static
+	//    failure remains visible even when the item has no usable tmdbId.
+	for (const entry of indexedRules.filter((candidate) => candidate.blocked)) {
+		await runRule(entry, undefined);
 	}
 
-	return {
-		rulesFired: rules.length,
-		results,
-		totals: { labelsApplied, failures },
-	};
+	const supportedRules = indexedRules.filter((candidate) => !candidate.blocked);
+	if (supportedRules.length === 0) {
+		return buildResult();
+	}
+
+	// 3. Resolve tmdbId for supported destinations — use the explicit value
+	//    when supplied (cheap), else look up from cache. If unresolvable, those
+	//    rules remain unattempted rather than widening into whole-library runs.
+	const tmdbId =
+		args.tmdbId ??
+		(await resolveTmdbId(
+			args.prisma,
+			args.sourceInstanceId,
+			args.arrItemId,
+			args.itemType,
+			childLog,
+		));
+
+	if (tmdbId === null) {
+		childLog.debug(
+			"Skipping Label Sync trigger: tmdbId unresolvable (item not in cache or missing tmdbId)",
+		);
+		return buildResult();
+	}
+
+	// 4. Fire supported rules with targetTmdbId set. Failures remain isolated.
+	for (const entry of supportedRules) {
+		await runRule(entry, tmdbId);
+	}
+
+	return buildResult();
 }

--- a/apps/api/src/lib/label-sync/trigger-for-item.ts
+++ b/apps/api/src/lib/label-sync/trigger-for-item.ts
@@ -180,7 +180,11 @@ export async function triggerLabelSyncForItem(
 				targetTmdbId: tmdbId,
 			});
 			labelsApplied += outcome.totals.labelsApplied;
-			failures += outcome.totals.failures;
+			// Preflight containment can fail a rule before any candidate operation
+			// exists to count. Preserve the outcome's attempt counters while making
+			// the event-level summary truthful for callers that choose UI severity.
+			failures +=
+				outcome.totals.failures > 0 ? outcome.totals.failures : outcome.status === "failed" ? 1 : 0;
 			results.push({ ruleId: rule.id, ruleName: rule.name, outcome });
 		} catch (err) {
 			childLog.warn(

--- a/apps/web/src/features/library/components/__tests__/sync-labels-now-button-containment.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/sync-labels-now-button-containment.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { runLabelSyncForItem } = vi.hoisted(() => ({
+	runLabelSyncForItem: vi.fn(),
+}));
+
+vi.mock("../../../../lib/api-client/label-sync", () => ({
+	runLabelSyncForItem,
+}));
+
+import { SyncLabelsNowButton } from "../sync-labels-now-button";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("SyncLabelsNowButton containment feedback", () => {
+	beforeEach(() => {
+		runLabelSyncForItem.mockReset();
+	});
+
+	it("renders failed feedback when a contained destination stops before write attempts", async () => {
+		runLabelSyncForItem.mockResolvedValue({
+			rulesFired: 1,
+			labelsApplied: 0,
+			failures: 1,
+			outcomes: [
+				{
+					ruleId: "contained-rule",
+					ruleName: "Contained destination",
+					status: "failed",
+					message:
+						"Jellyfin and Emby label destinations are temporarily unavailable because the provider cannot yet be re-authorized safely at execution time.",
+					labelsApplied: 0,
+				},
+			],
+		});
+
+		render(
+			<SyncLabelsNowButton
+				instanceId="sonarr-1"
+				arrItemId={836}
+				itemType="series"
+				service="sonarr"
+			/>,
+			{ wrapper },
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Sync labels for this item now" }));
+
+		const feedback = await screen.findByRole("status");
+		expect(feedback).toHaveTextContent("Fired 1 rule, all failed.");
+		expect(feedback).toHaveClass("text-rose-400");
+		expect(screen.queryByText(/nothing to apply/i)).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/library/components/__tests__/sync-labels-now-button-containment.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/sync-labels-now-button-containment.test.tsx
@@ -29,7 +29,7 @@ describe("SyncLabelsNowButton containment feedback", () => {
 		runLabelSyncForItem.mockResolvedValue({
 			rulesFired: 1,
 			labelsApplied: 0,
-			failures: 1,
+			failures: 0,
 			outcomes: [
 				{
 					ruleId: "contained-rule",
@@ -57,5 +57,87 @@ describe("SyncLabelsNowButton containment feedback", () => {
 		expect(feedback).toHaveTextContent("Fired 1 rule, all failed.");
 		expect(feedback).toHaveClass("text-rose-400");
 		expect(screen.queryByText(/nothing to apply/i)).not.toBeInTheDocument();
+	});
+
+	it("renders mixed feedback when one contained rule fails and one supported rule is a no-op", async () => {
+		runLabelSyncForItem.mockResolvedValue({
+			rulesFired: 2,
+			labelsApplied: 0,
+			failures: 0,
+			outcomes: [
+				{
+					ruleId: "contained-rule",
+					ruleName: "Contained destination",
+					status: "failed",
+					message: "Destination mutation authority unavailable.",
+					labelsApplied: 0,
+				},
+				{
+					ruleId: "supported-rule",
+					ruleName: "Supported destination",
+					status: "success",
+					message: "Nothing to apply.",
+					labelsApplied: 0,
+				},
+			],
+		});
+
+		render(
+			<SyncLabelsNowButton
+				instanceId="sonarr-1"
+				arrItemId={836}
+				itemType="series"
+				service="sonarr"
+			/>,
+			{ wrapper },
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Sync labels for this item now" }));
+
+		const feedback = await screen.findByRole("status");
+		expect(feedback).toHaveTextContent("1 of 2 rules failed.");
+		expect(feedback).toHaveClass("text-amber-400");
+		expect(feedback).not.toHaveTextContent("all failed");
+		expect(screen.queryByText(/nothing to apply/i)).not.toBeInTheDocument();
+	});
+
+	it("reports both a contained rule and supported-destination item failures", async () => {
+		runLabelSyncForItem.mockResolvedValue({
+			rulesFired: 2,
+			labelsApplied: 1,
+			failures: 1,
+			outcomes: [
+				{
+					ruleId: "contained-rule",
+					ruleName: "Contained destination",
+					status: "failed",
+					message: "Destination mutation authority unavailable.",
+					labelsApplied: 0,
+				},
+				{
+					ruleId: "partial-rule",
+					ruleName: "Partially applied destination",
+					status: "partial",
+					message: "Applied 1 label, 1 failure.",
+					labelsApplied: 1,
+				},
+			],
+		});
+
+		render(
+			<SyncLabelsNowButton
+				instanceId="sonarr-1"
+				arrItemId={836}
+				itemType="series"
+				service="sonarr"
+			/>,
+			{ wrapper },
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Sync labels for this item now" }));
+
+		const feedback = await screen.findByRole("status");
+		expect(feedback).toHaveTextContent(
+			"Applied 1 label; 1 of 2 rules failed; 1 item attempt failed.",
+		);
+		expect(feedback).toHaveClass("text-amber-400");
 	});
 });

--- a/apps/web/src/features/library/components/sync-labels-now-button.tsx
+++ b/apps/web/src/features/library/components/sync-labels-now-button.tsx
@@ -34,6 +34,7 @@ export const SyncLabelsNowButton = ({ instanceId, arrItemId, itemType, service }
 	const mutation = useMutation<RunLabelSyncForItemResponse, Error>({
 		mutationFn: () => runLabelSyncForItem({ instanceId, arrItemId, itemType }),
 		onSuccess: (result) => {
+			const failedRules = result.outcomes.filter((outcome) => outcome.status === "failed").length;
 			if (result.rulesFired === 0) {
 				setFeedback({
 					kind: "warn",
@@ -41,10 +42,25 @@ export const SyncLabelsNowButton = ({ instanceId, arrItemId, itemType, service }
 				});
 				return;
 			}
-			if (result.failures > 0 && result.labelsApplied === 0) {
+			if (failedRules === result.rulesFired && result.labelsApplied === 0) {
 				setFeedback({
 					kind: "err",
 					message: `Fired ${result.rulesFired} rule${result.rulesFired === 1 ? "" : "s"}, all failed.`,
+				});
+				return;
+			}
+			if (failedRules > 0) {
+				setFeedback({
+					kind: "warn",
+					message: `${
+						result.labelsApplied > 0
+							? `Applied ${result.labelsApplied} label${result.labelsApplied === 1 ? "" : "s"}; `
+							: ""
+					}${failedRules} of ${result.rulesFired} rules failed${
+						result.failures > 0
+							? `; ${result.failures} item attempt${result.failures === 1 ? "" : "s"} failed.`
+							: "."
+					}`,
 				});
 				return;
 			}


### PR DESCRIPTION
## Summary

Fail closed when a label-sync rule targets Jellyfin or Emby. Both services remain available as label sources, and existing destination rules remain stored, visible, and editable. Execution now stops before database resolution, client construction, cache reads, or provider requests.

## Related issue

Related to #836

## Scope

- Add one centralized destination-mutation capability table for the five label-sync services.
- Reject Jellyfin and Emby destinations at the common execution boundary.
- Keep a defensive zero-I/O barrier in both registered Jellyfin and Emby writers.
- Preserve accurate manual, scheduled, and direct per-item failure reporting. Provider-neutral structured summaries for auto-tag and library-sync chaining remain tracked by #818.
- Add focused containment, supported-source, supported-destination, privacy, and rendered-status coverage.

## Non-goals

- Durable mutation claims, outcomes, reconciliation, or conditional-write emulation.
- Provider identity or cache lifecycle changes.
- Jellyfin or Emby source changes.
- Schema, migration, generated Prisma, API contract, configuration UX, or provider-client changes.
- Completing or closing #836.
- Release preparation, advisory publication, or changes to `next`.

## Acceptance criteria

- [x] Jellyfin destination execution returns a bounded failed result before database or provider I/O.
- [x] Emby destination execution returns the same bounded failed result before database or provider I/O.
- [x] Direct Jellyfin and Emby writer calls cannot restore provider I/O.
- [x] Existing rules remain readable and editable, and newly stored rules remain backward compatible.
- [x] Jellyfin and Emby remain supported sources when the destination is supported.
- [x] Sonarr, Radarr, and Plex destination capability remains supported.
- [x] Manual and scheduled runs persist the failed status and static message.
- [x] Event-trigger summaries report a failed rule without inventing a candidate mutation attempt.
- [x] Auto-tag and library-sync chaining invoke the same containment barrier without recording a blocked destination write as applied or successful; structured background summaries remain deferred to #818.
- [x] Private provider, instance, user, media, and error canaries do not appear in logs or operator messages.
- [x] A disposable production-path request-capture stack proves zero blocked-provider requests and a normal supported-destination write against a synthetic endpoint.

## Changes

- Added `getLabelSyncDestinationMutationCapability()` with a closed internal code and static operator message.
- Applied the capability check at the start of `executeLabelSyncRule()`.
- Replaced the Jellyfin and Emby destination writer implementation with a defensive fail-closed barrier while retaining registry entries.
- Classify blocked rules before item metadata resolution, while supported rules still require a valid TMDb target.
- Keep rule failures separate from item-attempt failures and render both dimensions for mixed outcomes.
- Added API and rendered web regressions for all entry points, privacy canaries, source preservation, supported destinations, stale-cache reuse, missing metadata, mixed outcomes, duplicate candidates, and empty inputs.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed: all nine label-sync API files 89/89; complete changed API surface 46/46; rendered status 3/3
- [x] Focused tests passed, including manual, scheduler, event, direct writer, Plex safety/privacy, and #835 BoxSet/cache coverage
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: API 4,772 passed with 54 skipped; web 681 passed; shared 89 passed
- [x] `pnpm run lint`
- [x] `CI=true pnpm run validate:pr`, including 53/53 review-contract tests
- [x] `pnpm run build`
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7/7 passed
- [x] `pnpm run check:prisma-generated` and `node --test scripts/check-prisma-generated.test.mjs`: 17/17 passed
- [x] `git diff --check`
- [x] Rendered component verification covers all-failed, mixed failed/successful, and mixed failed/partial outcome messages
- [x] New queries are not applicable; the blocked path performs zero database queries
- [x] New sensitive displays are not applicable; binding-aware Pino and operator-message canaries passed
- [x] New Prisma queries are not applicable; no Prisma query was added
- [x] Optional-service UI gating is not applicable; no page, panel, or signal changed
- [x] User-facing counts are precise: blocked rules stay at zero mutation attempts, while mixed summaries report rule failures and real item-attempt failures separately
- [x] Action links are not applicable; no navigation changed
- [x] Duplicate surfaces were checked; manual, scheduler, and event entry points converge on the common executor
- [x] Disposable request capture: Jellyfin 0 requests, Emby 0 requests, supported Sonarr control 1 synthetic PUT, cleanup 0 resources
- [x] Exact-head CI retry classified the unrelated #810 timing gate: the first run exceeded its 2,000 ms threshold by 110.94 ms, the isolated test passed twice locally, and the unchanged-head retry plus all three E2E shards passed
- [x] Temporary background-caller verification passed 4/4 for Jellyfin and Emby; the combined caller and label-sync surface passed 158/158, and the temporary probe was removed

## Review plan

- Initial broad-reviewed head: candidate tree based on `057f33ba139d1b441607ea00d10389ebc6d3434b`
- Correction head: `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`
- Targeted delta range: `1d52b59dfe342b3ecc68dd54c7753e9a6af04ee4..169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`
- Material-scope change declared? No
- Independent regression reviewer: PASS; the final mixed-outcome correction delta was rechecked with no P0-P3 findings
- Independent data-safety reviewer, when required: PASS; the final correction delta was rechecked with no P0-P3 findings
- Independent privacy reviewer: PASS; the final correction delta was rechecked with no P0-P3 findings
- GitHub Codex reviewed exact head: `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`
- I836-R5: reproduced
- Safety effect: none; destination mutation remains blocked before provider I/O
- Operational gap: auto-tag and library-sync do not retain a structured background failure summary
- Disposition: P2 `planned-later-phase` through #818
- Code head: unchanged at `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`
- Maintainer decision: I836-R5 disposition approved; final merge approval remains pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| I836-R1 | P1 privacy / P2 regression | Introduced, in scope | A failed zero-attempt containment outcome contributed zero event failures, so the existing UI selected its successful no-op message | Fixed at `1d52b59dfe342b3ecc68dd54c7753e9a6af04ee4`; API 116/116, rendered test 1/1, three targeted delta reviews PASS | None |
| I836-R2 | P2 regression | Introduced, in scope | A missing TMDb id returned before capability classification, so an unsupported rule was reported as absent and containment was not surfaced | Fixed at `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`; blocked rules now execute before TMDb lookup with zero cache reads | None |
| I836-R3 | P2 regression | Introduced, in scope | A synthetic event failure counter mixed failed rules with item attempts and could falsely report that every mixed rule failed | Fixed at `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`; outcome status drives rule severity and totals retain attempt failures only | None |
| I836-R4 | P3 regression | Introduced, in scope | A mixed blocked failure plus supported partial result omitted the real item-attempt failure from rendered feedback | Fixed at `169c3efe8da1d7e23d57c1374f9f6c4cf0790be9`; rendered mixed-outcome regression 3/3 and all three final delta reviews PASS | None |
| I836-R5 | P2 observability | Planned later phase | Auto-tag discards the structured chained failure and library-sync retains only generic fired telemetry; neither path performs a blocked provider write or records labels applied | No code change in this containment PR; provider-neutral privacy-safe background summaries belong to #818 | #818 |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed locally
- [ ] No unresolved in-scope review threads remain
- [x] Valid findings are dispositioned; I836-R5 is planned later through #818 and has no containment safety effect
- [x] Current head is covered by the broad review and three targeted delta-review cycles
- [x] Base is unchanged and the merge preview is conflict free
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
