### PR TITLE
fix(backup): preserve durable configuration through restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,21 @@ jobs:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+        env:
+          POSTGRES_USER: arr_backup_test
+          POSTGRES_PASSWORD: arr_backup_test
+          POSTGRES_DB: arr_backup_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U arr_backup_test -d arr_backup_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -78,6 +93,19 @@ jobs:
 
       - name: Build shared package
         run: pnpm --filter @arr/shared run build
+
+      - name: Run backup round-trip contract on SQLite
+        run: pnpm exec vitest run src/lib/backup/__tests__/backup-roundtrip.test.ts
+        working-directory: apps/api
+        env:
+          TEST_DB: "true"
+
+      - name: Run backup round-trip contract on PostgreSQL
+        run: pnpm exec vitest run src/lib/backup/__tests__/backup-roundtrip.test.ts
+        working-directory: apps/api
+        env:
+          TEST_DB: "true"
+          TEST_DATABASE_URL: postgresql://arr_backup_test:arr_backup_test@127.0.0.1:5432/arr_backup_test
 
       - name: Check formatting
         run: pnpm run format

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Now integrates with **[autobrr/qui](https://github.com/autobrr/qui)** as a feder
 - **Zero-Config Security** — Auto-generated encryption keys on first run
 
 ### Management
-- **Backup & Restore** — Automated encrypted backups with configurable retention and scheduling
+- **Backup & Restore** — Automated encrypted backups with configurable retention and scheduling ([backup inventory](docs/BACKUPS.md))
 - **Tag Organization** — Organize instances with custom tags and storage groups
 - **Multi-Instance** — Manage unlimited instances across all supported services
 - **System Settings** — Configurable ports, listen address, and application restart from the UI

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { BackupCompatibilityError } from "../../errors.js";
 import type { PrismaClient } from "../../prisma.js";
 import { exportDatabase, restoreDatabase } from "../backup-database.js";
 
@@ -21,6 +22,8 @@ const TABLE_NAMES = [
 	"oIDCAccount",
 	"webAuthnCredential",
 	"systemSettings",
+	"backupSettings",
+	"vapidKeys",
 	"trashTemplate",
 	"trashSettings",
 	"trashSyncSchedule",
@@ -34,6 +37,20 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+	"namingConfig",
+	"namingDeployHistory",
+	"userCustomFormat",
 ] as const;
 
 type TableName = (typeof TABLE_NAMES)[number];
@@ -444,10 +461,33 @@ describe("exportDatabase — operational history exclusion", () => {
 });
 
 describe("restoreDatabase — current coordination preservation", () => {
+	async function expectCompatibilityFailure(
+		operation: Promise<unknown>,
+		expectedCause: string,
+	): Promise<void> {
+		let captured: unknown;
+		try {
+			await operation;
+		} catch (error) {
+			captured = error;
+		}
+
+		expect(captured).toBeInstanceOf(BackupCompatibilityError);
+		const compatibilityError = captured as BackupCompatibilityError;
+		expect(compatibilityError.message).toBe(
+			"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		);
+		expect(compatibilityError.cause).toBeInstanceOf(Error);
+		expect((compatibilityError.cause as Error).message).toContain(expectedCause);
+	}
+
 	function makeRestorePrisma(options: {
 		currentSync?: Array<Record<string, unknown>>;
 		currentDeployments?: Array<Record<string, unknown>>;
 		currentSnapshots?: Array<Record<string, unknown>>;
+		currentApprovals?: Array<Record<string, unknown>>;
+		currentScanParentApprovals?: Array<Record<string, unknown>>;
+		currentScans?: Array<Record<string, unknown>>;
 	}) {
 		const firstDelete = vi.fn().mockResolvedValue({ count: 0 });
 		const tx = {
@@ -461,6 +501,25 @@ describe("restoreDatabase — current coordination preservation", () => {
 			},
 			trashBackup: {
 				findMany: vi.fn().mockResolvedValue(options.currentSnapshots ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([]),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			namingDeployHistory: {
+				findMany: vi.fn().mockResolvedValue([]),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			libraryCleanupApproval: {
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce(options.currentApprovals ?? [])
+					.mockResolvedValue(options.currentScanParentApprovals ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			libraryCleanupMediaServerScan: {
+				findMany: vi.fn().mockResolvedValue(options.currentScans ?? []),
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 			},
 			huntSearchHistory: { deleteMany: firstDelete },
@@ -512,8 +571,88 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(restoreDatabase(prisma, incomingData())).rejects.toThrow(
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData()),
 			"current nonterminal coordination row current-sync",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it("rejects a restore that omits an active cleanup approval before deleting tables", async () => {
+		const currentApproval = {
+			id: "active-cleanup-approval",
+			configId: "cleanup-config",
+			instanceId: "instance-1",
+			arrItemId: 815,
+			itemType: "movie",
+			title: "Current cleanup target",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Current cleanup rule",
+			reason: "age",
+			action: "delete",
+			sizeOnDisk: BigInt(815),
+			status: "approved",
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentApprovals: [currentApproval],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData({ libraryCleanupApproval: [] })),
+			"current active cleanup approval active-cleanup-approval is missing from incoming data",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it("rejects a restore that omits a retryable media-server scan and its terminal parent", async () => {
+		const currentParent = {
+			id: "executed-cleanup-parent",
+			configId: "cleanup-config",
+			instanceId: "instance-1",
+			arrItemId: 816,
+			itemType: "series",
+			title: "Executed cleanup target",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Current cleanup rule",
+			reason: "size",
+			action: "delete",
+			sizeOnDisk: BigInt(816),
+			status: "executed",
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const currentScan = {
+			id: "retryable-cleanup-scan",
+			approvalId: currentParent.id,
+			instanceId: "instance-1",
+			service: "PLEX",
+			mediaType: "show",
+			targetKey: "series:816",
+			status: "failed",
+			attemptCount: 1,
+			completedSectionIds: "[]",
+			lastError: "temporary provider failure",
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+			updatedAt: new Date("2026-08-31T00:01:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentScanParentApprovals: [currentParent],
+			currentScans: [currentScan],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(
+				prisma,
+				incomingData({
+					libraryCleanupApproval: [
+						{ ...currentParent, sizeOnDisk: currentParent.sizeOnDisk.toString() },
+					],
+					libraryCleanupMediaServerScan: [],
+				}),
+			),
+			"current active media-server scan retryable-cleanup-scan is missing from incoming data",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
@@ -533,7 +672,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(restoreDatabase(prisma, incomingData())).rejects.toThrow(
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData()),
 			"current nonterminal coordination row interrupted-sync",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -561,9 +701,10 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(prisma, incomingData({ templateDeploymentHistory: [currentDeployment] })),
-		).rejects.toThrow("current recovery snapshot snapshot-deployment");
+			"current recovery snapshot snapshot-deployment",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -591,7 +732,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -599,7 +740,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current nonterminal coordination row current-sync changed userId");
+			"current nonterminal coordination row current-sync changed userId",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -622,7 +764,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -630,7 +772,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [{ ...currentSnapshot, backupData: "stale-sync-evidence" }],
 				}),
 			),
-		).rejects.toThrow("current recovery snapshot snapshot-sync changed backupData");
+			"current recovery snapshot snapshot-sync changed backupData",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -658,7 +801,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -668,7 +811,6 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow(
 			"current nonterminal coordination row current-deployment changed appliedConfigs",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -697,7 +839,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -705,7 +847,6 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow(
 			"current nonterminal coordination row current-deployment changed templateSnapshot",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -741,7 +882,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -750,7 +891,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current undeploy fallback template template-1 changed configData");
+			"current undeploy fallback template template-1 changed configData",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -777,7 +919,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -785,7 +927,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current nonterminal coordination row current-sync changed appliedConfigs");
+			"current nonterminal coordination row current-sync changed appliedConfigs",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { BackupCompatibilityError } from "../../errors.js";
 import type { PrismaClient } from "../../prisma.js";
-import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "../backup-database.js";
 
 const TABLE_NAMES = [
 	"user",
@@ -482,15 +482,21 @@ describe("restoreDatabase — current coordination preservation", () => {
 	}
 
 	function makeRestorePrisma(options: {
+		currentInstances?: Array<Record<string, unknown>>;
 		currentSync?: Array<Record<string, unknown>>;
 		currentDeployments?: Array<Record<string, unknown>>;
 		currentSnapshots?: Array<Record<string, unknown>>;
+		currentNaming?: Array<Record<string, unknown>>;
 		currentApprovals?: Array<Record<string, unknown>>;
 		currentScanParentApprovals?: Array<Record<string, unknown>>;
 		currentScans?: Array<Record<string, unknown>>;
 	}) {
 		const firstDelete = vi.fn().mockResolvedValue({ count: 0 });
 		const tx = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue(options.currentInstances ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
 			trashSyncHistory: {
 				findMany: vi.fn().mockResolvedValue(options.currentSync ?? []),
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -508,7 +514,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 			},
 			namingDeployHistory: {
-				findMany: vi.fn().mockResolvedValue([]),
+				findMany: vi.fn().mockResolvedValue(options.currentNaming ?? []),
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 			},
 			libraryCleanupApproval: {
@@ -530,7 +536,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			),
 		} as unknown as PrismaClient;
 
-		return { prisma, firstDelete };
+		return { prisma, compatibilityPrisma: tx as unknown as PrismaClient, firstDelete };
 	}
 
 	function incomingData(overrides: Record<string, unknown> = {}) {
@@ -576,6 +582,157 @@ describe("restoreDatabase — current coordination preservation", () => {
 			"current nonterminal coordination row current-sync",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["userId", "user-2"],
+		["service", "SONARR"],
+		["baseUrl", "http://radarr-replacement:7878"],
+		["encryptedApiKey", "replacement-api-key-ciphertext"],
+		["encryptionIv", "replacement-api-key-iv"],
+		["encryptedHttpAuthCredentials", "replacement-http-auth-ciphertext"],
+		["httpAuthEncryptionIv", "replacement-http-auth-iv"],
+	])(
+		"rejects a restore that changes active naming recovery service instance %s",
+		async (field, replacement) => {
+			const currentInstance = {
+				id: "instance-1",
+				userId: "user-1",
+				service: "RADARR",
+				baseUrl: "http://radarr-current:7878",
+				encryptedApiKey: "current-api-key-ciphertext",
+				encryptionIv: "current-api-key-iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+			};
+			const currentNaming = {
+				id: "active-naming-recovery",
+				instanceId: currentInstance.id,
+				userId: currentInstance.userId,
+				status: "SUCCESS",
+				selectedPresets: '["standard"]',
+				resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+				deployedHash: "deployed-hash",
+				previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+				changedFields: 1,
+				totalFields: 1,
+				errorMessage: null,
+				rolledBack: false,
+				rolledBackAt: null,
+				deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+			};
+			const { prisma, firstDelete } = makeRestorePrisma({
+				currentInstances: [currentInstance],
+				currentNaming: [currentNaming],
+			});
+
+			await expectCompatibilityFailure(
+				restoreDatabase(
+					prisma,
+					incomingData({
+						serviceInstances: [{ ...currentInstance, [field]: replacement }],
+						namingDeployHistory: [currentNaming],
+					}),
+				),
+				`current active naming recovery active-naming-recovery changed service instance ${field}`,
+			);
+			expect(firstDelete).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rejects a restore that changes query-routed active naming recovery authority", async () => {
+		const currentInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			baseUrl: "https://proxy.example/arr?tenant=A",
+			encryptedApiKey: "current-api-key-ciphertext",
+			encryptionIv: "current-api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		const currentNaming = {
+			id: "active-naming-recovery",
+			instanceId: currentInstance.id,
+			userId: currentInstance.userId,
+			status: "SUCCESS",
+			selectedPresets: '["standard"]',
+			resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+			deployedHash: "deployed-hash",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			changedFields: 1,
+			totalFields: 1,
+			errorMessage: null,
+			rolledBack: false,
+			rolledBackAt: null,
+			deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentInstances: [currentInstance],
+			currentNaming: [currentNaming],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(
+				prisma,
+				incomingData({
+					serviceInstances: [{ ...currentInstance, baseUrl: "https://proxy.example/arr?tenant=B" }],
+					namingDeployHistory: [currentNaming],
+				}),
+			),
+			"current active naming recovery active-naming-recovery changed service instance baseUrl",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it("allows equivalent endpoint and display-only changes while preserving active naming recovery authority", async () => {
+		const currentInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			label: "Current label",
+			baseUrl: "http://radarr-current:7878",
+			encryptedApiKey: "current-api-key-ciphertext",
+			encryptionIv: "current-api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		const currentNaming = {
+			id: "active-naming-recovery",
+			instanceId: currentInstance.id,
+			userId: currentInstance.userId,
+			status: "SUCCESS",
+			selectedPresets: '["standard"]',
+			resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+			deployedHash: "deployed-hash",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			changedFields: 1,
+			totalFields: 1,
+			errorMessage: null,
+			rolledBack: false,
+			rolledBackAt: null,
+			deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { compatibilityPrisma } = makeRestorePrisma({
+			currentInstances: [currentInstance],
+			currentNaming: [currentNaming],
+		});
+
+		await expect(
+			assertRestoreCompatibility(
+				compatibilityPrisma,
+				incomingData({
+					serviceInstances: [
+						{
+							...currentInstance,
+							label: "Restored display label",
+							baseUrl: `${currentInstance.baseUrl}/`,
+						},
+					],
+					namingDeployHistory: [currentNaming],
+				}),
+			),
+		).resolves.toBeUndefined();
 	});
 
 	it("rejects a restore that omits an active cleanup approval before deleting tables", async () => {

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -339,6 +339,59 @@ describe("exportDatabase — operational history exclusion", () => {
 		);
 	});
 
+	it("fails closed when active naming recovery changes during export", async () => {
+		const { prisma, mock } = makeMockPrisma();
+		const activeNaming = {
+			id: "active-naming-recovery",
+			instanceId: "instance-1",
+			userId: "user-1",
+			status: "SUCCESS",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			rolledBack: false,
+		};
+		mock.namingDeployHistory.findMany
+			.mockResolvedValueOnce([activeNaming])
+			.mockResolvedValueOnce([{ ...activeNaming, previousConfig: "changed-recovery-state" }]);
+
+		await expect(exportDatabase(prisma, { excludeOperationalHistory: true })).rejects.toThrow(
+			"Cannot create backup: active naming recovery changed during export; retry",
+		);
+	});
+
+	it("fails closed when active naming recovery service authority changes during export", async () => {
+		const { prisma, mock } = makeMockPrisma();
+		const activeNaming = {
+			id: "active-naming-recovery",
+			instanceId: "instance-1",
+			userId: "user-1",
+			status: "SUCCESS",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			rolledBack: false,
+		};
+		const initialInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			baseUrl: "https://proxy.example/arr?tenant=A",
+			encryptedApiKey: "api-key-ciphertext",
+			encryptionIv: "api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		mock.serviceInstance.findMany
+			.mockResolvedValueOnce([initialInstance])
+			.mockResolvedValueOnce([
+				{ ...initialInstance, baseUrl: "https://proxy.example/arr?tenant=B" },
+			]);
+		mock.namingDeployHistory.findMany
+			.mockResolvedValueOnce([activeNaming])
+			.mockResolvedValueOnce([activeNaming]);
+
+		await expect(exportDatabase(prisma, { excludeOperationalHistory: true })).rejects.toThrow(
+			"Cannot create backup: active naming recovery changed during export; retry",
+		);
+	});
+
 	it("includes operational history with row cap when excludeOperationalHistory: false (default)", async () => {
 		const { prisma, mock } = makeMockPrisma({
 			huntLog: [{ id: "h1", startedAt: new Date() }],

--- a/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../../prisma.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "../backup-database.js";
+import { validateBackup } from "../backup-validation.js";
+
+const DURABLE_CONFIG_KEYS = [
+	"backupSettings",
+	"vapidKeys",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+	"namingDeployHistory",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+] as const;
+
+const COMPLETE_V1_2_PAYLOAD_KEYS = [
+	"oidcProviders",
+	"systemSettings",
+	"trashTemplates",
+	"trashSettings",
+	"trashSyncSchedules",
+	"templateQualityProfileMappings",
+	"instanceQualityProfileOverrides",
+	"standaloneCFDeployments",
+	"qualitySizeMappings",
+	"trashSyncHistory",
+	"templateDeploymentHistory",
+	"trashBackups",
+	"huntConfigs",
+	"huntLogs",
+	"huntSearchHistory",
+	...DURABLE_CONFIG_KEYS,
+] as const;
+
+function baseBackup(data: Record<string, unknown> = {}) {
+	return {
+		version: "1.2",
+		appVersion: "2.24.2",
+		timestamp: new Date().toISOString(),
+		data: {
+			users: [],
+			sessions: [],
+			serviceInstances: [],
+			serviceTags: [],
+			serviceInstanceTags: [],
+			oidcAccounts: [],
+			webAuthnCredentials: [],
+			...Object.fromEntries(COMPLETE_V1_2_PAYLOAD_KEYS.map((key) => [key, []])),
+			...data,
+		},
+		secrets: {
+			encryptionKey: "encryption-key",
+			sessionCookieSecret: "session-cookie-secret",
+		},
+	};
+}
+
+describe("backup format 1.2", () => {
+	it("accepts explicit durable configuration arrays, including empty arrays", () => {
+		expect(() => validateBackup(baseBackup())).not.toThrow();
+	});
+
+	it("rejects a 1.2 payload when a durable configuration array is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.notificationChannel;
+
+		expect(() => validateBackup(backup)).toThrow(/notificationChannel/);
+	});
+
+	it("rejects a 1.2 payload when an older exported configuration array is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.qualitySizeMappings;
+
+		expect(() => validateBackup(backup)).toThrow(/qualitySizeMappings/);
+	});
+
+	it("rejects a 1.2 payload when cleanup coordination coverage is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.libraryCleanupApproval;
+
+		expect(() => validateBackup(backup)).toThrow(/libraryCleanupApproval/);
+	});
+
+	it("exports every durable configuration collection as an explicit array", async () => {
+		const models = [
+			"user",
+			"session",
+			"serviceInstance",
+			"serviceTag",
+			"serviceInstanceTag",
+			"oIDCProvider",
+			"oIDCAccount",
+			"webAuthnCredential",
+			"systemSettings",
+			"trashTemplate",
+			"trashSettings",
+			"trashSyncSchedule",
+			"templateQualityProfileMapping",
+			"instanceQualityProfileOverride",
+			"standaloneCFDeployment",
+			"qualitySizeMapping",
+			"trashSyncHistory",
+			"templateDeploymentHistory",
+			"huntConfig",
+			"huntLog",
+			"huntSearchHistory",
+			"trashBackup",
+			"libraryCleanupApproval",
+			"libraryCleanupMediaServerScan",
+			...DURABLE_CONFIG_KEYS.filter((key) => key !== "backupSettings" && key !== "vapidKeys"),
+			"backupSettings",
+			"vapidKeys",
+		];
+		const prisma = Object.fromEntries(
+			models.map((model) => [
+				model,
+				{
+					findMany: vi.fn().mockResolvedValue([]),
+					count: vi.fn().mockResolvedValue(0),
+				},
+			]),
+		) as unknown as PrismaClient;
+
+		const data = await exportDatabase(prisma);
+
+		for (const key of DURABLE_CONFIG_KEYS) {
+			expect(data[key]).toEqual([]);
+		}
+		expect(data.libraryCleanupApproval).toEqual([]);
+		expect(data.libraryCleanupMediaServerScan).toEqual([]);
+	});
+
+	it("exports no-scan approvals awaiting terminal audit and resets nonportable audit markers", async () => {
+		const awaitingAudit = {
+			id: "approval-awaiting-audit",
+			status: "executed",
+			sizeOnDisk: 10n,
+			terminalAuditRecordedAt: null,
+			terminalAuditRecoveryAttemptedAt: new Date("2026-08-30T00:00:00.000Z"),
+		};
+		const auditedScanParent = {
+			id: "approval-with-scan",
+			status: "executed",
+			sizeOnDisk: 20n,
+			terminalAuditRecordedAt: new Date("2026-08-30T01:00:00.000Z"),
+			terminalAuditRecoveryAttemptedAt: new Date("2026-08-30T00:30:00.000Z"),
+		};
+		const emptyDelegate = {
+			findMany: vi.fn().mockResolvedValue([]),
+			count: vi.fn().mockResolvedValue(0),
+		};
+		const approvalFindMany = vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+			if ("OR" in where) return [awaitingAudit];
+			if ("id" in where) return [auditedScanParent];
+			return [];
+		});
+		const scanFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "scan-1",
+				approvalId: auditedScanParent.id,
+				status: "failed",
+			},
+		]);
+		const prisma = new Proxy(
+			{},
+			{
+				get: (_target, property) => {
+					if (property === "libraryCleanupApproval") {
+						return { findMany: approvalFindMany };
+					}
+					if (property === "libraryCleanupMediaServerScan") {
+						return { findMany: scanFindMany };
+					}
+					return emptyDelegate;
+				},
+			},
+		) as unknown as PrismaClient;
+
+		const data = await exportDatabase(prisma);
+
+		expect(data.libraryCleanupApproval).toEqual([
+			expect.objectContaining({
+				id: awaitingAudit.id,
+				sizeOnDisk: "10",
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			}),
+			expect.objectContaining({
+				id: auditedScanParent.id,
+				sizeOnDisk: "20",
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			}),
+		]);
+	});
+
+	it("rejects legacy omission of an older relational config collection", async () => {
+		const prisma = {
+			trashTemplate: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.trashTemplates;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects an incomplete legacy payload over a populated durable-config target", async () => {
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects incomplete legacy coverage over partial stored backup-password state", async () => {
+		const prisma = {
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({
+					encryptedPassword: "ciphertext-without-iv",
+					passwordIv: null,
+				}),
+			},
+			vapidKeys: { findFirst: vi.fn().mockResolvedValue(null) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.backupSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects incomplete legacy coverage over stored VAPID private-key state", async () => {
+		const prisma = {
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({ encryptedPassword: null, passwordIv: null }),
+			},
+			vapidKeys: {
+				findFirst: vi.fn().mockResolvedValue({
+					encryptedPrivateKey: null,
+					privateKeyIv: "iv-without-ciphertext",
+				}),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.vapidKeys;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("allows incomplete legacy coverage over default non-secret backup settings", async () => {
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(0) },
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({ encryptedPassword: null, passwordIv: null }),
+			},
+			vapidKeys: { findFirst: vi.fn().mockResolvedValue(null) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.backupSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("allows unrelated legacy omissions when singleton replacement arrays are present", async () => {
+		const backupSettingsFindFirst = vi.fn().mockResolvedValue({
+			encryptedPassword: "target-ciphertext",
+			passwordIv: "target-iv",
+		});
+		const vapidKeysFindFirst = vi.fn().mockResolvedValue({
+			encryptedPrivateKey: "target-vapid-ciphertext",
+			privateKeyIv: "target-vapid-iv",
+		});
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(0) },
+			backupSettings: { findFirst: backupSettingsFindFirst },
+			vapidKeys: { findFirst: vapidKeysFindFirst },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+		expect(backupSettingsFindFirst).not.toHaveBeenCalled();
+		expect(vapidKeysFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("rejects legacy omission of current OIDC provider state", async () => {
+		const prisma = {
+			oIDCProvider: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.oidcProviders;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("allows legacy omission when the only naming history is terminal audit", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("allows legacy omission when the only naming history is rolled back", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("rejects legacy omission when active naming recovery is populated", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "active", status: "SUCCESS", rolledBack: false }]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rechecks compatibility inside the transaction before the first delete", async () => {
+		const firstDelete = vi.fn();
+		const tx = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(1) },
+			huntSearchHistory: { deleteMany: firstDelete },
+		};
+		const prisma = {
+			$transaction: vi.fn(async (operation: (value: unknown) => Promise<void>) => operation(tx)),
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(restoreDatabase(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
@@ -1,0 +1,670 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import { BackupCompatibilityError } from "../../errors.js";
+import type { PrismaClient } from "../../prisma.js";
+import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { BACKUP_VERSION, validateBackup } from "../backup-validation.js";
+
+const RUN_DB_TESTS = process.env.TEST_DB === "true";
+const execFileAsync = promisify(execFile);
+
+type DatabaseHandle = { prisma: PrismaClient; cleanup: () => Promise<void> };
+
+async function pushSqliteSchema(databasePath: string, apiDir: string): Promise<void> {
+	await execFileAsync(
+		"pnpm",
+		[
+			"exec",
+			"prisma",
+			"db",
+			"push",
+			"--schema",
+			"prisma/schema.prisma",
+			"--url",
+			`file:${databasePath}`,
+		],
+		{ cwd: apiDir, env: { ...process.env, DATABASE_URL: `file:${databasePath}` } },
+	);
+}
+
+function withPostgresSchema(connectionString: string, schema: string): string {
+	const url = new URL(connectionString);
+	url.searchParams.set("schema", schema);
+	return url.toString();
+}
+
+async function createPostgresDatabasePair(
+	connectionString: string,
+	tempDir: string,
+	apiDir: string,
+): Promise<{ source: DatabaseHandle; target: DatabaseHandle }> {
+	const suffix = `${process.pid}_${Date.now()}`;
+	const sourceSchema = `backup815_source_${suffix}`;
+	const targetSchema = `backup815_target_${suffix}`;
+	const pg = await import("pg");
+	const admin = new pg.default.Pool({ connectionString });
+	const schemaFile = path.join(tempDir, "postgres-schema.prisma");
+	const clientOutput = path.join(tempDir, "postgres-client");
+	const pools: InstanceType<typeof pg.default.Pool>[] = [];
+	const clients: PrismaClient[] = [];
+	try {
+		await admin.query(`CREATE SCHEMA "${sourceSchema}"`);
+		await admin.query(`CREATE SCHEMA "${targetSchema}"`);
+		const sourceSchemaText = await readFile(path.join(apiDir, "prisma/schema.prisma"), "utf8");
+		const postgresSchemaText = sourceSchemaText
+			.replace(
+				/generator client \{[\s\S]*?\}\n\n/,
+				`generator client {\n  provider = "prisma-client"\n  output = "${clientOutput}"\n}\n\n`,
+			)
+			.replace('provider = "sqlite"', 'provider = "postgresql"');
+		await writeFile(schemaFile, postgresSchemaText, "utf8");
+		await execFileAsync("pnpm", ["exec", "prisma", "generate", "--schema", schemaFile], {
+			cwd: apiDir,
+			env: process.env,
+		});
+		for (const schema of [sourceSchema, targetSchema]) {
+			const schemaUrl = withPostgresSchema(connectionString, schema);
+			await execFileAsync(
+				"pnpm",
+				["exec", "prisma", "db", "push", "--schema", schemaFile, "--url", schemaUrl],
+				{ cwd: apiDir, env: { ...process.env, DATABASE_URL: schemaUrl } },
+			);
+		}
+		const generatedModule = await import(
+			/* @vite-ignore */ pathToFileURL(path.join(clientOutput, "client.ts")).href
+		);
+		const generatedExports = (generatedModule.default ?? generatedModule) as {
+			PrismaClient: new (options: { adapter: unknown }) => PrismaClient;
+		};
+		const { PrismaPg } = await import("@prisma/adapter-pg");
+		for (const schema of [sourceSchema, targetSchema]) {
+			const pool = new pg.default.Pool({
+				connectionString: withPostgresSchema(connectionString, schema),
+			});
+			pools.push(pool);
+			clients.push(
+				new generatedExports.PrismaClient({
+					adapter: new PrismaPg(pool as never, { schema }),
+				}),
+			);
+		}
+		const [sourcePrisma, targetPrisma] = clients;
+		if (!sourcePrisma || !targetPrisma) throw new Error("PostgreSQL test clients were not created");
+		return {
+			source: {
+				prisma: sourcePrisma,
+				cleanup: async () => {
+					await sourcePrisma.$disconnect();
+					await pools[0]?.end();
+				},
+			},
+			target: {
+				prisma: targetPrisma,
+				cleanup: async () => {
+					await targetPrisma.$disconnect();
+					await pools[1]?.end();
+					await admin.query(`DROP SCHEMA "${sourceSchema}" CASCADE`);
+					await admin.query(`DROP SCHEMA "${targetSchema}" CASCADE`);
+					await admin.end();
+				},
+			},
+		};
+	} catch (error) {
+		await Promise.allSettled(clients.map((client) => client.$disconnect()));
+		await Promise.allSettled(pools.map((pool) => pool.end()));
+		await Promise.allSettled([
+			admin.query(`DROP SCHEMA IF EXISTS "${sourceSchema}" CASCADE`),
+			admin.query(`DROP SCHEMA IF EXISTS "${targetSchema}" CASCADE`),
+		]);
+		await admin.end().catch(() => undefined);
+		throw error;
+	}
+}
+
+async function createDatabasePair(): Promise<{
+	source: DatabaseHandle;
+	target: DatabaseHandle;
+	tempDir: string;
+}> {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), "backup-roundtrip-"));
+	const apiDir = path.resolve(import.meta.dirname, "../../../..");
+	const externalDatabaseUrl = process.env.TEST_DATABASE_URL;
+	if (externalDatabaseUrl?.startsWith("postgres")) {
+		return { ...(await createPostgresDatabasePair(externalDatabaseUrl, tempDir, apiDir)), tempDir };
+	}
+	const sourcePath = path.join(tempDir, "source.db");
+	const targetPath = path.join(tempDir, "target.db");
+	await pushSqliteSchema(sourcePath, apiDir);
+	await pushSqliteSchema(targetPath, apiDir);
+	return {
+		source: (() => {
+			const prisma = createTestPrismaClient(sourcePath);
+			return { prisma, cleanup: () => prisma.$disconnect() };
+		})(),
+		target: (() => {
+			const prisma = createTestPrismaClient(targetPath);
+			return { prisma, cleanup: () => prisma.$disconnect() };
+		})(),
+		tempDir,
+	};
+}
+
+async function seedDurableSource(prisma: PrismaClient): Promise<void> {
+	const userId = "issue815-roundtrip-user";
+	const instanceId = "issue815-roundtrip-instance";
+	const coordinationCreatedAt = new Date("2026-08-31T00:00:00.000Z");
+	const coordinationUpdatedAt = new Date("2026-08-31T00:01:00.000Z");
+	await prisma.user.create({
+		data: {
+			id: userId,
+			username: userId,
+			hashedPassword: "password-hash",
+			encryptedTmdbApiKey: "tmdb-ciphertext",
+			tmdbEncryptionIv: "tmdb-iv",
+			encryptedTraktAccessToken: "trakt-ciphertext",
+			traktTokenIv: "trakt-iv",
+		},
+	});
+	await prisma.session.create({
+		data: { id: "issue815-session", userId, expiresAt: new Date("2030-01-01T00:00:00.000Z") },
+	});
+	await prisma.serviceTag.create({ data: { id: "issue815-tag", name: "issue815" } });
+	await prisma.serviceInstance.create({
+		data: {
+			id: instanceId,
+			userId,
+			service: "RADARR",
+			label: "Issue 815 Radarr",
+			baseUrl: "http://radarr.example",
+			encryptedApiKey: "api-ciphertext",
+			encryptionIv: "api-iv",
+			encryptedHttpAuthCredentials: "http-auth-ciphertext",
+			httpAuthEncryptionIv: "http-auth-iv",
+		},
+	});
+	await prisma.serviceInstanceTag.create({ data: { instanceId, tagId: "issue815-tag" } });
+	await prisma.oIDCProvider.create({
+		data: {
+			id: 1,
+			displayName: "Issue 815 OIDC",
+			clientId: "client-id",
+			encryptedClientSecret: "oidc-ciphertext",
+			clientSecretIv: "oidc-iv",
+			issuer: "https://issuer.example",
+			redirectUri: "https://dashboard.example/callback",
+		},
+	});
+	await prisma.oIDCAccount.create({
+		data: { id: "issue815-oidc-account", userId, providerUserId: "provider-user" },
+	});
+	await prisma.webAuthnCredential.create({
+		data: { id: "issue815-credential", userId, publicKey: "passkey-public", counter: 3 },
+	});
+	await prisma.systemSettings.create({ data: { id: 1, appName: "Issue 815" } });
+	await prisma.backupSettings.create({
+		data: {
+			id: 1,
+			enabled: true,
+			intervalType: "DAILY",
+			encryptedPassword: "backup-password-ciphertext",
+			passwordIv: "backup-password-iv",
+		},
+	});
+	await prisma.vapidKeys.create({
+		data: {
+			id: 1,
+			publicKey: "vapid-public",
+			encryptedPrivateKey: "vapid-ciphertext",
+			privateKeyIv: "vapid-iv",
+		},
+	});
+
+	const template = await prisma.trashTemplate.create({
+		data: {
+			id: "issue815-template",
+			userId,
+			name: "Issue 815 template",
+			serviceType: "RADARR",
+			configData: '{"customFormats":[]}',
+		},
+	});
+	await prisma.trashSettings.create({ data: { id: "issue815-trash-settings", userId } });
+	await prisma.trashSyncSchedule.create({
+		data: {
+			id: "issue815-schedule",
+			userId,
+			instanceId,
+			templateId: template.id,
+			frequency: "DAILY",
+		},
+	});
+	await prisma.templateQualityProfileMapping.create({
+		data: {
+			id: "issue815-profile-mapping",
+			templateId: template.id,
+			instanceId,
+			qualityProfileId: 10,
+			qualityProfileName: "Issue 815 profile",
+		},
+	});
+	await prisma.instanceQualityProfileOverride.create({
+		data: {
+			id: "issue815-score-intent",
+			instanceId,
+			qualityProfileId: 10,
+			customFormatId: 20,
+			score: 42,
+			status: "PENDING",
+			intentOperation: "SET_SCORE",
+			intendedScore: 42,
+			userId,
+			connectionGeneration: 2,
+			connectionStateToken: "state-token",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.standaloneCFDeployment.create({
+		data: {
+			id: "issue815-standalone-cf",
+			userId,
+			instanceId,
+			cfTrashId: "issue815-cf",
+			cfName: "Issue 815 CF",
+			serviceType: "RADARR",
+			commitHash: "commit",
+		},
+	});
+	await prisma.qualitySizeMapping.create({
+		data: {
+			id: "issue815-quality-size",
+			instanceId,
+			userId,
+			presetTrashId: "issue815-preset",
+			presetType: "movie",
+			serviceType: "RADARR",
+			lastAppliedAt: new Date("2025-01-01T00:00:00.000Z"),
+		},
+	});
+	await prisma.huntConfig.create({
+		data: { id: "issue815-hunt", instanceId, huntMissingEnabled: true, missingBatchSize: 2 },
+	});
+	await prisma.queueCleanerConfig.create({
+		data: { id: "issue815-queue", instanceId, enabled: true, dryRunMode: false },
+	});
+	const cleanup = await prisma.libraryCleanupConfig.create({
+		data: { id: "issue815-cleanup", userId, enabled: true, dryRunMode: false },
+	});
+	await prisma.libraryCleanupRule.create({
+		data: {
+			id: "issue815-cleanup-rule",
+			configId: cleanup.id,
+			name: "Issue 815 rule",
+			ruleType: "age",
+			parameters: '{"days":30}',
+		},
+	});
+	await prisma.libraryCleanupApproval.create({
+		data: {
+			id: "issue815-active-approval",
+			configId: cleanup.id,
+			instanceId,
+			arrItemId: 815,
+			itemType: "movie",
+			title: "Issue 815 movie",
+			matchedRuleId: "issue815-cleanup-rule",
+			matchedRuleName: "Issue 815 rule",
+			reason: "age",
+			action: "delete",
+			sizeOnDisk: BigInt(1234),
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			status: "pending",
+			createdAt: coordinationCreatedAt,
+		},
+	});
+	await prisma.libraryCleanupApproval.create({
+		data: {
+			id: "issue815-executed-parent",
+			configId: cleanup.id,
+			instanceId,
+			arrItemId: 816,
+			itemType: "series",
+			title: "Issue 815 series",
+			matchedRuleId: "issue815-cleanup-rule",
+			matchedRuleName: "Issue 815 rule",
+			reason: "size",
+			action: "delete",
+			sizeOnDisk: BigInt(5678),
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			status: "executed",
+			terminalAuditRecordedAt: new Date("2029-01-01T00:00:00.000Z"),
+			terminalAuditRecoveryAttemptedAt: new Date("2028-12-31T23:00:00.000Z"),
+			createdAt: coordinationCreatedAt,
+		},
+	});
+	await prisma.libraryCleanupMediaServerScan.create({
+		data: {
+			id: "issue815-pending-scan",
+			approvalId: "issue815-active-approval",
+			instanceId,
+			service: "PLEX",
+			mediaType: "movie",
+			targetKey: "movie:815",
+			status: "pending",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.libraryCleanupMediaServerScan.create({
+		data: {
+			id: "issue815-failed-scan",
+			approvalId: "issue815-executed-parent",
+			instanceId,
+			service: "PLEX",
+			mediaType: "show",
+			targetKey: "series:816",
+			status: "failed",
+			lastError: "test failure",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.userCustomFormat.create({
+		data: {
+			id: "issue815-custom-format",
+			userId,
+			name: "Issue 815 format",
+			serviceType: "RADARR",
+			specifications: "[]",
+			defaultScore: 42,
+		},
+	});
+	const channel = await prisma.notificationChannel.create({
+		data: {
+			id: "issue815-channel",
+			userId,
+			name: "Issue 815 channel",
+			type: "WEBHOOK",
+			encryptedConfig: "notification-ciphertext",
+			configIv: "notification-iv",
+		},
+	});
+	await prisma.notificationSubscription.create({
+		data: { channelId: channel.id, eventType: "BACKUP_FAILED" },
+	});
+	await prisma.notificationRule.create({
+		data: {
+			id: "issue815-notification-rule",
+			userId,
+			name: "Issue 815 rule",
+			action: "suppress",
+			conditions: "[]",
+		},
+	});
+	await prisma.notificationAggregationConfig.create({
+		data: { id: "issue815-aggregation", userId, eventType: "BACKUP_FAILED" },
+	});
+	await prisma.namingConfig.create({
+		data: {
+			id: "issue815-naming",
+			instanceId,
+			userId,
+			serviceType: "RADARR",
+			selectedPresets: "{}",
+		},
+	});
+	await prisma.labelSyncRule.create({
+		data: {
+			id: "issue815-label-sync",
+			userId,
+			name: "Issue 815 label sync",
+			sourceService: "radarr",
+			sourceTagName: "source",
+			destInstanceId: instanceId,
+			destTagName: "destination",
+		},
+	});
+	await prisma.autoTagRule.create({
+		data: {
+			id: "issue815-auto-tag",
+			userId,
+			name: "Issue 815 auto tag",
+			ruleType: "age",
+			parameters: "{}",
+			tagName: "issue815",
+		},
+	});
+	await prisma.namingDeployHistory.create({
+		data: {
+			id: "issue815-naming-history",
+			instanceId,
+			userId,
+			status: "SUCCESS",
+			selectedPresets: "{}",
+			resolvedPayload: "{}",
+			changedFields: 1,
+			totalFields: 1,
+			deployedAt: coordinationCreatedAt,
+		},
+	});
+}
+
+function normalizedRows(rows: unknown[]): string[] {
+	return rows
+		.map((row) =>
+			JSON.stringify(row, (_key, value) => {
+				if (value instanceof Date) return value.toISOString();
+				if (typeof value === "bigint") return value.toString();
+				return value;
+			}),
+		)
+		.sort();
+}
+
+const MODEL_EXPORTS = [
+	["users", "user"],
+	["sessions", "session"],
+	["serviceInstances", "serviceInstance"],
+	["serviceTags", "serviceTag"],
+	["serviceInstanceTags", "serviceInstanceTag"],
+	["oidcProviders", "oIDCProvider"],
+	["oidcAccounts", "oIDCAccount"],
+	["webAuthnCredentials", "webAuthnCredential"],
+	["systemSettings", "systemSettings"],
+	["backupSettings", "backupSettings"],
+	["vapidKeys", "vapidKeys"],
+	["trashTemplates", "trashTemplate"],
+	["trashSettings", "trashSettings"],
+	["trashSyncSchedules", "trashSyncSchedule"],
+	["templateQualityProfileMappings", "templateQualityProfileMapping"],
+	["instanceQualityProfileOverrides", "instanceQualityProfileOverride"],
+	["standaloneCFDeployments", "standaloneCFDeployment"],
+	["qualitySizeMappings", "qualitySizeMapping"],
+	["huntConfigs", "huntConfig"],
+	["queueCleanerConfig", "queueCleanerConfig"],
+	["libraryCleanupConfig", "libraryCleanupConfig"],
+	["libraryCleanupRule", "libraryCleanupRule"],
+	["libraryCleanupApproval", "libraryCleanupApproval"],
+	["libraryCleanupMediaServerScan", "libraryCleanupMediaServerScan"],
+	["userCustomFormat", "userCustomFormat"],
+	["notificationChannel", "notificationChannel"],
+	["notificationSubscription", "notificationSubscription"],
+	["notificationRule", "notificationRule"],
+	["notificationAggregationConfig", "notificationAggregationConfig"],
+	["namingConfig", "namingConfig"],
+	["namingDeployHistory", "namingDeployHistory"],
+	["labelSyncRule", "labelSyncRule"],
+	["autoTagRule", "autoTagRule"],
+] as const;
+
+(RUN_DB_TESTS ? describe : describe.skip)(
+	"backup format 1.2 independent database round-trip",
+	() => {
+		let source: DatabaseHandle;
+		let target: DatabaseHandle;
+		let tempDir: string;
+
+		beforeAll(async () => {
+			({ source, target, tempDir } = await createDatabasePair());
+			await seedDurableSource(source.prisma);
+			await seedDurableSource(target.prisma);
+		});
+
+		afterAll(async () => {
+			const cleanupErrors: unknown[] = [];
+			for (const cleanup of [source?.cleanup, target?.cleanup]) {
+				try {
+					await cleanup?.();
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+			}
+			try {
+				if (tempDir) await rm(tempDir, { recursive: true, force: true });
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+			if (cleanupErrors.length > 0) {
+				throw new AggregateError(cleanupErrors, "Backup round-trip cleanup failed");
+			}
+		});
+
+		it("rejects incomplete populated-target restores, then replaces complete and covered legacy state", async () => {
+			const exported = await exportDatabase(source.prisma, { excludeOperationalHistory: true });
+			const backup = {
+				version: BACKUP_VERSION,
+				appVersion: "2.24.2",
+				timestamp: new Date().toISOString(),
+				data: exported,
+				secrets: { encryptionKey: "key", sessionCookieSecret: "session" },
+			};
+			validateBackup(backup);
+
+			await target.prisma.queueCleanerConfig.update({
+				where: { id: "issue815-queue" },
+				data: { enabled: false },
+			});
+			await target.prisma.backupSettings.update({
+				where: { id: 1 },
+				data: {
+					encryptedPassword: "target-backup-ciphertext",
+					passwordIv: "target-backup-iv",
+				},
+			});
+			const incompleteData = { ...exported } as Record<string, unknown>;
+			delete incompleteData.queueCleanerConfig;
+
+			await expect(restoreDatabase(target.prisma, incompleteData as never)).rejects.toBeInstanceOf(
+				BackupCompatibilityError,
+			);
+			expect(
+				await target.prisma.queueCleanerConfig.findUnique({ where: { id: "issue815-queue" } }),
+			).toMatchObject({ enabled: false });
+			expect(await target.prisma.backupSettings.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPassword: "target-backup-ciphertext",
+				passwordIv: "target-backup-iv",
+			});
+			expect(await target.prisma.libraryCleanupApproval.count()).toBe(2);
+
+			await restoreDatabase(target.prisma, backup.data);
+
+			for (const [exportKey, modelKey] of MODEL_EXPORTS) {
+				const model = (
+					target.prisma as unknown as Record<string, { findMany: () => Promise<unknown[]> }>
+				)[modelKey];
+				if (!model) throw new Error(`Missing Prisma model ${modelKey}`);
+				const targetRows = await model.findMany();
+				expect(normalizedRows(targetRows), modelKey).toEqual(
+					normalizedRows(exported[exportKey] as unknown[]),
+				);
+			}
+			expect(exported.notificationChannel?.[0]).toMatchObject({
+				encryptedConfig: "notification-ciphertext",
+				configIv: "notification-iv",
+			});
+			expect(exported.users[0]).toMatchObject({
+				encryptedTmdbApiKey: "tmdb-ciphertext",
+				tmdbEncryptionIv: "tmdb-iv",
+				encryptedTraktAccessToken: "trakt-ciphertext",
+				traktTokenIv: "trakt-iv",
+			});
+			expect(exported.oidcProviders?.[0]).toMatchObject({
+				encryptedClientSecret: "oidc-ciphertext",
+				clientSecretIv: "oidc-iv",
+			});
+			expect(exported.backupSettings?.[0]).toMatchObject({
+				encryptedPassword: "backup-password-ciphertext",
+				passwordIv: "backup-password-iv",
+			});
+			expect(exported.vapidKeys?.[0]).toMatchObject({
+				encryptedPrivateKey: "vapid-ciphertext",
+				privateKeyIv: "vapid-iv",
+			});
+			expect(exported.serviceInstances[0]).toMatchObject({
+				encryptedApiKey: "api-ciphertext",
+				encryptionIv: "api-iv",
+				encryptedHttpAuthCredentials: "http-auth-ciphertext",
+				httpAuthEncryptionIv: "http-auth-iv",
+			});
+			expect(exported.instanceQualityProfileOverrides?.[0]).toMatchObject({ status: "PENDING" });
+			expect(
+				(exported.libraryCleanupApproval as Array<Record<string, unknown>>).find(
+					(row) => row.id === "issue815-executed-parent",
+				),
+			).toMatchObject({
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			});
+
+			await target.prisma.notificationSubscription.deleteMany();
+			await target.prisma.notificationChannel.deleteMany();
+			await target.prisma.backupSettings.update({
+				where: { id: 1 },
+				data: { encryptedPassword: null, passwordIv: null },
+			});
+			await target.prisma.vapidKeys.update({
+				where: { id: 1 },
+				data: {
+					encryptedPrivateKey: "target-vapid-ciphertext",
+					privateKeyIv: "target-vapid-iv",
+				},
+			});
+			const coveredLegacyData = { ...exported } as Record<string, unknown>;
+			delete coveredLegacyData.notificationChannel;
+			delete coveredLegacyData.notificationSubscription;
+			coveredLegacyData.libraryCleanupApproval = (
+				exported.libraryCleanupApproval as Array<Record<string, unknown>>
+			).map((row) => ({
+				...row,
+				terminalAuditRecordedAt: "2031-01-01T00:00:00.000Z",
+				terminalAuditRecoveryAttemptedAt: "2031-01-01T01:00:00.000Z",
+			}));
+
+			await restoreDatabase(target.prisma, coveredLegacyData as never);
+			expect(await target.prisma.backupSettings.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPassword: "backup-password-ciphertext",
+				passwordIv: "backup-password-iv",
+			});
+			expect(await target.prisma.vapidKeys.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPrivateKey: "vapid-ciphertext",
+				privateKeyIv: "vapid-iv",
+			});
+			expect(await target.prisma.notificationChannel.count()).toBe(0);
+			expect(await target.prisma.notificationSubscription.count()).toBe(0);
+			expect(
+				await target.prisma.libraryCleanupApproval.findUnique({
+					where: { id: "issue815-executed-parent" },
+				}),
+			).toMatchObject({
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			});
+		});
+	},
+);

--- a/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
@@ -2,12 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loggers } from "../../logger.js";
-import type { PrismaClient } from "../../prisma.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,
 } from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { loggers } from "../../logger.js";
+import type { PrismaClient } from "../../prisma.js";
 import { decryptBackupData, type EncryptedBackupEnvelope } from "../backup-crypto.js";
 import { BackupService } from "../backup-service.js";
 
@@ -21,6 +21,8 @@ const TABLE_NAMES = [
 	"oIDCAccount",
 	"webAuthnCredential",
 	"systemSettings",
+	"backupSettings",
+	"vapidKeys",
 	"trashTemplate",
 	"trashSettings",
 	"trashSyncSchedule",
@@ -34,6 +36,20 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+	"namingConfig",
+	"namingDeployHistory",
+	"userCustomFormat",
 ] as const;
 
 function makePrismaWithCoordinationEvidence(): PrismaClient {
@@ -67,7 +83,10 @@ function makePrismaWithCoordinationEvidence(): PrismaClient {
 			expiresAt: new Date("2020-01-02T00:00:00.000Z"),
 		},
 	]);
-	prisma.backupSettings = { findUnique: vi.fn().mockResolvedValue(null) };
+	prisma.backupSettings = {
+		findMany: vi.fn().mockResolvedValue([]),
+		findUnique: vi.fn().mockResolvedValue(null),
+	};
 
 	return prisma as unknown as PrismaClient;
 }
@@ -147,7 +166,7 @@ describe("BackupService coordination safety", () => {
 			};
 
 			expect(envelope.version).toBe("1.0");
-			expect(payload.version).toBe("1.1");
+			expect(payload.version).toBe("1.2");
 			expect(payload.data.trashSyncHistory).toEqual([
 				expect.objectContaining({ id: "rollback-active" }),
 			]);
@@ -161,9 +180,15 @@ describe("BackupService coordination safety", () => {
 				expect.objectContaining({
 					backupType: "scheduled",
 					skippedTables: ["huntLog", "huntSearchHistory"],
-					preservedTables: ["trashSyncHistory", "templateDeploymentHistory", "trashBackup"],
+					preservedTables: [
+						"trashSyncHistory",
+						"templateDeploymentHistory",
+						"trashBackup",
+						"libraryCleanupApproval",
+						"libraryCleanupMediaServerScan",
+					],
 				}),
-				"Backup excluded disposable operational history while preserving nonterminal TRaSH coordination evidence",
+				"Backup excluded disposable operational history while preserving nonterminal safety coordination evidence",
 			);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });

--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -1029,6 +1029,7 @@ describe("BackupService - legacy restore normalization", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: vi.fn(),
 			restoreDatabase: restoreSpy,
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService: IsolatedBackupService } = await import("../backup-service.js");
@@ -1136,6 +1137,116 @@ describe("BackupService - cleanup maintenance exclusion", () => {
 
 		releaseCleanup();
 		await cleanup;
+	});
+});
+
+describe("BackupService - coordination preflight", () => {
+	const durableArrays = [
+		"oidcProviders",
+		"systemSettings",
+		"trashTemplates",
+		"trashSettings",
+		"trashSyncSchedules",
+		"templateQualityProfileMappings",
+		"instanceQualityProfileOverrides",
+		"standaloneCFDeployments",
+		"qualitySizeMappings",
+		"trashSyncHistory",
+		"templateDeploymentHistory",
+		"trashBackups",
+		"huntConfigs",
+		"huntLogs",
+		"huntSearchHistory",
+		"backupSettings",
+		"vapidKeys",
+		"notificationChannel",
+		"notificationSubscription",
+		"notificationRule",
+		"notificationAggregationConfig",
+		"autoTagRule",
+		"labelSyncRule",
+		"queueCleanerConfig",
+		"libraryCleanupConfig",
+		"libraryCleanupRule",
+		"namingConfig",
+		"userCustomFormat",
+		"namingDeployHistory",
+		"libraryCleanupApproval",
+		"libraryCleanupMediaServerScan",
+	] as const;
+
+	function makeCompleteBackup() {
+		return {
+			version: "1.2",
+			appVersion: "2.24.2",
+			timestamp: new Date().toISOString(),
+			data: {
+				users: [],
+				sessions: [],
+				serviceInstances: [],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+				...Object.fromEntries(durableArrays.map((field) => [field, []])),
+			},
+			secrets: { encryptionKey: "replacement-key", sessionCookieSecret: "replacement-session" },
+		};
+	}
+
+	it("rejects a current coordination mismatch before writing replacement secrets", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-preflight-"));
+		const secretsPath = path.join(tempDir, "secrets.json");
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "current-sync", status: "RUNNING", instanceId: "i", userId: "u" },
+					]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		} as unknown as PrismaClient;
+
+		try {
+			const service = new BackupService(prisma, secretsPath);
+			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toThrow(
+				"cannot safely replace",
+			);
+			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
+			expect(prisma.$transaction).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a coordination query failure before writing replacement secrets", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-query-"));
+		const secretsPath = path.join(tempDir, "secrets.json");
+		const queryError = new Error("database unavailable during coordination preflight");
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockRejectedValue(queryError) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		} as unknown as PrismaClient;
+
+		try {
+			const service = new BackupService(prisma, secretsPath);
+			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toBe(
+				queryError,
+			);
+			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
+			expect(prisma.$transaction).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -1255,6 +1366,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		// Reload the BackupService module so it picks up the mock.
 		vi.resetModules();
@@ -1300,6 +1412,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");
@@ -1344,6 +1457,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");
@@ -1386,6 +1500,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -300,6 +300,16 @@ const ACTIVE_NAMING_FIELDS = [
 	"deployedAt",
 ] as const;
 
+const ACTIVE_NAMING_INSTANCE_FIELDS = [
+	"userId",
+	"service",
+	"baseUrl",
+	"encryptedApiKey",
+	"encryptionIv",
+	"encryptedHttpAuthCredentials",
+	"httpAuthEncryptionIv",
+] as const;
+
 const ACTIVE_APPROVAL_FIELDS = [
 	"configId",
 	"instanceId",
@@ -481,6 +491,44 @@ function assertCurrentSpecialRowPreserved(
 	}
 }
 
+function assertCurrentNamingInstancePreserved(
+	history: CoordinationRow,
+	currentInstances: Map<string, CoordinationRow>,
+	incomingInstances: Map<string, CoordinationRow>,
+): void {
+	if (typeof history.instanceId !== "string" || history.instanceId.length === 0) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} has no service instance identity`,
+		);
+	}
+	const currentInstance = currentInstances.get(history.instanceId);
+	if (!currentInstance) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} references missing service instance ${history.instanceId}`,
+		);
+	}
+	const incomingInstance = incomingInstances.get(history.instanceId);
+	if (!incomingInstance) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} service instance ${history.instanceId} is missing from incoming data`,
+		);
+	}
+	for (const field of ACTIVE_NAMING_INSTANCE_FIELDS) {
+		const incomingValue = incomingInstance[field];
+		const currentValue = currentInstance[field];
+		const matches =
+			field === "baseUrl" && typeof incomingValue === "string" && typeof currentValue === "string"
+				? `${incomingValue.replace(/\/$/, "")}/api/v3/config/naming` ===
+					`${currentValue.replace(/\/$/, "")}/api/v3/config/naming`
+				: incomingValue === currentValue;
+		if (!matches) {
+			throw new CoordinationMismatchError(
+				`Cannot restore backup: current active naming recovery ${history.id} changed service instance ${field}`,
+			);
+		}
+	}
+}
+
 async function validateCurrentCoordinationPreserved(
 	tx: Prisma.TransactionClient | PrismaClient,
 	data: BackupData["data"],
@@ -531,6 +579,23 @@ async function validateCurrentCoordinationPreserved(
 	const currentActiveNaming = (await db.namingDeployHistory.findMany({
 		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
 	})) as CoordinationRow[];
+	const currentNamingInstances = recordsById(
+		currentActiveNaming.length > 0
+			? await db.serviceInstance.findMany({
+					where: {
+						id: {
+							in: [
+								...new Set(
+									currentActiveNaming
+										.map((row) => row.instanceId)
+										.filter((id): id is string => typeof id === "string" && id.length > 0),
+								),
+							],
+						},
+					},
+				})
+			: [],
+	);
 	const currentActiveApprovals = optionalModels.libraryCleanupApproval?.findMany
 		? ((await optionalModels.libraryCleanupApproval.findMany({
 				where: activeCleanupApprovalWhere(),
@@ -559,6 +624,7 @@ async function validateCurrentCoordinationPreserved(
 	const incomingTemplates = recordsById(data.trashTemplates);
 	const incomingScoreIntents = recordsById(data.instanceQualityProfileOverrides);
 	const incomingActiveNaming = recordsById(data.namingDeployHistory);
+	const incomingInstances = recordsById(data.serviceInstances);
 	const incomingApprovals = recordsById(data.libraryCleanupApproval);
 	const incomingScans = recordsById(data.libraryCleanupMediaServerScan);
 
@@ -584,6 +650,7 @@ async function validateCurrentCoordinationPreserved(
 			incomingActiveNaming,
 			ACTIVE_NAMING_FIELDS,
 		);
+		assertCurrentNamingInstancePreserved(row, currentNamingInstances, incomingInstances);
 	}
 	for (const row of [...currentActiveApprovals, ...currentScanParentApprovals]) {
 		assertCurrentSpecialRowPreserved(

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -6,11 +6,14 @@
  */
 
 import type { BackupData } from "@arr/shared";
+import { BackupCompatibilityError } from "../errors.js";
 import { loggers } from "../logger.js";
 import type { Prisma, PrismaClient, TrashBackup } from "../prisma.js";
 import {
 	isNonterminalRollback,
 	isNonterminalUndeploy,
+	LEGACY_RELATIONAL_CONFIG_DELEGATES,
+	LEGACY_RELATIONAL_CONFIG_FIELDS,
 	validateCoordinationEvidence,
 	validateRecords,
 } from "./backup-validation.js";
@@ -35,8 +38,192 @@ export interface ExportDatabaseOptions {
 	historyRetentionLimit?: number;
 }
 
+async function targetHasDurableConfig(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	missingFields: readonly string[],
+): Promise<boolean> {
+	const client = prisma as unknown as Record<string, { count?: () => Promise<number> }>;
+	for (const [payloadField, delegate] of LEGACY_RELATIONAL_CONFIG_DELEGATES) {
+		if (!missingFields.includes(payloadField)) continue;
+		if (
+			payloadField === "libraryCleanupApproval" ||
+			payloadField === "libraryCleanupMediaServerScan"
+		) {
+			continue;
+		}
+		const accessor = client[delegate];
+		if (accessor?.count && (await accessor.count()) > 0) return true;
+	}
+	return false;
+}
+
+const ACTIVE_APPROVAL_STATUSES = [
+	"pending",
+	"approved",
+	"retry_pending",
+	"executing",
+	"retry_executing",
+] as const;
+const ACTIVE_SCAN_STATUSES = ["pending", "triggering", "failed"] as const;
+
+function activeCleanupApprovalWhere() {
+	return {
+		OR: [
+			{ status: { in: [...ACTIVE_APPROVAL_STATUSES] } },
+			{ status: "executed", terminalAuditRecordedAt: null },
+		],
+	};
+}
+
+async function targetHasUncoveredSingletonSecretState(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	data: BackupData["data"],
+): Promise<boolean> {
+	const record = data as Record<string, unknown>;
+	const client = prisma as unknown as Record<
+		string,
+		{
+			findFirst?: (args: unknown) => Promise<Record<string, unknown> | null>;
+		}
+	>;
+	if (!Array.isArray(record.backupSettings)) {
+		const backupSettings = await client.backupSettings?.findFirst?.({
+			select: { encryptedPassword: true, passwordIv: true },
+		});
+		if (backupSettings?.encryptedPassword != null || backupSettings?.passwordIv != null) {
+			return true;
+		}
+	}
+
+	if (!Array.isArray(record.vapidKeys)) {
+		const vapidKeys = await client.vapidKeys?.findFirst?.({
+			select: { encryptedPrivateKey: true, privateKeyIv: true },
+		});
+		if (vapidKeys?.encryptedPrivateKey != null || vapidKeys?.privateKeyIv != null) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+async function targetHasOmittedOidcProvider(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const provider = (prisma as unknown as Record<string, { count?: () => Promise<number> }>)
+		.oIDCProvider;
+	return provider?.count ? (await provider.count()) > 0 : false;
+}
+
+async function targetHasActiveCleanupCoordination(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	missingFields: readonly string[],
+): Promise<boolean> {
+	const client = prisma as unknown as Record<
+		string,
+		{ findMany?: (args: unknown) => Promise<unknown[]> }
+	>;
+	const approval = client.libraryCleanupApproval;
+	const scan = client.libraryCleanupMediaServerScan;
+	let activeScans: Array<Record<string, unknown>> = [];
+
+	if (missingFields.includes("libraryCleanupMediaServerScan") && scan?.findMany) {
+		activeScans = (await scan.findMany({
+			where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+			select: { id: true, approvalId: true },
+		})) as Array<Record<string, unknown>>;
+		if (activeScans.length > 0) return true;
+	}
+
+	if (!missingFields.includes("libraryCleanupApproval") || !approval?.findMany) return false;
+	const activeApprovals = await approval.findMany({
+		where: activeCleanupApprovalWhere(),
+		select: { id: true },
+	});
+	if (activeApprovals.length > 0) return true;
+
+	if (!scan?.findMany) return false;
+	activeScans = (await scan.findMany({
+		where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+		select: { approvalId: true },
+	})) as Array<Record<string, unknown>>;
+	const approvalIds = activeScans
+		.map((row) => row.approvalId)
+		.filter((id): id is string => typeof id === "string" && id.length > 0);
+	if (approvalIds.length === 0) return false;
+	const parentApprovals = await approval.findMany({
+		where: { id: { in: [...new Set(approvalIds)] } },
+		select: { id: true },
+	});
+	return parentApprovals.length > 0;
+}
+
+async function targetHasActiveNamingRecovery(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const model = (
+		prisma as unknown as Record<string, { findMany?: (args: unknown) => Promise<unknown[]> }>
+	).namingDeployHistory;
+	if (!model?.findMany) return false;
+	const rows = await model.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+		select: { id: true },
+	});
+	return rows.length > 0;
+}
+
+/**
+ * Reject incomplete legacy payloads before restore mutation. Singleton rows
+ * that do not carry secrets may be preserved, but omitted ciphertext must not
+ * survive replacement of the installation encryption key.
+ */
+export async function assertRestoreCompatibility(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	data: BackupData["data"],
+): Promise<void> {
+	const record = data as Record<string, unknown>;
+	const missingFields = LEGACY_RELATIONAL_CONFIG_FIELDS.filter(
+		(field) => !Array.isArray(record[field]),
+	);
+	if (missingFields.length > 0 && (await targetHasDurableConfig(prisma, missingFields))) {
+		throw new BackupCompatibilityError();
+	}
+	if (await targetHasUncoveredSingletonSecretState(prisma, data)) {
+		throw new BackupCompatibilityError();
+	}
+	if (!Array.isArray(record.oidcProviders) && (await targetHasOmittedOidcProvider(prisma))) {
+		throw new BackupCompatibilityError();
+	}
+	if (
+		missingFields.some(
+			(field) => field === "libraryCleanupApproval" || field === "libraryCleanupMediaServerScan",
+		) &&
+		(await targetHasActiveCleanupCoordination(prisma, missingFields))
+	) {
+		throw new BackupCompatibilityError();
+	}
+	if (!Array.isArray(record.namingDeployHistory) && (await targetHasActiveNamingRecovery(prisma))) {
+		throw new BackupCompatibilityError();
+	}
+	try {
+		await validateCurrentCoordinationPreserved(prisma, data);
+	} catch (error) {
+		if (error instanceof CoordinationMismatchError) {
+			throw new BackupCompatibilityError(error);
+		}
+		throw error;
+	}
+}
+
 type CoordinationKind = "rollback" | "undeploy";
 type CoordinationRow = Record<string, unknown> & { id: string };
+
+class CoordinationMismatchError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CoordinationMismatchError";
+	}
+}
 
 function isAuditOnlyUncertainSync(record: Record<string, unknown>): boolean {
 	return (
@@ -63,6 +250,7 @@ const COORDINATION_FIELDS: Record<CoordinationKind, readonly string[]> = {
 		"rollbackAttemptedAt",
 		"rollbackProgress",
 		"backupId",
+		"startedAt",
 	],
 	undeploy: [
 		"userId",
@@ -77,8 +265,107 @@ const COORDINATION_FIELDS: Record<CoordinationKind, readonly string[]> = {
 		"undeployAttemptedAt",
 		"undeployProgress",
 		"backupId",
+		"deployedAt",
 	],
 };
+
+const SCORE_INTENT_FIELDS = [
+	"userId",
+	"instanceId",
+	"qualityProfileId",
+	"customFormatId",
+	"score",
+	"status",
+	"intentOperation",
+	"intendedScore",
+	"connectionGeneration",
+	"connectionStateToken",
+	"createdAt",
+	"updatedAt",
+] as const;
+
+const ACTIVE_NAMING_FIELDS = [
+	"instanceId",
+	"userId",
+	"status",
+	"selectedPresets",
+	"resolvedPayload",
+	"deployedHash",
+	"previousConfig",
+	"changedFields",
+	"totalFields",
+	"errorMessage",
+	"rolledBack",
+	"rolledBackAt",
+	"deployedAt",
+] as const;
+
+const ACTIVE_APPROVAL_FIELDS = [
+	"configId",
+	"instanceId",
+	"arrItemId",
+	"itemType",
+	"targetScope",
+	"arrEpisodeId",
+	"episodeFileId",
+	"seasonNumber",
+	"episodeNumber",
+	"episodeTitle",
+	"title",
+	"matchedRuleId",
+	"matchedRuleName",
+	"reason",
+	"action",
+	"scanMediaServerAfterDelete",
+	"sizeOnDisk",
+	"year",
+	"rating",
+	"status",
+	"executionToken",
+	"executionAuditCorrelationId",
+	"reconciledWithoutMutation",
+	"safetySnapshot",
+	"lastExecutionError",
+	"reviewedAt",
+	"executedAt",
+	"expiresAt",
+	"createdAt",
+] as const;
+
+const ACTIVE_SCAN_FIELDS = [
+	"approvalId",
+	"instanceId",
+	"service",
+	"serverIdentity",
+	"mediaType",
+	"plannedSectionIds",
+	"targetKey",
+	"status",
+	"executionToken",
+	"attemptCount",
+	"completedSectionIds",
+	"lastError",
+	"nextAttemptAt",
+	"requestStartedAt",
+	"triggeredAt",
+	"createdAt",
+	"updatedAt",
+] as const;
+
+const COORDINATION_DATE_FIELDS = new Set([
+	"startedAt",
+	"rollbackAttemptedAt",
+	"undeployAttemptedAt",
+	"deployedAt",
+	"createdAt",
+	"updatedAt",
+	"reviewedAt",
+	"executedAt",
+	"expiresAt",
+	"nextAttemptAt",
+	"requestStartedAt",
+	"triggeredAt",
+]);
 
 function recordsById(value: unknown): Map<string, CoordinationRow> {
 	const records = new Map<string, CoordinationRow>();
@@ -105,33 +392,45 @@ function assertCurrentUndeployFallbackPreserved(
 		return;
 	}
 	if (typeof current.templateId !== "string" || current.templateId.length === 0) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current nonterminal coordination row ${current.id} has no undeploy template authority`,
 		);
 	}
 	const currentTemplate = current.template;
 	if (typeof currentTemplate !== "object" || currentTemplate === null) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current undeploy fallback template ${current.templateId} is missing from the database`,
 		);
 	}
 	const incomingTemplate = incomingTemplates.get(current.templateId);
 	if (!incomingTemplate) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current undeploy fallback template ${current.templateId} is missing from incoming data`,
 		);
 	}
 	for (const field of ["userId", "serviceType", "configData"] as const) {
 		if (incomingTemplate[field] !== (currentTemplate as Record<string, unknown>)[field]) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current undeploy fallback template ${current.templateId} changed ${field}`,
 			);
 		}
 	}
 }
 
-function comparableCoordinationValue(value: unknown): unknown {
-	return value instanceof Date ? value.toISOString() : value;
+function comparableCoordinationValue(value: unknown, field?: string): unknown {
+	if (field === "sizeOnDisk" && (typeof value === "bigint" || typeof value === "string")) {
+		try {
+			return BigInt(value).toString();
+		} catch {
+			return value;
+		}
+	}
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === "string" && field && COORDINATION_DATE_FIELDS.has(field)) {
+		const parsed = new Date(value);
+		if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+	}
+	return value;
 }
 
 function assertCurrentRowPreserved(
@@ -141,28 +440,67 @@ function assertCurrentRowPreserved(
 ): void {
 	const incoming = incomingRows.get(current.id);
 	if (!incoming) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current nonterminal coordination row ${current.id} is missing from incoming data`,
 		);
 	}
 
 	for (const field of COORDINATION_FIELDS[kind]) {
 		if (
-			comparableCoordinationValue(incoming[field]) !== comparableCoordinationValue(current[field])
+			comparableCoordinationValue(incoming[field], field) !==
+			comparableCoordinationValue(current[field], field)
 		) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current nonterminal coordination row ${current.id} changed ${field}`,
 			);
 		}
 	}
 }
 
+function assertCurrentSpecialRowPreserved(
+	label: string,
+	current: CoordinationRow,
+	incomingRows: Map<string, CoordinationRow>,
+	fields: readonly string[],
+): void {
+	const incoming = incomingRows.get(current.id);
+	if (!incoming) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current ${label} ${current.id} is missing from incoming data`,
+		);
+	}
+	for (const field of fields) {
+		if (
+			comparableCoordinationValue(incoming[field], field) !==
+			comparableCoordinationValue(current[field], field)
+		) {
+			throw new CoordinationMismatchError(
+				`Cannot restore backup: current ${label} ${current.id} changed ${field}`,
+			);
+		}
+	}
+}
+
 async function validateCurrentCoordinationPreserved(
-	tx: Prisma.TransactionClient,
+	tx: Prisma.TransactionClient | PrismaClient,
 	data: BackupData["data"],
 ): Promise<void> {
+	const db = tx as Prisma.TransactionClient;
+	const optionalModels = tx as unknown as Record<
+		string,
+		{ findMany?: (args: unknown) => Promise<unknown[]> }
+	>;
+	if (
+		!optionalModels.trashSyncHistory?.findMany ||
+		!optionalModels.templateDeploymentHistory?.findMany ||
+		!optionalModels.instanceQualityProfileOverride?.findMany ||
+		!optionalModels.namingDeployHistory?.findMany ||
+		!optionalModels.trashBackup?.findMany
+	) {
+		return;
+	}
 	const currentRollbackRows = (
-		await tx.trashSyncHistory.findMany({
+		await db.trashSyncHistory.findMany({
 			where: {
 				OR: [
 					{ rollbackStatus: { not: "COMPLETED" } },
@@ -173,7 +511,7 @@ async function validateCurrentCoordinationPreserved(
 		})
 	).filter(shouldPreserveSyncHistory) as CoordinationRow[];
 	const currentUndeployRows = (
-		await tx.templateDeploymentHistory.findMany({
+		await db.templateDeploymentHistory.findMany({
 			where: {
 				OR: [
 					{ undeployStatus: { not: "COMPLETED" } },
@@ -187,9 +525,42 @@ async function validateCurrentCoordinationPreserved(
 			},
 		})
 	).filter(isNonterminalUndeploy) as CoordinationRow[];
+	const currentScoreIntents = (await db.instanceQualityProfileOverride.findMany({
+		where: { status: { in: ["PENDING", "UNCERTAIN"] } },
+	})) as CoordinationRow[];
+	const currentActiveNaming = (await db.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	})) as CoordinationRow[];
+	const currentActiveApprovals = optionalModels.libraryCleanupApproval?.findMany
+		? ((await optionalModels.libraryCleanupApproval.findMany({
+				where: activeCleanupApprovalWhere(),
+			})) as CoordinationRow[])
+		: [];
+	const currentActiveScans = optionalModels.libraryCleanupMediaServerScan?.findMany
+		? ((await optionalModels.libraryCleanupMediaServerScan.findMany({
+				where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+			})) as CoordinationRow[])
+		: [];
+	const scanApprovalIds = [
+		...new Set(
+			currentActiveScans
+				.map((row) => row.approvalId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const currentScanParentApprovals =
+		scanApprovalIds.length > 0 && optionalModels.libraryCleanupApproval?.findMany
+			? ((await optionalModels.libraryCleanupApproval.findMany({
+					where: { id: { in: scanApprovalIds } },
+				})) as CoordinationRow[])
+			: [];
 	const incomingRollbackRows = recordsById(data.trashSyncHistory);
 	const incomingUndeployRows = recordsById(data.templateDeploymentHistory);
 	const incomingTemplates = recordsById(data.trashTemplates);
+	const incomingScoreIntents = recordsById(data.instanceQualityProfileOverrides);
+	const incomingActiveNaming = recordsById(data.namingDeployHistory);
+	const incomingApprovals = recordsById(data.libraryCleanupApproval);
+	const incomingScans = recordsById(data.libraryCleanupMediaServerScan);
 
 	for (const row of currentRollbackRows) {
 		assertCurrentRowPreserved("rollback", row, incomingRollbackRows);
@@ -197,6 +568,38 @@ async function validateCurrentCoordinationPreserved(
 	for (const row of currentUndeployRows) {
 		assertCurrentRowPreserved("undeploy", row, incomingUndeployRows);
 		assertCurrentUndeployFallbackPreserved(row, incomingTemplates);
+	}
+	for (const row of currentScoreIntents) {
+		assertCurrentSpecialRowPreserved(
+			"pending or uncertain quality-score intent",
+			row,
+			incomingScoreIntents,
+			SCORE_INTENT_FIELDS,
+		);
+	}
+	for (const row of currentActiveNaming) {
+		assertCurrentSpecialRowPreserved(
+			"active naming recovery",
+			row,
+			incomingActiveNaming,
+			ACTIVE_NAMING_FIELDS,
+		);
+	}
+	for (const row of [...currentActiveApprovals, ...currentScanParentApprovals]) {
+		assertCurrentSpecialRowPreserved(
+			"active cleanup approval",
+			row,
+			incomingApprovals,
+			ACTIVE_APPROVAL_FIELDS,
+		);
+	}
+	for (const row of currentActiveScans) {
+		assertCurrentSpecialRowPreserved(
+			"active media-server scan",
+			row,
+			incomingScans,
+			ACTIVE_SCAN_FIELDS,
+		);
 	}
 
 	const currentRecoveryRows = [
@@ -211,7 +614,7 @@ async function validateCurrentCoordinationPreserved(
 	];
 	const requiredSnapshotIds = currentRecoveryRows.map((row) => {
 		if (typeof row.backupId !== "string" || row.backupId.length === 0) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current nonterminal coordination row ${row.id} has no required recovery snapshot reference`,
 			);
 		}
@@ -220,25 +623,25 @@ async function validateCurrentCoordinationPreserved(
 	if (requiredSnapshotIds.length === 0) return;
 
 	const currentSnapshots = recordsById(
-		await tx.trashBackup.findMany({ where: { id: { in: [...new Set(requiredSnapshotIds)] } } }),
+		await db.trashBackup.findMany({ where: { id: { in: [...new Set(requiredSnapshotIds)] } } }),
 	);
 	const incomingSnapshots = recordsById(data.trashBackups);
 	for (const snapshotId of new Set(requiredSnapshotIds)) {
 		const current = currentSnapshots.get(snapshotId);
 		if (!current) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current recovery snapshot ${snapshotId} is missing from the database`,
 			);
 		}
 		const incoming = incomingSnapshots.get(snapshotId);
 		if (!incoming) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current recovery snapshot ${snapshotId} is missing from incoming data`,
 			);
 		}
 		for (const field of ["userId", "instanceId", "backupData"] as const) {
 			if (incoming[field] !== current[field]) {
-				throw new Error(
+				throw new CoordinationMismatchError(
 					`Cannot restore backup: current recovery snapshot ${snapshotId} changed ${field}`,
 				);
 			}
@@ -283,6 +686,8 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 
 	// System settings (singleton-ish)
 	const systemSettings = await prisma.systemSettings.findMany();
+	const backupSettings = await prisma.backupSettings.findMany();
+	const vapidKeys = await prisma.vapidKeys.findMany();
 
 	// TRaSH Guides configuration (always full — these are config, not history)
 	const trashTemplates = await prisma.trashTemplate.findMany();
@@ -292,6 +697,49 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 	const instanceQualityProfileOverrides = await prisma.instanceQualityProfileOverride.findMany();
 	const standaloneCFDeployments = await prisma.standaloneCFDeployment.findMany();
 	const qualitySizeMappings = await prisma.qualitySizeMapping.findMany();
+
+	// Durable user and instance configuration (always full, including empty
+	// arrays so v1.2 distinguishes complete coverage from legacy omission).
+	const notificationChannel = await prisma.notificationChannel.findMany();
+	const notificationSubscription = await prisma.notificationSubscription.findMany();
+	const notificationRule = await prisma.notificationRule.findMany();
+	const notificationAggregationConfig = await prisma.notificationAggregationConfig.findMany();
+	const autoTagRule = await prisma.autoTagRule.findMany();
+	const labelSyncRule = await prisma.labelSyncRule.findMany();
+	const queueCleanerConfig = await prisma.queueCleanerConfig.findMany();
+	const libraryCleanupConfig = await prisma.libraryCleanupConfig.findMany();
+	const libraryCleanupRule = await prisma.libraryCleanupRule.findMany();
+	const namingConfig = await prisma.namingConfig.findMany();
+	const userCustomFormat = await prisma.userCustomFormat.findMany();
+	const activeCleanupApprovals = await prisma.libraryCleanupApproval.findMany({
+		where: activeCleanupApprovalWhere(),
+	});
+	const activeCleanupScans = await prisma.libraryCleanupMediaServerScan.findMany({
+		where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+	});
+	const cleanupScanApprovalIds = [
+		...new Set(
+			activeCleanupScans
+				.map((row) => row.approvalId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const cleanupScanParentApprovals =
+		cleanupScanApprovalIds.length > 0
+			? await prisma.libraryCleanupApproval.findMany({
+					where: { id: { in: cleanupScanApprovalIds } },
+				})
+			: [];
+	const serializeCleanupApproval = (row: (typeof activeCleanupApprovals)[number]) => ({
+		...row,
+		sizeOnDisk: row.sizeOnDisk.toString(),
+		terminalAuditRecordedAt: null,
+		terminalAuditRecoveryAttemptedAt: null,
+	});
+	const libraryCleanupApproval = mergeRowsById(
+		activeCleanupApprovals.map(serializeCleanupApproval),
+		cleanupScanParentApprovals.map(serializeCleanupApproval),
+	);
 
 	// TRaSH Guides history/audit — operational, capped or skipped.
 	// When capped, log a warn so operators can correlate restore-time gaps to
@@ -335,6 +783,9 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 			},
 		})
 	).filter(isNonterminalUndeploy);
+	const activeNamingDeployHistory = await prisma.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	});
 
 	const cappedTrashSyncHistory = skipHistory
 		? []
@@ -356,6 +807,14 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		cappedTemplateDeploymentHistory,
 		nonterminalUndeployHistory,
 	);
+	const cappedNamingDeployHistory = skipHistory
+		? []
+		: await fetchCappedHistory(
+				"namingDeployHistory",
+				() => prisma.namingDeployHistory.count(),
+				(take) => prisma.namingDeployHistory.findMany({ take, orderBy: { deployedAt: "desc" } }),
+			);
+	const namingDeployHistory = mergeRowsById(cappedNamingDeployHistory, activeNamingDeployHistory);
 
 	// Hunting feature: configs are config (always full); logs/history are operational
 	const huntConfigs = await prisma.huntConfig.findMany();
@@ -430,6 +889,8 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		webAuthnCredentials,
 		// System settings
 		systemSettings,
+		backupSettings,
+		vapidKeys,
 		// TRaSH Guides configuration
 		trashTemplates,
 		trashSettings,
@@ -442,12 +903,27 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		// TRaSH Guides history/audit
 		trashSyncHistory,
 		templateDeploymentHistory,
+		namingDeployHistory,
 		// TRaSH instance backups (optional)
 		trashBackups,
 		// Hunting feature
 		huntConfigs,
 		huntLogs,
 		huntSearchHistory,
+		// Durable configuration
+		notificationChannel,
+		notificationSubscription,
+		notificationRule,
+		notificationAggregationConfig,
+		autoTagRule,
+		labelSyncRule,
+		queueCleanerConfig,
+		libraryCleanupConfig,
+		libraryCleanupRule,
+		namingConfig,
+		userCustomFormat,
+		libraryCleanupApproval,
+		libraryCleanupMediaServerScan: activeCleanupScans,
 	};
 }
 
@@ -462,7 +938,10 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 export async function restoreDatabase(prisma: PrismaClient, data: BackupData["data"]) {
 	// Use a transaction to ensure atomicity
 	await prisma.$transaction(async (tx) => {
-		await validateCurrentCoordinationPreserved(tx, data);
+		// Recheck inside the transaction immediately before any delete. The
+		// service-level preflight closes the filesystem TOCTOU window; this check
+		// protects direct callers and races between preflight and transaction.
+		await assertRestoreCompatibility(tx, data);
 
 		// =================================================================
 		// DELETE all existing data (in reverse order of dependencies)
@@ -476,6 +955,7 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		// TRaSH history/audit (depends on templates, instances, backups)
 		await tx.templateDeploymentHistory.deleteMany();
 		await tx.trashSyncHistory.deleteMany();
+		await tx.namingDeployHistory.deleteMany();
 
 		// TRaSH configuration (depends on templates, instances)
 		await tx.qualitySizeMapping.deleteMany();
@@ -487,8 +967,35 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		await tx.trashTemplate.deleteMany();
 		await tx.trashSettings.deleteMany();
 
-		// System settings (singleton)
-		await tx.systemSettings.deleteMany();
+		// Durable configuration, children before parents.
+		await tx.libraryCleanupMediaServerScan.deleteMany();
+		await tx.libraryCleanupApproval.deleteMany();
+		await tx.notificationSubscription.deleteMany();
+		await tx.libraryCleanupRule.deleteMany();
+		await tx.notificationChannel.deleteMany();
+		await tx.notificationRule.deleteMany();
+		await tx.notificationAggregationConfig.deleteMany();
+		await tx.autoTagRule.deleteMany();
+		await tx.labelSyncRule.deleteMany();
+		await tx.queueCleanerConfig.deleteMany();
+		await tx.libraryCleanupConfig.deleteMany();
+		await tx.namingConfig.deleteMany();
+		await tx.userCustomFormat.deleteMany();
+
+		// These singleton rows are not removed by user/instance cascades. Each
+		// incoming array independently authorizes replacement of its own model.
+		if (Array.isArray(data.backupSettings)) {
+			await tx.backupSettings.deleteMany();
+		}
+		if (Array.isArray(data.vapidKeys)) {
+			await tx.vapidKeys.deleteMany();
+		}
+
+		// System settings are independent of user/instance cascades. Preserve
+		// them for legacy files that predate this payload coverage.
+		if (Array.isArray(data.systemSettings)) {
+			await tx.systemSettings.deleteMany();
+		}
 
 		// Core tables (existing)
 		await tx.serviceInstanceTag.deleteMany();
@@ -496,7 +1003,11 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		await tx.serviceInstance.deleteMany();
 		await tx.webAuthnCredential.deleteMany();
 		await tx.oIDCAccount.deleteMany();
-		await tx.oIDCProvider.deleteMany();
+		// OIDC providers are independent of the user/instance cascades too.
+		// Legacy files may omit them, so do not turn omission into deletion.
+		if (Array.isArray(data.oidcProviders)) {
+			await tx.oIDCProvider.deleteMany();
+		}
 		await tx.session.deleteMany();
 		await tx.user.deleteMany();
 
@@ -577,6 +1088,18 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			await tx.systemSettings.create({
 				data: { ...settingsData, id: 1 },
 			});
+		}
+
+		if (Array.isArray(data.backupSettings) && data.backupSettings.length > 0) {
+			validateRecords(data.backupSettings, "backupSettings", ["id"]);
+			const settings = data.backupSettings[0] as Prisma.BackupSettingsCreateInput;
+			await tx.backupSettings.create({ data: { ...settings, id: 1 } });
+		}
+
+		if (Array.isArray(data.vapidKeys) && data.vapidKeys.length > 0) {
+			validateRecords(data.vapidKeys, "vapidKeys", ["id", "publicKey"]);
+			const keys = data.vapidKeys[0] as Prisma.VapidKeysCreateInput;
+			await tx.vapidKeys.create({ data: { ...keys, id: 1 } });
 		}
 
 		// --- TRaSH Guides configuration ---
@@ -672,6 +1195,18 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			});
 		}
 
+		if (data.namingDeployHistory && data.namingDeployHistory.length > 0) {
+			validateRecords(data.namingDeployHistory, "namingDeployHistory", [
+				"id",
+				"instanceId",
+				"userId",
+				"status",
+			]);
+			await tx.namingDeployHistory.createMany({
+				data: data.namingDeployHistory as Prisma.NamingDeployHistoryCreateManyInput[],
+			});
+		}
+
 		// --- Hunting feature ---
 
 		if (data.huntConfigs && data.huntConfigs.length > 0) {
@@ -692,6 +1227,115 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			validateRecords(data.huntSearchHistory, "huntSearchHistory", ["id", "configId"]);
 			await tx.huntSearchHistory.createMany({
 				data: data.huntSearchHistory as Prisma.HuntSearchHistoryCreateManyInput[],
+			});
+		}
+
+		// Durable configuration (dependency order).
+		if (data.notificationChannel && data.notificationChannel.length > 0) {
+			validateRecords(data.notificationChannel, "notificationChannel", ["id", "userId"]);
+			await tx.notificationChannel.createMany({
+				data: data.notificationChannel as Prisma.NotificationChannelCreateManyInput[],
+			});
+		}
+		if (data.notificationSubscription && data.notificationSubscription.length > 0) {
+			validateRecords(data.notificationSubscription, "notificationSubscription", [
+				"channelId",
+				"eventType",
+			]);
+			await tx.notificationSubscription.createMany({
+				data: data.notificationSubscription as Prisma.NotificationSubscriptionCreateManyInput[],
+			});
+		}
+		if (data.notificationRule && data.notificationRule.length > 0) {
+			validateRecords(data.notificationRule, "notificationRule", ["id", "userId"]);
+			await tx.notificationRule.createMany({
+				data: data.notificationRule as Prisma.NotificationRuleCreateManyInput[],
+			});
+		}
+		if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
+			validateRecords(data.notificationAggregationConfig, "notificationAggregationConfig", [
+				"id",
+				"userId",
+			]);
+			await tx.notificationAggregationConfig.createMany({
+				data: data.notificationAggregationConfig as Prisma.NotificationAggregationConfigCreateManyInput[],
+			});
+		}
+		if (data.autoTagRule && data.autoTagRule.length > 0) {
+			validateRecords(data.autoTagRule, "autoTagRule", ["id", "userId"]);
+			await tx.autoTagRule.createMany({
+				data: data.autoTagRule as Prisma.AutoTagRuleCreateManyInput[],
+			});
+		}
+		if (data.labelSyncRule && data.labelSyncRule.length > 0) {
+			validateRecords(data.labelSyncRule, "labelSyncRule", ["id", "userId"]);
+			await tx.labelSyncRule.createMany({
+				data: data.labelSyncRule as Prisma.LabelSyncRuleCreateManyInput[],
+			});
+		}
+		if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
+			validateRecords(data.queueCleanerConfig, "queueCleanerConfig", ["id", "instanceId"]);
+			await tx.queueCleanerConfig.createMany({
+				data: data.queueCleanerConfig as Prisma.QueueCleanerConfigCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
+			validateRecords(data.libraryCleanupConfig, "libraryCleanupConfig", ["id", "userId"]);
+			await tx.libraryCleanupConfig.createMany({
+				data: data.libraryCleanupConfig as Prisma.LibraryCleanupConfigCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
+			validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
+			await tx.libraryCleanupRule.createMany({
+				data: data.libraryCleanupRule as Prisma.LibraryCleanupRuleCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupApproval && data.libraryCleanupApproval.length > 0) {
+			validateRecords(data.libraryCleanupApproval, "libraryCleanupApproval", [
+				"id",
+				"configId",
+				"instanceId",
+				"status",
+				"sizeOnDisk",
+				"expiresAt",
+			]);
+			await tx.libraryCleanupApproval.createMany({
+				data: data.libraryCleanupApproval.map((row) => ({
+					...(row as Prisma.LibraryCleanupApprovalCreateManyInput),
+					terminalAuditRecordedAt: null,
+					terminalAuditRecoveryAttemptedAt: null,
+					sizeOnDisk:
+						typeof (row as Record<string, unknown>).sizeOnDisk === "string"
+							? BigInt((row as Record<string, unknown>).sizeOnDisk as string)
+							: (row as Prisma.LibraryCleanupApprovalCreateManyInput).sizeOnDisk,
+				})) as Prisma.LibraryCleanupApprovalCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupMediaServerScan && data.libraryCleanupMediaServerScan.length > 0) {
+			validateRecords(data.libraryCleanupMediaServerScan, "libraryCleanupMediaServerScan", [
+				"id",
+				"approvalId",
+				"instanceId",
+				"service",
+				"mediaType",
+				"targetKey",
+				"status",
+			]);
+			await tx.libraryCleanupMediaServerScan.createMany({
+				data: data.libraryCleanupMediaServerScan as Prisma.LibraryCleanupMediaServerScanCreateManyInput[],
+			});
+		}
+		if (data.namingConfig && data.namingConfig.length > 0) {
+			validateRecords(data.namingConfig, "namingConfig", ["id", "instanceId", "userId"]);
+			await tx.namingConfig.createMany({
+				data: data.namingConfig as Prisma.NamingConfigCreateManyInput[],
+			});
+		}
+		if (data.userCustomFormat && data.userCustomFormat.length > 0) {
+			validateRecords(data.userCustomFormat, "userCustomFormat", ["id", "userId"]);
+			await tx.userCustomFormat.createMany({
+				data: data.userCustomFormat as Prisma.UserCustomFormatCreateManyInput[],
 			});
 		}
 	});

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -310,6 +310,9 @@ const ACTIVE_NAMING_INSTANCE_FIELDS = [
 	"httpAuthEncryptionIv",
 ] as const;
 
+const ACTIVE_NAMING_EXPORT_CHANGED =
+	"Cannot create backup: active naming recovery changed during export; retry";
+
 const ACTIVE_APPROVAL_FIELDS = [
 	"configId",
 	"instanceId",
@@ -491,6 +494,13 @@ function assertCurrentSpecialRowPreserved(
 	}
 }
 
+function namingInstanceFieldMatches(field: string, left: unknown, right: unknown): boolean {
+	return field === "baseUrl" && typeof left === "string" && typeof right === "string"
+		? `${left.replace(/\/$/, "")}/api/v3/config/naming` ===
+				`${right.replace(/\/$/, "")}/api/v3/config/naming`
+		: left === right;
+}
+
 function assertCurrentNamingInstancePreserved(
 	history: CoordinationRow,
 	currentInstances: Map<string, CoordinationRow>,
@@ -516,15 +526,51 @@ function assertCurrentNamingInstancePreserved(
 	for (const field of ACTIVE_NAMING_INSTANCE_FIELDS) {
 		const incomingValue = incomingInstance[field];
 		const currentValue = currentInstance[field];
-		const matches =
-			field === "baseUrl" && typeof incomingValue === "string" && typeof currentValue === "string"
-				? `${incomingValue.replace(/\/$/, "")}/api/v3/config/naming` ===
-					`${currentValue.replace(/\/$/, "")}/api/v3/config/naming`
-				: incomingValue === currentValue;
-		if (!matches) {
+		if (!namingInstanceFieldMatches(field, incomingValue, currentValue)) {
 			throw new CoordinationMismatchError(
 				`Cannot restore backup: current active naming recovery ${history.id} changed service instance ${field}`,
 			);
+		}
+	}
+}
+
+function assertActiveNamingExportStable(
+	capturedHistory: CoordinationRow[],
+	latestHistory: CoordinationRow[],
+	capturedInstances: CoordinationRow[],
+	latestInstances: CoordinationRow[],
+): void {
+	const capturedHistoryById = recordsById(capturedHistory);
+	const latestHistoryById = recordsById(latestHistory);
+	if (capturedHistoryById.size !== latestHistoryById.size) {
+		throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+	}
+	for (const captured of capturedHistoryById.values()) {
+		const latest = latestHistoryById.get(captured.id);
+		if (!latest) throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		for (const field of ACTIVE_NAMING_FIELDS) {
+			if (
+				comparableCoordinationValue(captured[field], field) !==
+				comparableCoordinationValue(latest[field], field)
+			) {
+				throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+			}
+		}
+	}
+
+	const capturedInstancesById = recordsById(capturedInstances);
+	const latestInstancesById = recordsById(latestInstances);
+	for (const history of capturedHistoryById.values()) {
+		if (typeof history.instanceId !== "string" || history.instanceId.length === 0) {
+			throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		}
+		const captured = capturedInstancesById.get(history.instanceId);
+		const latest = latestInstancesById.get(history.instanceId);
+		if (!captured || !latest) throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		for (const field of ACTIVE_NAMING_INSTANCE_FIELDS) {
+			if (!namingInstanceFieldMatches(field, captured[field], latest[field])) {
+				throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+			}
 		}
 	}
 }
@@ -935,6 +981,32 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		});
 		trashBackups = mergeRowsById(trashBackups, requiredSnapshots);
 	}
+
+	// Active naming rows carry rollback authority. Re-read their recovery
+	// fields and referenced connection authority at the publication boundary so
+	// a concurrent change cannot produce a backup assembled from two states.
+	const latestActiveNamingDeployHistory = await prisma.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	});
+	const activeNamingInstanceIds = [
+		...new Set(
+			activeNamingDeployHistory
+				.map((row) => row.instanceId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const latestActiveNamingInstances =
+		activeNamingInstanceIds.length > 0
+			? await prisma.serviceInstance.findMany({
+					where: { id: { in: activeNamingInstanceIds } },
+				})
+			: [];
+	assertActiveNamingExportStable(
+		activeNamingDeployHistory as CoordinationRow[],
+		latestActiveNamingDeployHistory as CoordinationRow[],
+		serviceInstances as CoordinationRow[],
+		latestActiveNamingInstances as CoordinationRow[],
+	);
 
 	validateCoordinationEvidence({
 		serviceInstances,

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -33,7 +33,7 @@ import { withCleanupMaintenanceGuard } from "../library-cleanup/cleanup-maintena
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { decryptBackupData, encryptBackupData } from "./backup-crypto.js";
-import { exportDatabase, restoreDatabase } from "./backup-database.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "./backup-database.js";
 import {
 	ensureBackupsDirectory,
 	generateBackupId,
@@ -433,9 +433,15 @@ export class BackupService {
 				{
 					backupType: type,
 					skippedTables: ["huntLog", "huntSearchHistory"],
-					preservedTables: ["trashSyncHistory", "templateDeploymentHistory", "trashBackup"],
+					preservedTables: [
+						"trashSyncHistory",
+						"templateDeploymentHistory",
+						"trashBackup",
+						"libraryCleanupApproval",
+						"libraryCleanupMediaServerScan",
+					],
 				},
-				"Backup excluded disposable operational history while preserving nonterminal TRaSH coordination evidence",
+				"Backup excluded disposable operational history while preserving nonterminal safety coordination evidence",
 			);
 		}
 
@@ -775,6 +781,11 @@ export class BackupService {
 		let secretsBackedUp = false;
 
 		try {
+			// Compatibility must be checked before creating the secrets backup or
+			// writing replacement secrets. restoreDatabase repeats this check inside
+			// its transaction immediately before deletes.
+			await assertRestoreCompatibility(this.prisma, backup.data);
+
 			// Phase 1: Backup current secrets before making any changes
 			try {
 				const currentSecrets = await fs.readFile(this.secretsPath, "utf-8");

--- a/apps/api/src/lib/backup/backup-validation.ts
+++ b/apps/api/src/lib/backup/backup-validation.ts
@@ -8,10 +8,85 @@
 import type { BackupData } from "@arr/shared";
 import type { EncryptedBackupEnvelope } from "./backup-crypto.js";
 
-export const BACKUP_VERSION = "1.1";
+export const BACKUP_VERSION = "1.2";
 export const LEGACY_BACKUP_VERSION = "1.0";
+export const PRE_CONFIG_BACKUP_VERSION = "1.1";
 
-const SUPPORTED_BACKUP_VERSIONS = new Set([LEGACY_BACKUP_VERSION, BACKUP_VERSION]);
+const SUPPORTED_BACKUP_VERSIONS = new Set([
+	LEGACY_BACKUP_VERSION,
+	PRE_CONFIG_BACKUP_VERSION,
+	BACKUP_VERSION,
+]);
+
+/** Durable configuration collections added to the v1.2 backup contract. */
+export const DURABLE_CONFIG_PAYLOAD_FIELDS = [
+	"backupSettings",
+	"vapidKeys",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+	"namingDeployHistory",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+] as const;
+
+/** Every optional array emitted by exportDatabase and required by v1.2. */
+export const COMPLETE_V1_2_PAYLOAD_FIELDS = [
+	"oidcProviders",
+	"systemSettings",
+	"trashTemplates",
+	"trashSettings",
+	"trashSyncSchedules",
+	"templateQualityProfileMappings",
+	"instanceQualityProfileOverrides",
+	"standaloneCFDeployments",
+	"qualitySizeMappings",
+	"trashSyncHistory",
+	"templateDeploymentHistory",
+	"trashBackups",
+	"huntConfigs",
+	"huntLogs",
+	"huntSearchHistory",
+	...DURABLE_CONFIG_PAYLOAD_FIELDS,
+] as const;
+
+/** Explicit payload-to-Prisma mapping for relational legacy coverage checks. */
+export const LEGACY_RELATIONAL_CONFIG_DELEGATES = [
+	["trashTemplates", "trashTemplate"],
+	["trashSettings", "trashSettings"],
+	["trashSyncSchedules", "trashSyncSchedule"],
+	["templateQualityProfileMappings", "templateQualityProfileMapping"],
+	["instanceQualityProfileOverrides", "instanceQualityProfileOverride"],
+	["standaloneCFDeployments", "standaloneCFDeployment"],
+	["qualitySizeMappings", "qualitySizeMapping"],
+	["huntConfigs", "huntConfig"],
+	["notificationChannel", "notificationChannel"],
+	["notificationSubscription", "notificationSubscription"],
+	["notificationRule", "notificationRule"],
+	["notificationAggregationConfig", "notificationAggregationConfig"],
+	["autoTagRule", "autoTagRule"],
+	["labelSyncRule", "labelSyncRule"],
+	["queueCleanerConfig", "queueCleanerConfig"],
+	["libraryCleanupConfig", "libraryCleanupConfig"],
+	["libraryCleanupRule", "libraryCleanupRule"],
+	["libraryCleanupApproval", "libraryCleanupApproval"],
+	["libraryCleanupMediaServerScan", "libraryCleanupMediaServerScan"],
+	["namingConfig", "namingConfig"],
+	["userCustomFormat", "userCustomFormat"],
+] as const;
+
+/** Relational durable configuration that legacy files cannot safely replace. */
+export const LEGACY_RELATIONAL_CONFIG_FIELDS = LEGACY_RELATIONAL_CONFIG_DELEGATES.map(
+	([payloadField]) => payloadField,
+);
 
 type CoordinationRecord = Record<string, unknown>;
 
@@ -425,6 +500,8 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 		"huntConfigs",
 		"huntLogs",
 		"huntSearchHistory",
+		// Durable configuration (required in v1.2, optional for legacy files)
+		...DURABLE_CONFIG_PAYLOAD_FIELDS,
 	];
 
 	for (const field of optionalArrayFields) {
@@ -434,6 +511,16 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 	}
 
 	if (b.version === BACKUP_VERSION) {
+		for (const field of COMPLETE_V1_2_PAYLOAD_FIELDS) {
+			if (!Array.isArray(dataRecord[field])) {
+				throw new Error(
+					`Invalid backup format: ${field} is required for version ${BACKUP_VERSION}`,
+				);
+			}
+		}
+	}
+
+	if (b.version === BACKUP_VERSION || b.version === PRE_CONFIG_BACKUP_VERSION) {
 		validateCoordinationEvidence(dataRecord);
 	}
 

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -28,6 +28,24 @@ export class ConflictError extends Error {
 	}
 }
 
+/**
+ * Thrown when a backup does not carry the configuration or recovery coverage
+ * needed to safely replace the current installation.
+ * Maps to a bounded HTTP 409 response without exposing backup contents.
+ */
+export class BackupCompatibilityError extends Error {
+	readonly statusCode = 409;
+	readonly code = "BACKUP_COMPATIBILITY_CONFLICT";
+
+	constructor(cause?: unknown) {
+		super(
+			"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		);
+		if (cause !== undefined) this.cause = cause;
+		this.name = "BackupCompatibilityError";
+	}
+}
+
 /** Thrown for application-level validation failures. Maps to HTTP 400. */
 export class AppValidationError extends Error {
 	readonly statusCode = 400;

--- a/apps/api/src/routes/__tests__/backup.test.ts
+++ b/apps/api/src/routes/__tests__/backup.test.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BackupPasswordConfigurationError } from "../../lib/backup/backup-service.js";
+import { BackupCompatibilityError } from "../../lib/errors.js";
 import {
 	withCleanupMaintenanceGuard,
 	withCleanupOperationGuard,
@@ -8,8 +9,9 @@ import {
 import { registerBackupRoutes } from "../backup.js";
 import { registerTestErrorHandler } from "./test-helpers.js";
 
-const { mockCreateBackup } = vi.hoisted(() => ({
+const { mockCreateBackup, mockRestoreBackup } = vi.hoisted(() => ({
 	mockCreateBackup: vi.fn(),
+	mockRestoreBackup: vi.fn(),
 }));
 
 vi.mock("../../lib/backup/backup-service.js", async (importOriginal) => {
@@ -19,6 +21,9 @@ vi.mock("../../lib/backup/backup-service.js", async (importOriginal) => {
 		BackupService: class {
 			createBackup(...args: unknown[]) {
 				return mockCreateBackup(...args);
+			}
+			restoreBackup(...args: unknown[]) {
+				return mockRestoreBackup(...args);
 			}
 		},
 	};
@@ -178,5 +183,36 @@ describe("POST /api/backup/create", () => {
 		expect(response.statusCode).toBe(401);
 		expect(JSON.parse(response.payload)).toEqual({ error: "Authentication required" });
 		expect(mockCreateBackup).not.toHaveBeenCalled();
+	});
+
+	it("returns bounded 409 for an incomplete legacy restore", async () => {
+		mockRestoreBackup.mockRejectedValue(new BackupCompatibilityError());
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore",
+			headers: { "x-test-auth": "1" },
+			payload: { backupData: Buffer.from("legacy-backup").toString("base64") },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(JSON.parse(response.payload)).toEqual({
+			error:
+				"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		});
+	});
+
+	it("preserves the generic 500 mapping for a restore infrastructure failure", async () => {
+		mockRestoreBackup.mockRejectedValue(new Error("database unavailable"));
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore",
+			headers: { "x-test-auth": "1" },
+			payload: { backupData: Buffer.from("current-backup").toString("base64") },
+		});
+
+		expect(response.statusCode).toBe(500);
+		expect(JSON.parse(response.payload)).toEqual({ error: "Failed to restore backup" });
 	});
 });

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -12,6 +12,7 @@ import {
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { BackupPasswordConfigurationError, BackupService } from "../lib/backup/backup-service.js";
+import { BackupCompatibilityError } from "../lib/errors.js";
 import { CleanupMaintenanceConflictError } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
@@ -159,6 +160,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				await app.lifecycle.restart("backup-restore");
 			}
 		} catch (error) {
+			if (error instanceof BackupCompatibilityError) {
+				request.log.warn(
+					{ code: error.code },
+					"Backup restore rejected because configuration or recovery coverage is incomplete",
+				);
+				return reply.status(409).send({ error: error.message });
+			}
+
 			if (error instanceof CleanupMaintenanceConflictError) {
 				request.log.warn({ err: error }, "Backup restore blocked by active cleanup maintenance");
 				return reply.status(409).send({ error: error.message });
@@ -218,6 +227,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					await app.lifecycle.restart("backup-restore");
 				}
 			} catch (error) {
+				if (error instanceof BackupCompatibilityError) {
+					request.log.warn(
+						{ code: error.code },
+						"Backup restore from file rejected because configuration or recovery coverage is incomplete",
+					);
+					return reply.status(409).send({ error: error.message });
+				}
+
 				if (error instanceof CleanupMaintenanceConflictError) {
 					request.log.warn(
 						{ err: error },

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,151 @@
+# Backup inventory
+
+Arr Dashboard backup format **1.2** emits complete, explicit coverage for the
+durable configuration and authentication state needed to recreate an
+installation. Every collection is represented as an array, including an empty
+array. Encrypted values are copied with their ciphertext and IV unchanged.
+
+## What format 1.2 contains
+
+The payload contains all of these arrays:
+
+- Authentication and services: `users`, `sessions`, `serviceInstances`,
+  `serviceTags`, `serviceInstanceTags`, `oidcProviders`, `oidcAccounts`, and
+  `webAuthnCredentials`.
+- Singleton/configuration state: `systemSettings`, `backupSettings`, and
+  `vapidKeys`.
+- TRaSH configuration: `trashTemplates`, `trashSettings`,
+  `trashSyncSchedules`, `templateQualityProfileMappings`,
+  `instanceQualityProfileOverrides`, `standaloneCFDeployments`, and
+  `qualitySizeMappings`.
+- Hunting configuration: `huntConfigs`.
+- Durable feature configuration: `notificationChannel`,
+  `notificationSubscription`, `notificationRule`,
+  `notificationAggregationConfig`, `autoTagRule`, `labelSyncRule`,
+  `queueCleanerConfig`, `libraryCleanupConfig`, `libraryCleanupRule`,
+  `namingConfig`, and `userCustomFormat`.
+- Cleanup coordination: active `libraryCleanupApproval` rows, executed
+  approvals still awaiting terminal audit, and active
+  `libraryCleanupMediaServerScan` rows are included; an active scan also
+  carries its parent approval even when that approval is already executed.
+  Nonportable terminal-audit and recovery-attempt timestamps are reset so the
+  restored scheduler can record fresh audit evidence.
+- Bounded operational history: `trashSyncHistory`,
+  `templateDeploymentHistory`, `namingDeployHistory`, `huntLogs`, and
+  `huntSearchHistory`.
+
+The shared TypeScript shape keeps later-added properties optional so 1.0 and
+1.1 files remain representable. Runtime `validateBackup` is authoritative:
+format 1.2 rejects any missing array in the complete contract, including an
+array that would otherwise be safely interpreted as empty.
+
+History is capped according to the backup retention option and may be omitted
+for scheduled/update backups. The exception is safety coordination: every
+nonterminal TRaSH rollback/undeploy row and its referenced `trashBackups` row
+is always included. Active naming recovery rows are also included even when
+history is omitted or capped. These rows preserve resumability and are checked
+for equality against current state during restore.
+
+## Prisma model inventory
+
+This is the current model classification. “Included” means copied by format
+1.2; “conditional” means only the bounded coordination rows described above
+are copied.
+
+| Model | Classification | Backup status |
+| --- | --- | --- |
+| `User` | durable config/auth-secret | included |
+| `Session` | durable config/auth-secret | included |
+| `ServiceTag` | durable config/auth-secret | included |
+| `ServiceInstance` | durable config/auth-secret | included |
+| `ServiceInstanceTag` | durable config/auth-secret | included |
+| `OIDCProvider` | durable config/auth-secret | included |
+| `OIDCAccount` | durable config/auth-secret | included |
+| `WebAuthnCredential` | durable config/auth-secret | included |
+| `BackupSettings` | durable config/auth-secret | included |
+| `SystemSettings` | durable config/auth-secret | included |
+| `TrashTemplate` | durable config/auth-secret | included |
+| `TrashSyncSchedule` | durable config/auth-secret | included |
+| `TrashSettings` | durable config/auth-secret | included |
+| `TemplateQualityProfileMapping` | durable config/auth-secret | included |
+| `InstanceQualityProfileOverride` | durable config/auth-secret | included; pending/uncertain intent is equality-checked |
+| `StandaloneCFDeployment` | durable config/auth-secret | included |
+| `QualitySizeMapping` | durable config/auth-secret | included |
+| `HuntConfig` | durable config/auth-secret | included |
+| `HuntLog` | audit/history | excluded for scheduled/update backups; bounded in manual backups |
+| `HuntSearchHistory` | audit/history | excluded for scheduled/update backups; bounded in manual backups |
+| `UserCustomFormat` | durable config/auth-secret | included |
+| `QueueCleanerConfig` | durable config/auth-secret | included |
+| `LibraryCleanupConfig` | durable config/auth-secret | included |
+| `LibraryCleanupRule` | durable config/auth-secret | included |
+| `NotificationChannel` | durable config/auth-secret | included |
+| `NotificationSubscription` | durable config/auth-secret | included |
+| `VapidKeys` | durable config/auth-secret | included |
+| `NotificationRule` | durable config/auth-secret | included |
+| `NotificationAggregationConfig` | durable config/auth-secret | included |
+| `NamingConfig` | durable config/auth-secret | included |
+| `LabelSyncRule` | durable config/auth-secret | included |
+| `AutoTagRule` | durable config/auth-secret | included |
+| `TrashSyncHistory` | coordination | conditional: nonterminal/uncertain rows always included |
+| `TemplateDeploymentHistory` | coordination | conditional: nonterminal rows always included |
+| `TrashBackup` | coordination | conditional: snapshots referenced by coordination always included |
+| `NamingDeployHistory` | coordination | active recovery rows always included; other rows bounded |
+| `TrashCache` | disposable/rebuildable cache | excluded |
+| `InodeIndexCache` | disposable/rebuildable cache | excluded |
+| `LibraryCache` | disposable/rebuildable cache | excluded |
+| `EpisodeFileCache` | disposable/rebuildable cache | excluded |
+| `LibrarySyncStatus` | disposable/rebuildable cache | excluded |
+| `QueueCleanerStrike` | audit/history | excluded |
+| `QueueCleanerLog` | audit/history | excluded |
+| `LibraryCleanupApproval` | coordination | active statuses and executed rows awaiting terminal audit included; terminal-audit markers reset |
+| `LibraryCleanupMediaServerScan` | coordination | pending/triggering/failed statuses included; terminal audit excluded |
+| `LibraryCleanupMediaServerScanLease` | coordination | excluded; nonportable lease is recoverable from scan state |
+| `LibraryCleanupLog` | audit/history | excluded |
+| `LibraryCleanupAuditEvent` | audit/history | excluded |
+| `NotificationLog` | audit/history | excluded |
+| `PlexCache` | disposable/rebuildable cache | excluded |
+| `PlexGenerationTarget` | disposable/rebuildable cache | excluded |
+| `PlexEpisodeCache` | disposable/rebuildable cache | excluded |
+| `JellyfinCache` | disposable/rebuildable cache | excluded |
+| `JellyfinEpisodeCache` | disposable/rebuildable cache | excluded |
+| `TautulliCache` | disposable/rebuildable cache | excluded |
+| `CacheRefreshStatus` | disposable/rebuildable cache | excluded |
+| `SessionSnapshot` | audit/history | excluded |
+| `SeerrActionLog` | audit/history | excluded |
+| `TmdbListCache` | disposable/rebuildable cache | excluded |
+| `TraktListCache` | disposable/rebuildable cache | excluded |
+| `ListCacheRefreshStatus` | disposable/rebuildable cache | excluded |
+| `QuiActivityLog` | audit/history | excluded |
+| `QuiActionLog` | audit/history | excluded |
+| `QuiEventLog` | audit/history | excluded |
+
+Excluded cache and refresh-status models start empty after restore. They are
+repopulated by the application’s normal provider synchronization, list-cache,
+and scheduled/manual refresh paths after the required application restart;
+their absence from the backup is not treated as durable authority or success
+evidence.
+
+## Legacy restore behavior
+
+Versions **1.0** and **1.1** remain readable. Their older optional arrays may
+be absent, and a clean target may restore them. A legacy restore is rejected
+with HTTP 409 when the target already contains a relational durable-configuration
+row whose coverage is absent from the file. The check runs before the current
+secrets file is changed and again inside the database transaction before any
+delete, so an incomplete legacy backup cannot silently erase configuration.
+
+Independent singleton rows are preserved when absent from a legacy file only
+when that is safe. An incomplete legacy payload is rejected if the target has
+stored backup-password state, VAPID private-key state, or an OIDC provider that
+the file omits, because preserving that ciphertext while replacing the
+installation encryption key would make it unusable. A default `BackupSettings`
+row with neither password ciphertext nor IV remains compatible. When a legacy
+file does carry `backupSettings` or `vapidKeys`, each array independently
+authorizes deterministic replacement of that singleton even if an unrelated
+newer configuration collection is absent. A format 1.2 backup always carries
+both singleton arrays.
+
+The compatibility response is intentionally bounded and does not include
+secrets, URLs, names, or configuration contents. Snapshotless legacy partial
+undeploy records are normalized to uncertain audit-only records; they are never
+treated as resumable rollback authority.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -201,7 +201,7 @@ Follow [`CODE-REVIEW.md`](CODE-REVIEW.md) for the finite review contract.
 - **Docker vs Dev**: Different env vars and paths (`/config/` vs `./`)
 - **Secrets auto-generated**: `ENCRYPTION_KEY` and `SESSION_COOKIE_SECRET` are auto-generated to `secrets.json` if not provided
 - **Error responses**: `{ error: "message" }` with optional `details` for validation. Status codes: 400 (bad input), 401 (auth required), 403 (forbidden), 404 (not found/access denied), 423 (locked)
-- **Backup service**: Decomposed into `backup-crypto.ts`, `backup-validation.ts`, `backup-file-utils.ts`, `backup-database.ts`
+- **Backup service**: Decomposed into `backup-crypto.ts`, `backup-validation.ts`, `backup-file-utils.ts`, `backup-database.ts`; see the [backup inventory](BACKUPS.md) for format 1.2 coverage and legacy restore behavior.
 - **Queue Cleaner**: Has its own `QueueCleanerConfig` model for per-instance auto-cleanup settings
 
 ## Release Checklist

--- a/packages/shared/src/types/backup.ts
+++ b/packages/shared/src/types/backup.ts
@@ -74,7 +74,7 @@ export const restoreBackupFromFileRequestSchema = z.object({
 export type RestoreBackupFromFileRequest = z.infer<typeof restoreBackupFromFileRequestSchema>;
 
 // Backup structure (internal, not exposed via API)
-export type BackupFormatVersion = "1.0" | "1.1";
+export type BackupFormatVersion = "1.0" | "1.1" | "1.2";
 
 export interface BackupData {
 	version: BackupFormatVersion;
@@ -105,6 +105,7 @@ export interface BackupData {
 		// TRaSH Guides history/audit (useful for tracking)
 		trashSyncHistory?: unknown[];
 		templateDeploymentHistory?: unknown[];
+		namingDeployHistory?: unknown[];
 
 		// TRaSH instance backups (ARR config snapshots) - optional, can be large.
 		// Recent snapshots follow BackupSettings.includeTrashBackups; snapshots
@@ -118,6 +119,24 @@ export interface BackupData {
 		huntConfigs?: unknown[];
 		huntLogs?: unknown[];
 		huntSearchHistory?: unknown[];
+
+		// Durable configuration (runtime validation requires explicit arrays in v1.2;
+		// properties remain optional here so legacy payloads remain representable).
+		backupSettings?: unknown[];
+		vapidKeys?: unknown[];
+		notificationChannel?: unknown[];
+		notificationSubscription?: unknown[];
+		notificationRule?: unknown[];
+		notificationAggregationConfig?: unknown[];
+		autoTagRule?: unknown[];
+		labelSyncRule?: unknown[];
+		queueCleanerConfig?: unknown[];
+		libraryCleanupConfig?: unknown[];
+		libraryCleanupRule?: unknown[];
+		namingConfig?: unknown[];
+		userCustomFormat?: unknown[];
+		libraryCleanupApproval?: unknown[];
+		libraryCleanupMediaServerScan?: unknown[];
 	};
 	secrets: {
 		encryptionKey: string;


### PR DESCRIPTION
## Summary

Introduces backup format 1.2 with complete durable configuration coverage and a fail-closed restore contract. Restores now preserve active recovery authority, reject older payloads that cannot safely replace populated target state, reset nonportable cleanup-audit markers, and replace secret-bearing singleton rows only when their own arrays are present.

## Related issue

Closes #815

## Scope

- Version and validate a complete backup payload for every durable configuration collection.
- Export and restore durable authentication, notification, cleanup, naming, label-sync, auto-tag, queue-cleaner, TRaSH, hunt, backup-password, VAPID, OIDC, and passkey state.
- Preserve nonterminal rollback, undeploy, naming, quality-score, cleanup approval, and media-server scan coordination across history exclusion and restore.
- Reject incomplete legacy restores before secrets I/O and again inside the database transaction when omitted target state cannot be preserved safely.
- Add SQLite and PostgreSQL round-trip CI coverage and a complete Prisma model inventory.

## Non-goals

- Restoring disposable provider caches, leases, or terminal audit/history rows.
- Adding a schema migration or changing cleanup mutation authority.
- Changing application version, preparing a release, publishing an image, or modifying the private advisory.
- Changing the 3.0 development branch.

## Acceptance criteria

- [x] Every Prisma model is classified as durable configuration, secret-bearing state, coordination, audit/history, or disposable cache.
- [x] Format 1.2 requires explicit arrays for every complete-contract collection, including empty arrays.
- [x] Every durable model and semantically relevant encrypted field round-trips through SQLite and PostgreSQL.
- [x] Restore deletion and insertion follow dependency order with foreign-key integrity.
- [x] Formats 1.0 and 1.1 remain readable without claiming newer configuration coverage.
- [x] Populated targets reject unsafe incomplete restores with bounded HTTP 409 before any database deletion or secrets write.
- [x] Active recovery evidence survives exclusion/caps and is equality-checked at restore time.
- [x] Cleanup approvals awaiting terminal audit are preserved while nonportable audit markers are reset for local recovery.
- [x] Excluded caches/history and post-restore rebuild behavior are documented.

## Changes

- Adds format 1.2 validation, shared types, complete export arrays, dependency-ordered restore, and bounded compatibility errors.
- Adds pre-secrets and in-transaction restore preflight for omitted relational state, OIDC providers, and secret-bearing singleton state.
- Binds preserved active naming rollback history to the current instance owner, service, exact rollback request target, and encrypted credential material before any restore deletion.
- Re-reads active naming recovery rows and their referenced service authority at the export publication boundary, rejecting a concurrently torn backup with a bounded retry error.
- Makes `backupSettings` and `vapidKeys` replacement authority independent so valid legacy files can carry either array without requiring unrelated newer fields.
- Adds real populated-target contracts for incomplete rejection, complete replacement, covered legacy replacement, coordination preservation, and audit-marker sanitization.
- Runs the SQLite and PostgreSQL round-trip contract in CI using a digest-pinned PostgreSQL service.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed: backup surface 120 passed, 13 intentional skips.
- [x] Focused tests passed: coordination preservation and export stability 37/37; format 1.2 contract 17/17.
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: API 4,812; web 683; shared 89 passed.
- [x] `pnpm run lint`
- [x] `CI=true pnpm run validate:pr`: green, including 53 review-contract tests.
- [x] `pnpm run build`
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7/7.
- [x] `pnpm run check:prisma-generated`
- [x] SQLite populated-target round trip: green.
- [x] PostgreSQL populated-target round trip: green against the digest-pinned CI image.
- [x] Local Docker image build and SQLite/PostgreSQL API/web health: green on Docker-assigned ports.
- [x] Docker Combined Supervision surface: clock/query 20/20; cache permissions 122/122; supervision 34/34; launcher 15/15; live restart 14/14; heap dump 21/21; shutdown grace 15/15; stop timing 12/12.
- [x] User-visible behavior was live-verified — not applicable; no frontend behavior changed.
- [x] New queries use centralized query keys and polling constants — not applicable; no frontend query added.
- [x] New sensitive displays preserve incognito behavior — not applicable; no display added.
- [x] New Prisma queries for user-owned resources include `userId` — not applicable; backup serialization operates on the installation-wide authenticated maintenance boundary.
- [x] Optional-service gating is verified — not applicable; no new service surface.
- [x] User-facing counts are precise rather than proxies — not applicable; no count UI changed.
- [x] Action links reach the correct page — not applicable; no action link changed.
- [x] Duplicate surfaces were checked — format validation, service preflight, and transaction recheck are intentionally layered at distinct trust boundaries.

## Review plan

- Initial broad-reviewed head: uncommitted coherent snapshot on base `ab6fdeee29a2db8976117f8c6a598256ff6dd294`; no commit SHA had yet been assigned.
- Initial correction head: `f2fc9422f3bc1830492aad632f1b368c49af0457`
- Current correction head: `8df6c9da07564c4e61a815e238773c0612f6684a`
- Targeted delta range: `49279f6768484c3b40b3d84822666c0f6e803d7f..8df6c9da07564c4e61a815e238773c0612f6684a`; all three reviewers confirmed the export-publication barrier delta is clean.
- Material-scope change declared? No; corrections were confined to recorded singleton-authority and binding-test findings.
- Independent regression reviewer: CLEAN; F815-RG-7 and F815-RG-8 corrected; exact cycle-5 delta COVERED.
- Independent data-safety reviewer, when required: CLEAN; F815-DS-1 and F815-DS-2 corrected; exact cycle-5 delta COVERED.
- Independent security reviewer: CLEAN; endpoint, owner, service, ciphertext/key-continuity, publication timing, and bounded disclosure confirmed; exact cycle-5 delta COVERED.
- GitHub Codex review: exact `f2fc9422f3bc1830492aad632f1b368c49af0457` review found GH842-CX-1; exact `49279f6768484c3b40b3d84822666c0f6e803d7f` review found GH842-CX-2; exact `8df6c9da07564c4e61a815e238773c0612f6684a` re-review pending.
- Maintainer decision: merge authorized after exact-head GitHub gates under the standing convergence instruction.

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| F815-RG-7 | P2 | introduced-regression | A legacy payload carrying singleton arrays but omitting an unrelated collection was rejected by the aggregate coverage gate; format test RED. | Corrected with per-singleton coverage/deletion; unit, SQLite, PostgreSQL, and targeted regression/security reviews green. | None |
| F815-DS-1 | P3 | contract-violation | Fresh-target round trip did not prove populated-target 409 atomicity on real SQLite/PostgreSQL delegates. | Corrected with populated durable/secret/coordination fixtures, no-replacement assertions, complete replacement, legacy replacement, and marker reset; targeted data-safety review green. | None |
| GH842-CX-1 | P1 | introduced-safety | Exact-head GitHub review reproduced that a preserved active naming rollback row could keep its ID/owner while the referenced instance endpoint or credentials changed, redirecting the later rollback PUT. | Corrected by transaction-time binding of owner, service, rollback request target, API-key ciphertext/IV, and HTTP-auth ciphertext/IV; mismatch cases reject before deletion. | None |
| F815-RG-8 | P2 | introduced-regression | Raw `baseUrl` equality rejected the valid one-trailing-slash equivalent used by the ARR request client. | Corrected by comparing the exact naming rollback request target constructed with the client's one-trailing-slash rule; focused regression review green. | None |
| F815-DS-2 | P2 | introduced-safety | The broader deployment URL normalizer erased query routing even though `rawRequest()` preserves it in the actual request target. | Corrected by mirroring literal `rawRequest()` target construction; query A/B regression rejects before deletion and final data-safety review is green. | None |
| GH842-CX-2 | P1 | introduced-safety | Exact-head GitHub review reproduced that export could read service authority before a concurrent naming deployment and later pair the old endpoint/credentials with the new rollback payload. | Corrected with a publication-boundary re-read of the active recovery set, recovery fields, and referenced service owner/service/request-target/ciphertext authority; two interleaving regressions and all targeted reviews are green. | None |

## Final merge gate

- [ ] Exact-head CI is green
- [x] Acceptance criteria passed locally
- [ ] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned; none remain.
- [x] Current head is covered by the broad review and targeted delta/tree-identity confirmations.
- [x] Base is unchanged at `ab6fdeee29a2db8976117f8c6a598256ff6dd294`; no meaningful overlap exists.
- [x] Maintainer authorized merge after exact-head gates under the standing convergence instruction.
- [x] Post-merge exact-SHA verification is planned.
