### PR TITLE
fix(trash-guides): keep runtime bindings out of Prisma filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,13 @@ jobs:
         env:
           TEST_DB: "true"
 
+      - name: Run override-route persistence contract (SQLite)
+        run: pnpm exec vitest run src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+        working-directory: apps/api
+        env:
+          INTEGRATION_TESTS: "1"
+          OVERRIDE_ROUTE_DATABASE_URL: file:./prisma/test-integration.db
+
       - name: Build shared package
         run: pnpm --filter @arr/shared run build
 
@@ -96,6 +103,66 @@ jobs:
 
       - name: Run provider cache heap regression
         run: pnpm --filter @arr/api run test:provider-cache-heap
+
+  postgresql-contract:
+    name: PostgreSQL Persistence Contract
+    runs-on: ubuntu-latest
+    needs: [lint-and-test]
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: arr_contract
+          POSTGRES_PASSWORD: arr_contract_test
+          POSTGRES_DB: arr_contract
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U arr_contract -d arr_contract"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @arr/shared run build
+
+      - name: Generate PostgreSQL Prisma client
+        run: |
+          sed -i '/datasource db/,/^}/ s/provider = "sqlite"/provider = "postgresql"/' prisma/schema.prisma
+          grep -A2 'datasource db' prisma/schema.prisma | grep -F 'provider = "postgresql"'
+          pnpm exec prisma generate --schema prisma/schema.prisma
+        working-directory: apps/api
+
+      - name: Initialize PostgreSQL contract database
+        run: pnpm exec prisma db push --schema prisma/schema.prisma
+        working-directory: apps/api
+        env:
+          DATABASE_URL: postgresql://arr_contract:arr_contract_test@127.0.0.1:5432/arr_contract
+
+      - name: Run override-route persistence contract (PostgreSQL)
+        run: pnpm exec vitest run src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+        working-directory: apps/api
+        env:
+          INTEGRATION_TESTS: "1"
+          OVERRIDE_ROUTE_DATABASE_URL: postgresql://arr_contract:arr_contract_test@127.0.0.1:5432/arr_contract
 
   # End-to-End Tests with Playwright (sharded for parallelism)
   # Uses production builds for faster, more realistic testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Verify PR review contract checker
         run: node --test scripts/check-pr-review-contract.test.mjs
 
+      - name: Build shared package
+        run: pnpm --filter @arr/shared run build
+
       - name: Initialize deployment-state contract database
         run: pnpm exec prisma db push --schema prisma/schema.prisma
         working-directory: apps/api
@@ -82,9 +85,6 @@ jobs:
         env:
           INTEGRATION_TESTS: "1"
           OVERRIDE_ROUTE_DATABASE_URL: file:./prisma/test-integration.db
-
-      - name: Build shared package
-        run: pnpm --filter @arr/shared run build
 
       - name: Check formatting
         run: pnpm run format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres@sha256:cf78e76683b9ca8c5733cbbdce6c9262b45b6767934dd0a95e671f9a0fc20685 # 16-alpine
         env:
           POSTGRES_USER: arr_contract
           POSTGRES_PASSWORD: arr_contract_test

--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -85,8 +85,9 @@ describe("BulkScoreManager canonical profile identity", () => {
 			},
 			templateQualityProfileMapping: { findMany: findMappings },
 			trashTemplate: {
-				findMany: vi.fn(async ({ where }) =>
-					where.id.in.map((id: string) => ({
+				findMany: vi.fn(async ({ where }) => {
+					expect(where).toMatchObject({ userId });
+					return where.id.in.map((id: string) => ({
 						id,
 						configData: JSON.stringify({
 							qualityProfile: { trash_score_set: "default" },
@@ -98,8 +99,8 @@ describe("BulkScoreManager canonical profile identity", () => {
 								},
 							],
 						}),
-					})),
-				),
+					}));
+				}),
 			},
 		};
 		const clientFactory = {

--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -33,6 +33,9 @@ describe("BulkScoreManager canonical profile identity", () => {
 		]);
 		const findMappings = vi.fn(async ({ where }) => {
 			const bindings = Array.isArray(where.OR) ? where.OR : [];
+			expect(bindings).not.toContainEqual(
+				expect.objectContaining({ credentialIdentity: expect.anything() }),
+			);
 			const managedCustomFormats = JSON.stringify([
 				{
 					trashId: "trash-reject",

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -5,16 +5,17 @@ import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBinding,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createDeploymentStateToken,
 	createLegacyDeploymentConnectionBindings,
 	createQualityProfileStateToken,
+	type DeploymentProfileMapping,
 	getEquivalentServiceInstanceIds,
 	isDeploymentBackupEndpointIdentityCurrent,
 	isVerifiedClonedProfileSourceConnection,
 	resolveDeploymentTarget,
-	type DeploymentProfileMapping,
 } from "../deployment-target.js";
 
 const profiles = [
@@ -655,6 +656,25 @@ describe("getEquivalentServiceInstanceIds", () => {
 
 		expect(createDeploymentConnectionBindingCandidates(connection)).toEqual([
 			createDeploymentConnectionBinding(connection),
+		]);
+	});
+
+	it("removes credential-only evidence before using connection bindings in persistence filters", () => {
+		expect(
+			createDeploymentConnectionPersistenceBindings([
+				{
+					instanceId: "radarr-1",
+					connectionGeneration: 2,
+					connectionStateToken: "state-token",
+					credentialIdentity: "credential-only-evidence",
+				},
+			]),
+		).toEqual([
+			{
+				instanceId: "radarr-1",
+				connectionGeneration: 2,
+				connectionStateToken: "state-token",
+			},
 		]);
 	});
 

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -248,6 +248,7 @@ export class BulkScoreManager {
 				? await this.prisma.trashTemplate.findMany({
 						where: {
 							id: { in: templateIds },
+							userId,
 						},
 						select: {
 							id: true,

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -26,6 +26,7 @@ import { readPersistedManagedCustomFormatIdentities } from "./deployment-managed
 import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	getEquivalentServiceInstanceIds,
 } from "./deployment-target.js";
 
@@ -170,7 +171,7 @@ export class BulkScoreManager {
 		// Resolve management through every current alias for the physical ARR endpoint.
 		const templateMappings = await this.prisma.templateQualityProfileMapping.findMany({
 			where: {
-				OR: connectionBindings,
+				OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 				template: { userId },
 			},
 			select: {

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -56,6 +56,7 @@ import {
 	assertEquivalentDeploymentMappingAuthority,
 	createAutomationCatchUpTemplateStateToken,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createDeploymentMappingAuthorityState,
@@ -2415,7 +2416,9 @@ export class DeploymentExecutorService {
 										userId: orphanedOverrideCleanup.userId,
 										qualityProfileId: orphanedOverrideCleanup.qualityProfileId,
 										customFormatId: { in: orphanedOverrideCleanup.customFormatIds },
-										OR: orphanedOverrideCleanup.connectionReadBindings,
+										OR: createDeploymentConnectionPersistenceBindings(
+											orphanedOverrideCleanup.connectionReadBindings,
+										),
 									},
 								});
 							}

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -39,6 +39,11 @@ export interface DeploymentConnectionBinding {
 	credentialIdentity?: string;
 }
 
+export type DeploymentConnectionPersistenceBinding = Pick<
+	DeploymentConnectionBinding,
+	"instanceId" | "connectionGeneration" | "connectionStateToken"
+>;
+
 export interface AutomationCatchUpTemplateState {
 	configData: string;
 	instanceOverrides: string | null;
@@ -397,6 +402,17 @@ export function createDeploymentConnectionBindingCandidates(
 	credentialIdentity?: string,
 ): DeploymentConnectionBinding[] {
 	return [createDeploymentConnectionBinding(instance, credentialIdentity)];
+}
+
+/** Project in-memory connection evidence to fields that exist on persisted ownership rows. */
+export function createDeploymentConnectionPersistenceBindings(
+	bindings: DeploymentConnectionBinding[],
+): DeploymentConnectionPersistenceBinding[] {
+	return bindings.map(({ instanceId, connectionGeneration, connectionStateToken }) => ({
+		instanceId,
+		connectionGeneration,
+		connectionStateToken,
+	}));
 }
 
 /** Locate pre-binding mappings so callers can reject them without trusting them as ownership. */

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from "node:crypto";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTestPgClient, createTestPrismaClient } from "../../../lib/__tests__/test-prisma.js";
+import type { PrismaClientInstance } from "../../../lib/prisma.js";
+import { createDeploymentConnectionStateToken } from "../../../lib/trash-guides/deployment-target.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+import registerInstanceQualityProfileRoutes from "../instance-quality-profile-routes.js";
+
+const databaseUrl = process.env.OVERRIDE_ROUTE_DATABASE_URL;
+const runDatabaseTests =
+	process.env.INTEGRATION_TESTS === "1" && databaseUrl ? describe : describe.skip;
+
+const runId = randomUUID();
+const ids = {
+	user: `override-route-database-user-${runId}`,
+	foreignUser: `override-route-database-foreign-user-${runId}`,
+	primary: `override-route-database-primary-${runId}`,
+	alias: `override-route-database-alias-${runId}`,
+	otherCredential: `override-route-database-other-credential-${runId}`,
+	otherEndpoint: `override-route-database-other-endpoint-${runId}`,
+	foreignInstance: `override-route-database-foreign-instance-${runId}`,
+};
+
+const sharedConnection = {
+	service: "SONARR" as const,
+	baseUrl: "http://sonarr-override-route.test:8989",
+	encryptedApiKey: "synthetic-encrypted-api-key",
+	encryptionIv: "synthetic-encryption-iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 3,
+};
+const otherCredentialConnection = {
+	...sharedConnection,
+	encryptedApiKey: `synthetic-other-encrypted-api-key-${runId}`,
+	encryptionIv: `synthetic-other-encryption-iv-${runId}`,
+};
+
+runDatabaseTests("instance quality-profile override route Prisma contract", () => {
+	let app: FastifyInstance;
+	let prisma: PrismaClientInstance;
+	let cleanupDatabaseClient: (() => Promise<void>) | undefined;
+	const createdUserIds: string[] = [];
+
+	beforeAll(async () => {
+		if (!databaseUrl) throw new Error("OVERRIDE_ROUTE_DATABASE_URL is required");
+		if (/^postgres(ql)?:\/\//i.test(databaseUrl)) {
+			const client = await createTestPgClient(databaseUrl);
+			prisma = client.prisma;
+			cleanupDatabaseClient = client.cleanup;
+		} else {
+			prisma = createTestPrismaClient(databaseUrl.replace(/^file:/, ""));
+			cleanupDatabaseClient = () => prisma.$disconnect();
+		}
+
+		await prisma.user.create({ data: { id: ids.user, username: ids.user } });
+		createdUserIds.push(ids.user);
+		await prisma.user.create({
+			data: { id: ids.foreignUser, username: ids.foreignUser },
+		});
+		createdUserIds.push(ids.foreignUser);
+		await prisma.serviceInstance.createMany({
+			data: [
+				{
+					id: ids.primary,
+					userId: ids.user,
+					label: "Primary Sonarr",
+					...sharedConnection,
+				},
+				{
+					id: ids.alias,
+					userId: ids.user,
+					label: "Alias Sonarr",
+					...sharedConnection,
+				},
+				{
+					id: ids.otherCredential,
+					userId: ids.user,
+					label: "Same endpoint with other credentials",
+					...otherCredentialConnection,
+				},
+				{
+					id: ids.otherEndpoint,
+					userId: ids.user,
+					label: "Other Sonarr endpoint",
+					...sharedConnection,
+					baseUrl: "http://other-sonarr-override-route.test:8989",
+				},
+				{
+					id: ids.foreignInstance,
+					userId: ids.foreignUser,
+					label: "Foreign Sonarr",
+					...sharedConnection,
+				},
+			],
+		});
+
+		const connectionStateToken = createDeploymentConnectionStateToken(sharedConnection);
+		await prisma.instanceQualityProfileOverride.createMany({
+			data: [
+				{
+					id: `override-route-database-primary-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-applied-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-uncertain-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 8,
+					score: 25,
+					status: "UNCERTAIN",
+					intentOperation: "SET_SCORE",
+					intendedScore: 25,
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-other-credential-applied-${runId}`,
+					instanceId: ids.otherCredential,
+					qualityProfileId: 4,
+					customFormatId: 11,
+					score: 1_100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: otherCredentialConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(otherCredentialConnection),
+				},
+				{
+					id: `override-route-database-other-credential-uncertain-${runId}`,
+					instanceId: ids.otherCredential,
+					qualityProfileId: 4,
+					customFormatId: 12,
+					score: 1_200,
+					status: "UNCERTAIN",
+					intentOperation: "SET_SCORE",
+					intendedScore: 1_200,
+					userId: ids.user,
+					connectionGeneration: otherCredentialConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(otherCredentialConnection),
+				},
+				{
+					id: `override-route-database-other-endpoint-${runId}`,
+					instanceId: ids.otherEndpoint,
+					qualityProfileId: 4,
+					customFormatId: 9,
+					score: 900,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken({
+						...sharedConnection,
+						baseUrl: "http://other-sonarr-override-route.test:8989",
+					}),
+				},
+				{
+					id: `override-route-database-foreign-user-${runId}`,
+					instanceId: ids.foreignInstance,
+					qualityProfileId: 4,
+					customFormatId: 10,
+					score: 1_000,
+					status: "APPLIED",
+					userId: ids.foreignUser,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+			],
+		});
+
+		app = Fastify({ logger: false });
+		setupAuthInjection(app, { id: ids.user, username: ids.user });
+		registerTestErrorHandler(app);
+		app.decorate("prisma", prisma);
+		app.decorate("arrClientFactory", {
+			createConnectionCredentialIdentity: vi.fn(
+				(instance: typeof sharedConnection) =>
+					`${instance.encryptedApiKey}:${instance.encryptionIv}`,
+			),
+		} as never);
+		app.decorate("deploymentExecutor", {} as never);
+		await app.register(registerInstanceQualityProfileRoutes, {
+			prefix: "/api/trash-guides/instances",
+		});
+		await app.ready();
+	});
+
+	afterAll(async () => {
+		await app?.close();
+		if (prisma) {
+			if (createdUserIds.length > 0) {
+				await prisma.user.deleteMany({
+					where: { id: { in: createdUserIds } },
+				});
+			}
+			await cleanupDatabaseClient?.();
+		}
+	});
+
+	it("returns alias-bound overrides and recovery without leaking users, endpoints, or secrets", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			`/api/trash-guides/instances/${ids.primary}/quality-profiles/4/overrides`,
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		const body = response.json();
+		expect(body.overrides).toHaveLength(1);
+		expect(body.overrides[0]).toMatchObject({
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			userId: ids.user,
+		});
+		expect(body.recoveryPlans).toMatchObject([
+			{
+				qualityProfileId: 4,
+				retryable: true,
+				requiresManualReconciliation: false,
+				entries: [
+					{
+						customFormatId: 8,
+						operation: "SET_SCORE",
+						intendedScore: 25,
+						status: "UNCERTAIN",
+					},
+				],
+				retryAction: {
+					method: "PATCH",
+					recoveryToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+					scoreUpdates: [{ customFormatId: 8, score: 25 }],
+				},
+			},
+		]);
+		expect(response.body).not.toContain(ids.otherEndpoint);
+		expect(response.body).not.toContain(ids.otherCredential);
+		expect(response.body).not.toContain(ids.foreignInstance);
+		expect(response.body).not.toContain(ids.foreignUser);
+		expect(response.body).not.toContain(sharedConnection.encryptedApiKey);
+		expect(response.body).not.toContain(sharedConnection.encryptionIv);
+		expect(response.body).not.toContain(otherCredentialConnection.encryptedApiKey);
+		expect(response.body).not.toContain(otherCredentialConnection.encryptionIv);
+		expect(body.overrides).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ customFormatId: 11 })]),
+		);
+		expect(body.recoveryPlans).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					entries: expect.arrayContaining([expect.objectContaining({ customFormatId: 12 })]),
+				}),
+			]),
+		);
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
@@ -126,6 +126,17 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 					connectionStateToken,
 				},
 				{
+					id: `override-route-database-alias-unique-applied-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 16,
+					score: 1_600,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
 					id: `override-route-database-alias-uncertain-${runId}`,
 					instanceId: ids.alias,
 					qualityProfileId: 4,
@@ -137,6 +148,41 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 					userId: ids.user,
 					connectionGeneration: sharedConnection.connectionGeneration,
 					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-pending-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 15,
+					score: 75,
+					status: "PENDING",
+					intentOperation: "SET_SCORE",
+					intendedScore: 75,
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-stale-generation-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 13,
+					score: 1_300,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration - 1,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-stale-token-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 14,
+					score: 1_400,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken: `stale-connection-state-token-${runId}`,
 				},
 				{
 					id: `override-route-database-other-credential-applied-${runId}`,
@@ -227,33 +273,57 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 
 		expect(response.statusCode, response.body).toBe(200);
 		const body = response.json();
-		expect(body.overrides).toHaveLength(1);
-		expect(body.overrides[0]).toMatchObject({
-			customFormatId: 7,
-			score: 100,
-			status: "APPLIED",
-			userId: ids.user,
-		});
+		expect(body.overrides).toHaveLength(2);
+		expect(body.overrides).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+				}),
+				expect.objectContaining({
+					customFormatId: 16,
+					score: 1_600,
+					status: "APPLIED",
+					userId: ids.user,
+				}),
+			]),
+		);
 		expect(body.recoveryPlans).toMatchObject([
 			{
 				qualityProfileId: 4,
 				retryable: true,
 				requiresManualReconciliation: false,
-				entries: [
+				entries: expect.arrayContaining([
 					{
 						customFormatId: 8,
 						operation: "SET_SCORE",
 						intendedScore: 25,
 						status: "UNCERTAIN",
 					},
-				],
+					{
+						customFormatId: 15,
+						operation: "SET_SCORE",
+						intendedScore: 75,
+						status: "PENDING",
+					},
+				]),
 				retryAction: {
 					method: "PATCH",
 					recoveryToken: expect.stringMatching(/^[a-f0-9]{64}$/),
-					scoreUpdates: [{ customFormatId: 8, score: 25 }],
+					scoreUpdates: expect.arrayContaining([
+						{ customFormatId: 8, score: 25 },
+						{ customFormatId: 15, score: 75 },
+					]),
 				},
 			},
 		]);
+		for (const staleCustomFormatId of [13, 14]) {
+			expect(body.overrides).not.toEqual(
+				expect.arrayContaining([expect.objectContaining({ customFormatId: staleCustomFormatId })]),
+			);
+		}
 		expect(response.body).not.toContain(ids.otherEndpoint);
 		expect(response.body).not.toContain(ids.otherCredential);
 		expect(response.body).not.toContain(ids.foreignInstance);

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -727,6 +727,46 @@ describe("instance quality profile score persistence", () => {
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
 
+	it("rebinds a saved score retry only through its owner and exact prior connection", async () => {
+		const updatedAt = new Date("2026-08-09T00:00:00Z");
+		const connectionStateToken = createDeploymentConnectionStateToken(instance);
+		findOverrides.mockResolvedValue([
+			{
+				id: "intent-7",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				intentOperation: "SET_SCORE",
+				intendedScore: -10_000,
+				status: "UNCERTAIN",
+				updatedAt,
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(updateOverrides).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				where: expect.objectContaining({
+					id: "intent-7",
+					userId,
+					instanceId: instance.id,
+					connectionGeneration: instance.connectionGeneration,
+					connectionStateToken,
+					updatedAt,
+				}),
+			}),
+		);
+	});
+
 	it("rejects a recovery token after the saved intent changes", async () => {
 		findOverrides.mockResolvedValue([
 			{
@@ -1154,6 +1194,18 @@ describe("instance quality profile score persistence", () => {
 		);
 		expect(updateOverrides.mock.invocationCallOrder[0]).toBeLessThan(
 			updateProfile.mock.invocationCallOrder[0]!,
+		);
+		expect(updateOverrides).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				where: expect.objectContaining({
+					id: "override-1",
+					userId,
+					instanceId: instance.id,
+					connectionGeneration: instance.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(instance),
+				}),
+			}),
 		);
 		expect(deleteOverrides.mock.invocationCallOrder[0]).toBeGreaterThan(
 			updateProfile.mock.invocationCallOrder[0]!,

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -811,6 +811,26 @@ describe("instance quality profile score persistence", () => {
 				}),
 			}),
 		);
+		expect(findOverrides.mock.calls[0]?.[0].where.OR[0].OR[0]).not.toHaveProperty(
+			"credentialIdentity",
+		);
+	});
+
+	it("does not pass runtime credential identity evidence to Prisma override reads", async () => {
+		findOverrides.mockImplementationOnce(async ({ where }) => {
+			if (JSON.stringify(where).includes("credentialIdentity")) {
+				throw new Error("Unknown argument `credentialIdentity`");
+			}
+			return [];
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(findOverrides).toHaveBeenCalledOnce();
 	});
 
 	it("exposes retryable uncertain intent without treating it as an applied override", async () => {

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -14,13 +14,14 @@ import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deplo
 import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
-	isVerifiedClonedProfileSourceConnection,
 	isCurrentDeploymentConnectionMapping,
+	isVerifiedClonedProfileSourceConnection,
 } from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -475,7 +476,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				const mappings = await app.prisma.templateQualityProfileMapping.findMany({
 					where: {
 						qualityProfileId: profileId,
-						OR: connectionBindings,
+						OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 						template: { userId },
 					},
 					include: { template: true },
@@ -636,7 +637,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						qualityProfileId: profileId,
 						customFormatId: { in: customFormatIds },
 						status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
-						OR: connectionBindings,
+						OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 					},
 				});
 				assertCurrentConnectionRows(overrides, connectionBindings, "saved score override");
@@ -1327,7 +1328,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				userId,
 				qualityProfileId: profileIdNum,
 				OR: [
-					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: "APPLIED",
+						OR: createDeploymentConnectionPersistenceBindings(
+							connectionContext.connectionReadBindings,
+						),
+					},
 					{
 						status: { in: ["PENDING", "UNCERTAIN"] },
 						instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1421,7 +1427,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						customFormatId,
 						userId,
 						OR: [
-							{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+							{
+								status: "APPLIED",
+								OR: createDeploymentConnectionPersistenceBindings(
+									connectionContext.connectionReadBindings,
+								),
+							},
 							{
 								status: { in: ["PENDING", "UNCERTAIN"] },
 								instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1461,7 +1472,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					{
 						where: {
 							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
+							OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 							template: { userId },
 						},
 						include: { template: true },
@@ -1552,7 +1563,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					const transactionMappings = await transaction.templateQualityProfileMapping.findMany({
 						where: {
 							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
+							OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 							template: { userId },
 						},
 						select: {
@@ -1598,7 +1609,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 							customFormatId,
 							userId,
 							OR: [
-								{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+								{
+									status: "APPLIED",
+									OR: createDeploymentConnectionPersistenceBindings(
+										connectionContext.connectionReadBindings,
+									),
+								},
 								{
 									status: { in: ["PENDING", "UNCERTAIN"] },
 									instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1676,7 +1692,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					in: profileIds,
 				},
 				OR: [
-					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: "APPLIED",
+						OR: createDeploymentConnectionPersistenceBindings(
+							connectionContext.connectionReadBindings,
+						),
+					},
 					{
 						status: { in: ["PENDING", "UNCERTAIN"] },
 						instanceId: { in: connectionContext.equivalentInstanceIds },

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -665,6 +665,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						const write = await transaction.instanceQualityProfileOverride.updateMany({
 							where: {
 								id: override.id,
+								userId,
+								instanceId: override.instanceId,
+								connectionGeneration: override.connectionGeneration,
+								connectionStateToken: override.connectionStateToken,
 								updatedAt: override.updatedAt,
 								status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
 							},
@@ -1069,6 +1073,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 								const write = await transaction.instanceQualityProfileOverride.updateMany({
 									where: {
 										id: intent.id,
+										userId,
+										instanceId: intent.instanceId,
+										connectionGeneration: intent.connectionGeneration,
+										connectionStateToken: intent.connectionStateToken,
 										updatedAt: intent.updatedAt,
 										status: { in: ["PENDING", "UNCERTAIN"] },
 										intentOperation: "SET_SCORE",


### PR DESCRIPTION
## Summary

Integrate the community fix from #799 onto current `main` so runtime-only TRaSH connection binding data is projected to persisted fields before it is used in Prisma filters. Preserve the contributor-authored implementation commits and add maintainer-owned cross-database contract coverage.

Original contribution by `bttfw`; both implementation commits retain original authorship.

## Related issue

Related to #799

## Scope

- Project runtime deployment connection bindings to the fields persisted by Prisma.
- Apply the projection at each affected TRaSH deployment persistence boundary.
- Preserve tenant scoping and strengthen compare-and-swap filters with the persisted connection generation and state token.
- Exercise the real Prisma contract on SQLite and PostgreSQL in CI.

## Non-goals

- No Prisma schema or migration changes.
- No release, version, image-publication, or deployment work.
- No general TRaSH Guides redesign beyond the affected persistence boundaries.
- No changes to `next`.

## Acceptance criteria

- [x] Runtime-only `credentialIdentity` never reaches affected Prisma `where` filters.
- [x] Persisted connection binding fields still constrain the intended tenant, instance, generation, and state token.
- [x] Stale generation/token, different credentials/endpoints, and foreign-user rows cannot satisfy the persistence contract.
- [x] The real database regression passes on SQLite and PostgreSQL.
- [x] The current-main production candidate passes the full repository gauntlet, build, Docker regressions, and a fresh 104/104 integration run.

## Changes

- Add a single persistence projection for runtime deployment connection bindings.
- Use that projection in bulk-score writes, deployment orphan cleanup, and quality-profile override routes.
- Add tenant scoping to the affected TRaSH template lookup and persisted binding fields to compare-and-swap updates.
- Add a real-database regression and run it against both supported database providers in CI.
- Pin the PostgreSQL CI service to an immutable official image digest.
- Build `@arr/shared` before the database contracts so fresh runners can resolve its package entrypoint.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable
- [x] New queries use centralized query keys and polling constants, when applicable
- [x] New sensitive displays preserve incognito behavior, when applicable
- [x] New Prisma queries for user-owned resources include `userId`, when applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable
- [x] User-facing counts are precise rather than proxies, when applicable
- [x] Action links reach the correct page with required parameters, when applicable
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

Production-candidate evidence at `903492c19b1c2fc140ce3888777fff0db0cc33de`:

- Focused unit coverage: 101 passed; nearest executor and writer-lock coverage: 71 passed.
- Real Prisma regression: SQLite 1/1 and PostgreSQL 1/1.
- Full `CI=true pnpm run validate:pr`: API 4,781 passed / 55 skipped; web 683 passed; shared 89 passed; review-contract tests 53 passed.
- Docker supervision and shutdown regression suites: 253/253 across eight focused scripts.
- Fresh disposable integration stack: 104/104 passed with zero skips, failures, or retries; stack and generated artifacts were removed afterward.
- Local unpublished image `arr-dashboard:pr799-903492c1` was built from that production candidate; SQLite and PostgreSQL API/web smoke checks passed.

Workflow-only correction evidence at `5e5f8ef4a3b5318fb7cfc1ced271162dcc341a74`:

- The hosted fresh-run failure was reproduced locally by removing the existing shared build artifacts: Vitest could not resolve `@arr/shared` before collecting the contract.
- Replaying the corrected workflow slice from a missing shared build—shared build, schema push, deployment-state contract, then override-route contract—passed both database tests 1/1.
- The workflow YAML parses successfully and `git diff --check` passes.
- Exact-head hosted CI is green: root validation, PostgreSQL persistence contract, three E2E shards, Docker build, image build, SQLite and PostgreSQL smokes, combined supervision, CodeQL, Semgrep, and the PR contract all passed.

## Review plan

- Initial broad-reviewed head: `487bbb6b070879776da9d9fe252b4131d1206db1`
- Correction head: `5e5f8ef4a3b5318fb7cfc1ced271162dcc341a74`
- Targeted delta range: `487bbb6b070879776da9d9fe252b4131d1206db1..0ee58bd27283096e384093fe866c4d7909787263`, `0ee58bd27283096e384093fe866c4d7909787263..903492c19b1c2fc140ce3888777fff0db0cc33de`, and `903492c19b1c2fc140ce3888777fff0db0cc33de..5e5f8ef4a3b5318fb7cfc1ced271162dcc341a74`
- Material-scope change declared? No
- Independent regression reviewer: completed; one P2 corrected, targeted delta clean
- Independent data-safety reviewer, when required: completed; no P1/P2/P3 findings
- Independent supply-chain reviewer: completed; one P3 corrected; both targeted workflow deltas clean
- GitHub Codex review head: `5e5f8ef4a3b5318fb7cfc1ced271162dcc341a74`; completed with no findings
- Maintainer decision: Merge under the standing convergence authorization

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| F799-RG-1 | P2 | In scope | The real-database regression was permanently skipped by the pre-correction CI workflow | Fixed in `0ee58bd27283096e384093fe866c4d7909787263`; SQLite and PostgreSQL lanes pass locally | Exact-head hosted checks confirmed |
| F799-SC-1 | P3 | In scope | The new PostgreSQL service initially used mutable `postgres:16-alpine` | Fixed in `903492c19b1c2fc140ce3888777fff0db0cc33de` with the official immutable digest; targeted supply-chain delta review is clean | Hosted PostgreSQL job passed with the pinned digest |
| F799-CI-1 | P2 | In scope | Hosted job `99877786021` failed before test collection because the SQLite contract ran before `@arr/shared` was built on a fresh runner | Reproduced without local shared artifacts and fixed in `5e5f8ef4a3b5318fb7cfc1ced271162dcc341a74`; corrected local workflow slice and targeted review are clean | Every exact-head hosted job passed, including prior skips |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
