### PR TITLE
fix(backup): fail closed until restore is crash safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,21 @@ jobs:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+        env:
+          POSTGRES_USER: arr_backup_test
+          POSTGRES_PASSWORD: arr_backup_test
+          POSTGRES_DB: arr_backup_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U arr_backup_test -d arr_backup_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -85,6 +100,19 @@ jobs:
         env:
           INTEGRATION_TESTS: "1"
           OVERRIDE_ROUTE_DATABASE_URL: file:./prisma/test-integration.db
+
+      - name: Run backup round-trip contract on SQLite
+        run: pnpm exec vitest run src/lib/backup/__tests__/backup-roundtrip.test.ts
+        working-directory: apps/api
+        env:
+          TEST_DB: "true"
+
+      - name: Run backup round-trip contract on PostgreSQL
+        run: pnpm exec vitest run src/lib/backup/__tests__/backup-roundtrip.test.ts
+        working-directory: apps/api
+        env:
+          TEST_DB: "true"
+          TEST_DATABASE_URL: postgresql://arr_backup_test:arr_backup_test@127.0.0.1:5432/arr_backup_test
 
       - name: Check formatting
         run: pnpm run format

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Now integrates with **[autobrr/qui](https://github.com/autobrr/qui)** as a feder
 - **Zero-Config Security** — Auto-generated encryption keys on first run
 
 ### Management
-- **Backup & Restore** — Automated encrypted backups with configurable retention and scheduling ([backup inventory](docs/BACKUPS.md))
+- **Encrypted Backups** — Automated encrypted export with configurable retention and scheduling; restore is temporarily disabled pending crash-safe recovery ([backup inventory](docs/BACKUPS.md))
 - **Tag Organization** — Organize instances with custom tags and storage groups
 - **Multi-Instance** — Manage unlimited instances across all supported services
 - **System Settings** — Configurable ports, listen address, and application restart from the UI

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Now integrates with **[autobrr/qui](https://github.com/autobrr/qui)** as a feder
 - **Zero-Config Security** — Auto-generated encryption keys on first run
 
 ### Management
-- **Backup & Restore** — Automated encrypted backups with configurable retention and scheduling
+- **Backup & Restore** — Automated encrypted backups with configurable retention and scheduling ([backup inventory](docs/BACKUPS.md))
 - **Tag Organization** — Organize instances with custom tags and storage groups
 - **Multi-Instance** — Manage unlimited instances across all supported services
 - **System Settings** — Configurable ports, listen address, and application restart from the UI

--- a/apps/api/src/lib/arr/__tests__/connection-warmer.test.ts
+++ b/apps/api/src/lib/arr/__tests__/connection-warmer.test.ts
@@ -1,0 +1,70 @@
+import type { FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../client-helpers.js", () => ({
+	isSonarrClient: () => true,
+	isRadarrClient: () => false,
+	isProwlarrClient: () => false,
+}));
+
+import {
+	withCleanupMaintenanceGuard,
+	withIndependentCleanupOperationGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { warmConnectionsForUser } from "../connection-warmer.js";
+
+describe.sequential("connection warmer restore exclusion", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("does not detach an old-authority request at the legacy five-second boundary", async () => {
+		vi.useFakeTimers();
+		let releaseSystemGet: (() => void) | undefined;
+		const systemGetBlocked = new Promise<void>((resolve) => {
+			releaseSystemGet = resolve;
+		});
+		const systemGet = vi.fn(() => systemGetBlocked);
+		const app = {
+			prisma: {
+				serviceInstance: {
+					findMany: vi.fn().mockResolvedValue([
+						{
+							id: "sonarr-1",
+							userId: "user-1",
+							service: "SONARR",
+							enabled: true,
+						},
+					]),
+				},
+			},
+			arrClientFactory: {
+				create: vi.fn(() => ({ system: { get: systemGet } })),
+			},
+			log: {
+				debug: vi.fn(),
+				info: vi.fn(),
+			},
+		} as unknown as FastifyInstance;
+
+		const warming = withIndependentCleanupOperationGuard(() =>
+			warmConnectionsForUser(app, "user-1"),
+		);
+		try {
+			await vi.advanceTimersByTimeAsync(0);
+			expect(systemGet).toHaveBeenCalledOnce();
+
+			await vi.advanceTimersByTimeAsync(5001);
+			const restoreWork = vi.fn();
+			await expect(withCleanupMaintenanceGuard(restoreWork)).rejects.toMatchObject({
+				statusCode: 409,
+			});
+			expect(restoreWork).not.toHaveBeenCalled();
+		} finally {
+			releaseSystemGet?.();
+			await warming;
+		}
+
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+});

--- a/apps/api/src/lib/arr/connection-warmer.ts
+++ b/apps/api/src/lib/arr/connection-warmer.ts
@@ -31,7 +31,9 @@ export async function warmConnectionsForUser(app: FastifyInstance, userId: strin
 			return;
 		}
 
-		// Warm connections in parallel with short timeout
+		// Warm connections in parallel. Each ARR client owns a bounded request
+		// timeout; do not race these promises with an uncancelling outer timer.
+		// Callers may retain a restore-exclusion lease until every request settles.
 		const warmPromises = instances.map((instance) =>
 			warmSingleConnection(app, instance).catch((error) => {
 				// Log but don't fail - this is best-effort
@@ -42,11 +44,7 @@ export async function warmConnectionsForUser(app: FastifyInstance, userId: strin
 			}),
 		);
 
-		// Wait for all with a reasonable timeout
-		await Promise.race([
-			Promise.all(warmPromises),
-			new Promise((resolve) => setTimeout(resolve, 5000)), // 5s max
-		]);
+		await Promise.all(warmPromises);
 
 		app.log.info({ userId, instanceCount: instances.length }, "Connections pre-warmed for user");
 	} catch (error) {

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -8,8 +8,9 @@
  */
 
 import { describe, expect, it, vi } from "vitest";
+import { BackupCompatibilityError } from "../../errors.js";
 import type { PrismaClient } from "../../prisma.js";
-import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "../backup-database.js";
 
 const TABLE_NAMES = [
 	"user",
@@ -21,6 +22,8 @@ const TABLE_NAMES = [
 	"oIDCAccount",
 	"webAuthnCredential",
 	"systemSettings",
+	"backupSettings",
+	"vapidKeys",
 	"trashTemplate",
 	"trashSettings",
 	"trashSyncSchedule",
@@ -34,6 +37,20 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+	"namingConfig",
+	"namingDeployHistory",
+	"userCustomFormat",
 ] as const;
 
 type TableName = (typeof TABLE_NAMES)[number];
@@ -322,6 +339,59 @@ describe("exportDatabase — operational history exclusion", () => {
 		);
 	});
 
+	it("fails closed when active naming recovery changes during export", async () => {
+		const { prisma, mock } = makeMockPrisma();
+		const activeNaming = {
+			id: "active-naming-recovery",
+			instanceId: "instance-1",
+			userId: "user-1",
+			status: "SUCCESS",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			rolledBack: false,
+		};
+		mock.namingDeployHistory.findMany
+			.mockResolvedValueOnce([activeNaming])
+			.mockResolvedValueOnce([{ ...activeNaming, previousConfig: "changed-recovery-state" }]);
+
+		await expect(exportDatabase(prisma, { excludeOperationalHistory: true })).rejects.toThrow(
+			"Cannot create backup: active naming recovery changed during export; retry",
+		);
+	});
+
+	it("fails closed when active naming recovery service authority changes during export", async () => {
+		const { prisma, mock } = makeMockPrisma();
+		const activeNaming = {
+			id: "active-naming-recovery",
+			instanceId: "instance-1",
+			userId: "user-1",
+			status: "SUCCESS",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			rolledBack: false,
+		};
+		const initialInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			baseUrl: "https://proxy.example/arr?tenant=A",
+			encryptedApiKey: "api-key-ciphertext",
+			encryptionIv: "api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		mock.serviceInstance.findMany
+			.mockResolvedValueOnce([initialInstance])
+			.mockResolvedValueOnce([
+				{ ...initialInstance, baseUrl: "https://proxy.example/arr?tenant=B" },
+			]);
+		mock.namingDeployHistory.findMany
+			.mockResolvedValueOnce([activeNaming])
+			.mockResolvedValueOnce([activeNaming]);
+
+		await expect(exportDatabase(prisma, { excludeOperationalHistory: true })).rejects.toThrow(
+			"Cannot create backup: active naming recovery changed during export; retry",
+		);
+	});
+
 	it("includes operational history with row cap when excludeOperationalHistory: false (default)", async () => {
 		const { prisma, mock } = makeMockPrisma({
 			huntLog: [{ id: "h1", startedAt: new Date() }],
@@ -444,13 +514,42 @@ describe("exportDatabase — operational history exclusion", () => {
 });
 
 describe("restoreDatabase — current coordination preservation", () => {
+	async function expectCompatibilityFailure(
+		operation: Promise<unknown>,
+		expectedCause: string,
+	): Promise<void> {
+		let captured: unknown;
+		try {
+			await operation;
+		} catch (error) {
+			captured = error;
+		}
+
+		expect(captured).toBeInstanceOf(BackupCompatibilityError);
+		const compatibilityError = captured as BackupCompatibilityError;
+		expect(compatibilityError.message).toBe(
+			"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		);
+		expect(compatibilityError.cause).toBeInstanceOf(Error);
+		expect((compatibilityError.cause as Error).message).toContain(expectedCause);
+	}
+
 	function makeRestorePrisma(options: {
+		currentInstances?: Array<Record<string, unknown>>;
 		currentSync?: Array<Record<string, unknown>>;
 		currentDeployments?: Array<Record<string, unknown>>;
 		currentSnapshots?: Array<Record<string, unknown>>;
+		currentNaming?: Array<Record<string, unknown>>;
+		currentApprovals?: Array<Record<string, unknown>>;
+		currentScanParentApprovals?: Array<Record<string, unknown>>;
+		currentScans?: Array<Record<string, unknown>>;
 	}) {
 		const firstDelete = vi.fn().mockResolvedValue({ count: 0 });
 		const tx = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue(options.currentInstances ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
 			trashSyncHistory: {
 				findMany: vi.fn().mockResolvedValue(options.currentSync ?? []),
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -463,6 +562,25 @@ describe("restoreDatabase — current coordination preservation", () => {
 				findMany: vi.fn().mockResolvedValue(options.currentSnapshots ?? []),
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 			},
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([]),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			namingDeployHistory: {
+				findMany: vi.fn().mockResolvedValue(options.currentNaming ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			libraryCleanupApproval: {
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce(options.currentApprovals ?? [])
+					.mockResolvedValue(options.currentScanParentApprovals ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+			libraryCleanupMediaServerScan: {
+				findMany: vi.fn().mockResolvedValue(options.currentScans ?? []),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
 			huntSearchHistory: { deleteMany: firstDelete },
 		};
 		const prisma = {
@@ -471,7 +589,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			),
 		} as unknown as PrismaClient;
 
-		return { prisma, firstDelete };
+		return { prisma, compatibilityPrisma: tx as unknown as PrismaClient, firstDelete };
 	}
 
 	function incomingData(overrides: Record<string, unknown> = {}) {
@@ -512,8 +630,239 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(restoreDatabase(prisma, incomingData())).rejects.toThrow(
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData()),
 			"current nonterminal coordination row current-sync",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["userId", "user-2"],
+		["service", "SONARR"],
+		["baseUrl", "http://radarr-replacement:7878"],
+		["encryptedApiKey", "replacement-api-key-ciphertext"],
+		["encryptionIv", "replacement-api-key-iv"],
+		["encryptedHttpAuthCredentials", "replacement-http-auth-ciphertext"],
+		["httpAuthEncryptionIv", "replacement-http-auth-iv"],
+	])(
+		"rejects a restore that changes active naming recovery service instance %s",
+		async (field, replacement) => {
+			const currentInstance = {
+				id: "instance-1",
+				userId: "user-1",
+				service: "RADARR",
+				baseUrl: "http://radarr-current:7878",
+				encryptedApiKey: "current-api-key-ciphertext",
+				encryptionIv: "current-api-key-iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+			};
+			const currentNaming = {
+				id: "active-naming-recovery",
+				instanceId: currentInstance.id,
+				userId: currentInstance.userId,
+				status: "SUCCESS",
+				selectedPresets: '["standard"]',
+				resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+				deployedHash: "deployed-hash",
+				previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+				changedFields: 1,
+				totalFields: 1,
+				errorMessage: null,
+				rolledBack: false,
+				rolledBackAt: null,
+				deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+			};
+			const { prisma, firstDelete } = makeRestorePrisma({
+				currentInstances: [currentInstance],
+				currentNaming: [currentNaming],
+			});
+
+			await expectCompatibilityFailure(
+				restoreDatabase(
+					prisma,
+					incomingData({
+						serviceInstances: [{ ...currentInstance, [field]: replacement }],
+						namingDeployHistory: [currentNaming],
+					}),
+				),
+				`current active naming recovery active-naming-recovery changed service instance ${field}`,
+			);
+			expect(firstDelete).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rejects a restore that changes query-routed active naming recovery authority", async () => {
+		const currentInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			baseUrl: "https://proxy.example/arr?tenant=A",
+			encryptedApiKey: "current-api-key-ciphertext",
+			encryptionIv: "current-api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		const currentNaming = {
+			id: "active-naming-recovery",
+			instanceId: currentInstance.id,
+			userId: currentInstance.userId,
+			status: "SUCCESS",
+			selectedPresets: '["standard"]',
+			resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+			deployedHash: "deployed-hash",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			changedFields: 1,
+			totalFields: 1,
+			errorMessage: null,
+			rolledBack: false,
+			rolledBackAt: null,
+			deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentInstances: [currentInstance],
+			currentNaming: [currentNaming],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(
+				prisma,
+				incomingData({
+					serviceInstances: [{ ...currentInstance, baseUrl: "https://proxy.example/arr?tenant=B" }],
+					namingDeployHistory: [currentNaming],
+				}),
+			),
+			"current active naming recovery active-naming-recovery changed service instance baseUrl",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it("allows equivalent endpoint and display-only changes while preserving active naming recovery authority", async () => {
+		const currentInstance = {
+			id: "instance-1",
+			userId: "user-1",
+			service: "RADARR",
+			label: "Current label",
+			baseUrl: "http://radarr-current:7878",
+			encryptedApiKey: "current-api-key-ciphertext",
+			encryptionIv: "current-api-key-iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+		};
+		const currentNaming = {
+			id: "active-naming-recovery",
+			instanceId: currentInstance.id,
+			userId: currentInstance.userId,
+			status: "SUCCESS",
+			selectedPresets: '["standard"]',
+			resolvedPayload: '{"standardMovieFormat":"{Movie Title}"}',
+			deployedHash: "deployed-hash",
+			previousConfig: '{"standardMovieFormat":"{Movie OriginalTitle}"}',
+			changedFields: 1,
+			totalFields: 1,
+			errorMessage: null,
+			rolledBack: false,
+			rolledBackAt: null,
+			deployedAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { compatibilityPrisma } = makeRestorePrisma({
+			currentInstances: [currentInstance],
+			currentNaming: [currentNaming],
+		});
+
+		await expect(
+			assertRestoreCompatibility(
+				compatibilityPrisma,
+				incomingData({
+					serviceInstances: [
+						{
+							...currentInstance,
+							label: "Restored display label",
+							baseUrl: `${currentInstance.baseUrl}/`,
+						},
+					],
+					namingDeployHistory: [currentNaming],
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("rejects a restore that omits an active cleanup approval before deleting tables", async () => {
+		const currentApproval = {
+			id: "active-cleanup-approval",
+			configId: "cleanup-config",
+			instanceId: "instance-1",
+			arrItemId: 815,
+			itemType: "movie",
+			title: "Current cleanup target",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Current cleanup rule",
+			reason: "age",
+			action: "delete",
+			sizeOnDisk: BigInt(815),
+			status: "approved",
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentApprovals: [currentApproval],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData({ libraryCleanupApproval: [] })),
+			"current active cleanup approval active-cleanup-approval is missing from incoming data",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+
+	it("rejects a restore that omits a retryable media-server scan and its terminal parent", async () => {
+		const currentParent = {
+			id: "executed-cleanup-parent",
+			configId: "cleanup-config",
+			instanceId: "instance-1",
+			arrItemId: 816,
+			itemType: "series",
+			title: "Executed cleanup target",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Current cleanup rule",
+			reason: "size",
+			action: "delete",
+			sizeOnDisk: BigInt(816),
+			status: "executed",
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+		};
+		const currentScan = {
+			id: "retryable-cleanup-scan",
+			approvalId: currentParent.id,
+			instanceId: "instance-1",
+			service: "PLEX",
+			mediaType: "show",
+			targetKey: "series:816",
+			status: "failed",
+			attemptCount: 1,
+			completedSectionIds: "[]",
+			lastError: "temporary provider failure",
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+			updatedAt: new Date("2026-08-31T00:01:00.000Z"),
+		};
+		const { prisma, firstDelete } = makeRestorePrisma({
+			currentScanParentApprovals: [currentParent],
+			currentScans: [currentScan],
+		});
+
+		await expectCompatibilityFailure(
+			restoreDatabase(
+				prisma,
+				incomingData({
+					libraryCleanupApproval: [
+						{ ...currentParent, sizeOnDisk: currentParent.sizeOnDisk.toString() },
+					],
+					libraryCleanupMediaServerScan: [],
+				}),
+			),
+			"current active media-server scan retryable-cleanup-scan is missing from incoming data",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
@@ -533,7 +882,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(restoreDatabase(prisma, incomingData())).rejects.toThrow(
+		await expectCompatibilityFailure(
+			restoreDatabase(prisma, incomingData()),
 			"current nonterminal coordination row interrupted-sync",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -561,9 +911,10 @@ describe("restoreDatabase — current coordination preservation", () => {
 			],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(prisma, incomingData({ templateDeploymentHistory: [currentDeployment] })),
-		).rejects.toThrow("current recovery snapshot snapshot-deployment");
+			"current recovery snapshot snapshot-deployment",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -591,7 +942,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -599,7 +950,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current nonterminal coordination row current-sync changed userId");
+			"current nonterminal coordination row current-sync changed userId",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -622,7 +974,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -630,7 +982,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [{ ...currentSnapshot, backupData: "stale-sync-evidence" }],
 				}),
 			),
-		).rejects.toThrow("current recovery snapshot snapshot-sync changed backupData");
+			"current recovery snapshot snapshot-sync changed backupData",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -658,7 +1011,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -668,7 +1021,6 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow(
 			"current nonterminal coordination row current-deployment changed appliedConfigs",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -697,7 +1049,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -705,7 +1057,6 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow(
 			"current nonterminal coordination row current-deployment changed templateSnapshot",
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
@@ -741,7 +1092,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -750,7 +1101,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current undeploy fallback template template-1 changed configData");
+			"current undeploy fallback template template-1 changed configData",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 
@@ -777,7 +1129,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 			currentSnapshots: [currentSnapshot],
 		});
 
-		await expect(
+		await expectCompatibilityFailure(
 			restoreDatabase(
 				prisma,
 				incomingData({
@@ -785,7 +1137,8 @@ describe("restoreDatabase — current coordination preservation", () => {
 					trashBackups: [currentSnapshot],
 				}),
 			),
-		).rejects.toThrow("current nonterminal coordination row current-sync changed appliedConfigs");
+			"current nonterminal coordination row current-sync changed appliedConfigs",
+		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -626,7 +626,12 @@ describe("restoreDatabase — current coordination preservation", () => {
 			),
 		} as unknown as PrismaClient;
 
-		return { prisma, compatibilityPrisma: tx as unknown as PrismaClient, firstDelete };
+		return {
+			prisma,
+			compatibilityPrisma: tx as unknown as PrismaClient,
+			firstDelete,
+			transaction: prisma.$transaction,
+		};
 	}
 
 	function incomingData(overrides: Record<string, unknown> = {}) {
@@ -645,6 +650,38 @@ describe("restoreDatabase — current coordination preservation", () => {
 			...overrides,
 		} as never;
 	}
+
+	it("rejects malformed bulk rows before opening the destructive transaction", async () => {
+		const { prisma, transaction } = makeRestorePrisma({});
+
+		await expect(
+			restoreDatabase(prisma, incomingData({ users: [{ id: "missing-required-username" }] })),
+		).rejects.toThrow("Invalid user record at index 0: missing required field 'username'");
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
+	it("rejects malformed approval sizes before opening the destructive transaction", async () => {
+		const { prisma, transaction } = makeRestorePrisma({});
+
+		await expect(
+			restoreDatabase(
+				prisma,
+				incomingData({
+					libraryCleanupApproval: [
+						{
+							id: "approval-with-invalid-size",
+							configId: "cleanup-config",
+							instanceId: "instance-1",
+							status: "pending",
+							sizeOnDisk: "not-an-integer",
+							expiresAt: "2030-01-01T00:00:00.000Z",
+						},
+					],
+				}),
+			),
+		).rejects.toThrow("Cannot convert not-an-integer to a BigInt");
+		expect(transaction).not.toHaveBeenCalled();
+	});
 
 	it("rejects a restore that omits a current nonterminal sync row before deleting tables", async () => {
 		const { prisma, firstDelete } = makeRestorePrisma({
@@ -1103,6 +1140,7 @@ describe("restoreDatabase — current coordination preservation", () => {
 		const currentTemplate = {
 			id: "template-1",
 			userId: "user-1",
+			name: "Current template",
 			serviceType: "RADARR",
 			configData: '{"customFormats":[{"name":"Current CF"}]}',
 		};

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -60,6 +60,8 @@ type MockPrisma = {
 		findMany: ReturnType<typeof vi.fn>;
 		count: ReturnType<typeof vi.fn>;
 	};
+} & {
+	$transaction: ReturnType<typeof vi.fn>;
 };
 
 function makeMockPrisma(rows: Partial<Record<TableName, unknown[]>> = {}): {
@@ -74,10 +76,45 @@ function makeMockPrisma(rows: Partial<Record<TableName, unknown[]>> = {}): {
 			count: vi.fn().mockResolvedValue(tableRows.length),
 		};
 	}
+	mock.$transaction = vi.fn(async (operation: (tx: MockPrisma) => Promise<unknown>) =>
+		operation(mock),
+	);
 	return { prisma: mock as unknown as PrismaClient, mock };
 }
 
 describe("exportDatabase — operational history exclusion", () => {
+	it("reads the portable snapshot in one Serializable transaction", async () => {
+		const { prisma: transactionClient } = makeMockPrisma();
+		const transaction = vi.fn(
+			async (
+				operation: (tx: PrismaClient) => Promise<unknown>,
+				_options: { isolationLevel: string; timeout: number },
+			) => operation(transactionClient),
+		);
+		const rootNamingFindMany = vi.fn().mockResolvedValue([]);
+		const prisma = new Proxy(
+			{ $transaction: transaction },
+			{
+				get: (target, property) => {
+					if (property === "$transaction") return target.$transaction;
+					if (property === "namingDeployHistory") {
+						return { findMany: rootNamingFindMany };
+					}
+					throw new Error(`root delegate ${String(property)} was read outside the snapshot`);
+				},
+			},
+		) as unknown as PrismaClient;
+
+		await exportDatabase(prisma, { excludeOperationalHistory: true });
+
+		expect(transaction).toHaveBeenCalledOnce();
+		expect(transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+			timeout: 60_000,
+		});
+		expect(rootNamingFindMany).toHaveBeenCalledOnce();
+	});
+
 	it("skips disposable history but preserves nonterminal rollback and undeploy coordination", async () => {
 		const { prisma, mock } = makeMockPrisma({
 			serviceInstance: [{ id: "instance-1", userId: "user-1" }],

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -46,6 +46,7 @@ const TABLE_NAMES = [
 	"queueCleanerConfig",
 	"libraryCleanupConfig",
 	"libraryCleanupRule",
+	"librarySyncStatus",
 	"libraryCleanupApproval",
 	"libraryCleanupMediaServerScan",
 	"namingConfig",

--- a/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
@@ -69,6 +69,19 @@ describe("backup format 1.2", () => {
 		expect(() => validateBackup(baseBackup())).not.toThrow();
 	});
 
+	it.each(["oidcProviders", "systemSettings", "backupSettings", "vapidKeys"])(
+		"rejects ambiguous duplicate %s singleton records",
+		(collection) => {
+			expect(() =>
+				validateBackup(
+					baseBackup({
+						[collection]: [{ id: 1 }, { id: 2 }],
+					}),
+				),
+			).toThrow(new RegExp(`${collection}.*at most one`, "i"));
+		},
+	);
+
 	it("rejects a 1.2 payload when a durable configuration array is missing", () => {
 		const backup = baseBackup() as { data: Record<string, unknown> };
 		delete backup.data.notificationChannel;
@@ -120,7 +133,7 @@ describe("backup format 1.2", () => {
 			"backupSettings",
 			"vapidKeys",
 		];
-		const prisma = Object.fromEntries(
+		const transactionClient = Object.fromEntries(
 			models.map((model) => [
 				model,
 				{
@@ -128,7 +141,13 @@ describe("backup format 1.2", () => {
 					count: vi.fn().mockResolvedValue(0),
 				},
 			]),
-		) as unknown as PrismaClient;
+		);
+		const prisma = {
+			...transactionClient,
+			$transaction: vi.fn(async (operation: (tx: unknown) => Promise<unknown>) =>
+				operation(transactionClient),
+			),
+		} as unknown as PrismaClient;
 
 		const data = await exportDatabase(prisma);
 
@@ -170,10 +189,14 @@ describe("backup format 1.2", () => {
 				status: "failed",
 			},
 		]);
-		const prisma = new Proxy(
+		let prisma!: PrismaClient;
+		prisma = new Proxy(
 			{},
 			{
 				get: (_target, property) => {
+					if (property === "$transaction") {
+						return async (operation: (tx: PrismaClient) => Promise<unknown>) => operation(prisma);
+					}
 					if (property === "libraryCleanupApproval") {
 						return { findMany: approvalFindMany };
 					}
@@ -373,4 +396,17 @@ describe("backup format 1.2", () => {
 		);
 		expect(firstDelete).not.toHaveBeenCalled();
 	});
+
+	it.each(["oidcProviders", "systemSettings", "backupSettings", "vapidKeys"])(
+		"rejects duplicate %s records before opening the restore transaction",
+		async (collection) => {
+			const transaction = vi.fn();
+			const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+			await expect(
+				restoreDatabase(prisma, baseBackup({ [collection]: [{ id: 1 }, { id: 2 }] }).data as never),
+			).rejects.toThrow(new RegExp(`${collection}.*at most one`, "i"));
+			expect(transaction).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../../prisma.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "../backup-database.js";
+import { validateBackup } from "../backup-validation.js";
+
+const DURABLE_CONFIG_KEYS = [
+	"backupSettings",
+	"vapidKeys",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+	"namingDeployHistory",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+] as const;
+
+const COMPLETE_V1_2_PAYLOAD_KEYS = [
+	"oidcProviders",
+	"systemSettings",
+	"trashTemplates",
+	"trashSettings",
+	"trashSyncSchedules",
+	"templateQualityProfileMappings",
+	"instanceQualityProfileOverrides",
+	"standaloneCFDeployments",
+	"qualitySizeMappings",
+	"trashSyncHistory",
+	"templateDeploymentHistory",
+	"trashBackups",
+	"huntConfigs",
+	"huntLogs",
+	"huntSearchHistory",
+	...DURABLE_CONFIG_KEYS,
+] as const;
+
+function baseBackup(data: Record<string, unknown> = {}) {
+	return {
+		version: "1.2",
+		appVersion: "2.24.2",
+		timestamp: new Date().toISOString(),
+		data: {
+			users: [],
+			sessions: [],
+			serviceInstances: [],
+			serviceTags: [],
+			serviceInstanceTags: [],
+			oidcAccounts: [],
+			webAuthnCredentials: [],
+			...Object.fromEntries(COMPLETE_V1_2_PAYLOAD_KEYS.map((key) => [key, []])),
+			...data,
+		},
+		secrets: {
+			encryptionKey: "encryption-key",
+			sessionCookieSecret: "session-cookie-secret",
+		},
+	};
+}
+
+describe("backup format 1.2", () => {
+	it("accepts explicit durable configuration arrays, including empty arrays", () => {
+		expect(() => validateBackup(baseBackup())).not.toThrow();
+	});
+
+	it("rejects a 1.2 payload when a durable configuration array is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.notificationChannel;
+
+		expect(() => validateBackup(backup)).toThrow(/notificationChannel/);
+	});
+
+	it("rejects a 1.2 payload when an older exported configuration array is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.qualitySizeMappings;
+
+		expect(() => validateBackup(backup)).toThrow(/qualitySizeMappings/);
+	});
+
+	it("rejects a 1.2 payload when cleanup coordination coverage is missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.libraryCleanupApproval;
+
+		expect(() => validateBackup(backup)).toThrow(/libraryCleanupApproval/);
+	});
+
+	it("exports every durable configuration collection as an explicit array", async () => {
+		const models = [
+			"user",
+			"session",
+			"serviceInstance",
+			"serviceTag",
+			"serviceInstanceTag",
+			"oIDCProvider",
+			"oIDCAccount",
+			"webAuthnCredential",
+			"systemSettings",
+			"trashTemplate",
+			"trashSettings",
+			"trashSyncSchedule",
+			"templateQualityProfileMapping",
+			"instanceQualityProfileOverride",
+			"standaloneCFDeployment",
+			"qualitySizeMapping",
+			"trashSyncHistory",
+			"templateDeploymentHistory",
+			"huntConfig",
+			"huntLog",
+			"huntSearchHistory",
+			"trashBackup",
+			"libraryCleanupApproval",
+			"libraryCleanupMediaServerScan",
+			...DURABLE_CONFIG_KEYS.filter((key) => key !== "backupSettings" && key !== "vapidKeys"),
+			"backupSettings",
+			"vapidKeys",
+		];
+		const prisma = Object.fromEntries(
+			models.map((model) => [
+				model,
+				{
+					findMany: vi.fn().mockResolvedValue([]),
+					count: vi.fn().mockResolvedValue(0),
+				},
+			]),
+		) as unknown as PrismaClient;
+
+		const data = await exportDatabase(prisma);
+
+		for (const key of DURABLE_CONFIG_KEYS) {
+			expect(data[key]).toEqual([]);
+		}
+		expect(data.libraryCleanupApproval).toEqual([]);
+		expect(data.libraryCleanupMediaServerScan).toEqual([]);
+	});
+
+	it("exports no-scan approvals awaiting terminal audit and resets nonportable audit markers", async () => {
+		const awaitingAudit = {
+			id: "approval-awaiting-audit",
+			status: "executed",
+			sizeOnDisk: 10n,
+			terminalAuditRecordedAt: null,
+			terminalAuditRecoveryAttemptedAt: new Date("2026-08-30T00:00:00.000Z"),
+		};
+		const auditedScanParent = {
+			id: "approval-with-scan",
+			status: "executed",
+			sizeOnDisk: 20n,
+			terminalAuditRecordedAt: new Date("2026-08-30T01:00:00.000Z"),
+			terminalAuditRecoveryAttemptedAt: new Date("2026-08-30T00:30:00.000Z"),
+		};
+		const emptyDelegate = {
+			findMany: vi.fn().mockResolvedValue([]),
+			count: vi.fn().mockResolvedValue(0),
+		};
+		const approvalFindMany = vi.fn(async ({ where }: { where: Record<string, unknown> }) => {
+			if ("OR" in where) return [awaitingAudit];
+			if ("id" in where) return [auditedScanParent];
+			return [];
+		});
+		const scanFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "scan-1",
+				approvalId: auditedScanParent.id,
+				status: "failed",
+			},
+		]);
+		const prisma = new Proxy(
+			{},
+			{
+				get: (_target, property) => {
+					if (property === "libraryCleanupApproval") {
+						return { findMany: approvalFindMany };
+					}
+					if (property === "libraryCleanupMediaServerScan") {
+						return { findMany: scanFindMany };
+					}
+					return emptyDelegate;
+				},
+			},
+		) as unknown as PrismaClient;
+
+		const data = await exportDatabase(prisma);
+
+		expect(data.libraryCleanupApproval).toEqual([
+			expect.objectContaining({
+				id: awaitingAudit.id,
+				sizeOnDisk: "10",
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			}),
+			expect.objectContaining({
+				id: auditedScanParent.id,
+				sizeOnDisk: "20",
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			}),
+		]);
+	});
+
+	it("rejects legacy omission of an older relational config collection", async () => {
+		const prisma = {
+			trashTemplate: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.trashTemplates;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects an incomplete legacy payload over a populated durable-config target", async () => {
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects incomplete legacy coverage over partial stored backup-password state", async () => {
+		const prisma = {
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({
+					encryptedPassword: "ciphertext-without-iv",
+					passwordIv: null,
+				}),
+			},
+			vapidKeys: { findFirst: vi.fn().mockResolvedValue(null) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.backupSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rejects incomplete legacy coverage over stored VAPID private-key state", async () => {
+		const prisma = {
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({ encryptedPassword: null, passwordIv: null }),
+			},
+			vapidKeys: {
+				findFirst: vi.fn().mockResolvedValue({
+					encryptedPrivateKey: null,
+					privateKeyIv: "iv-without-ciphertext",
+				}),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.vapidKeys;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("allows incomplete legacy coverage over default non-secret backup settings", async () => {
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(0) },
+			backupSettings: {
+				findFirst: vi.fn().mockResolvedValue({ encryptedPassword: null, passwordIv: null }),
+			},
+			vapidKeys: { findFirst: vi.fn().mockResolvedValue(null) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.backupSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("allows unrelated legacy omissions when singleton replacement arrays are present", async () => {
+		const backupSettingsFindFirst = vi.fn().mockResolvedValue({
+			encryptedPassword: "target-ciphertext",
+			passwordIv: "target-iv",
+		});
+		const vapidKeysFindFirst = vi.fn().mockResolvedValue({
+			encryptedPrivateKey: "target-vapid-ciphertext",
+			privateKeyIv: "target-vapid-iv",
+		});
+		const prisma = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(0) },
+			backupSettings: { findFirst: backupSettingsFindFirst },
+			vapidKeys: { findFirst: vapidKeysFindFirst },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+		expect(backupSettingsFindFirst).not.toHaveBeenCalled();
+		expect(vapidKeysFindFirst).not.toHaveBeenCalled();
+	});
+
+	it("rejects legacy omission of current OIDC provider state", async () => {
+		const prisma = {
+			oIDCProvider: { count: vi.fn().mockResolvedValue(1) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.oidcProviders;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("allows legacy omission when the only naming history is terminal audit", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("allows legacy omission when the only naming history is rolled back", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it("rejects legacy omission when active naming recovery is populated", async () => {
+		const prisma = {
+			namingDeployHistory: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "active", status: "SUCCESS", rolledBack: false }]),
+			},
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.namingDeployHistory;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+	});
+
+	it("rechecks compatibility inside the transaction before the first delete", async () => {
+		const firstDelete = vi.fn();
+		const tx = {
+			notificationChannel: { count: vi.fn().mockResolvedValue(1) },
+			huntSearchHistory: { deleteMany: firstDelete },
+		};
+		const prisma = {
+			$transaction: vi.fn(async (operation: (value: unknown) => Promise<void>) => operation(tx)),
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.notificationChannel;
+
+		await expect(restoreDatabase(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+		expect(firstDelete).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-format-12.test.ts
@@ -15,6 +15,7 @@ const DURABLE_CONFIG_KEYS = [
 	"queueCleanerConfig",
 	"libraryCleanupConfig",
 	"libraryCleanupRule",
+	"librarySyncSettings",
 	"namingConfig",
 	"userCustomFormat",
 	"namingDeployHistory",
@@ -103,6 +104,13 @@ describe("backup format 1.2", () => {
 		expect(() => validateBackup(backup)).toThrow(/libraryCleanupApproval/);
 	});
 
+	it("rejects a 1.2 payload when library polling settings are missing", () => {
+		const backup = baseBackup() as { data: Record<string, unknown> };
+		delete backup.data.librarySyncSettings;
+
+		expect(() => validateBackup(backup)).toThrow(/librarySyncSettings/);
+	});
+
 	it("exports every durable configuration collection as an explicit array", async () => {
 		const models = [
 			"user",
@@ -129,7 +137,10 @@ describe("backup format 1.2", () => {
 			"trashBackup",
 			"libraryCleanupApproval",
 			"libraryCleanupMediaServerScan",
-			...DURABLE_CONFIG_KEYS.filter((key) => key !== "backupSettings" && key !== "vapidKeys"),
+			"librarySyncStatus",
+			...DURABLE_CONFIG_KEYS.filter(
+				(key) => key !== "backupSettings" && key !== "vapidKeys" && key !== "librarySyncSettings",
+			),
 			"backupSettings",
 			"vapidKeys",
 		];
@@ -156,6 +167,66 @@ describe("backup format 1.2", () => {
 		}
 		expect(data.libraryCleanupApproval).toEqual([]);
 		expect(data.libraryCleanupMediaServerScan).toEqual([]);
+	});
+
+	it("exports only durable library polling settings", async () => {
+		const status = {
+			id: "status-1",
+			instanceId: "instance-1",
+			pollingEnabled: false,
+			pollingIntervalMins: 90,
+			lastFullSync: new Date("2026-08-31T00:00:00.000Z"),
+			lastIncrementalSync: new Date("2026-08-31T00:01:00.000Z"),
+			syncInProgress: true,
+			lastSyncDurationMs: 123,
+			lastError: "stale failure",
+			itemCount: 42,
+			createdAt: new Date("2026-08-31T00:00:00.000Z"),
+			updatedAt: new Date("2026-08-31T00:01:00.000Z"),
+		};
+		const emptyDelegate = {
+			findMany: vi.fn().mockResolvedValue([]),
+			count: vi.fn().mockResolvedValue(0),
+		};
+		const librarySyncFindMany = vi.fn().mockResolvedValue([
+			{
+				instanceId: status.instanceId,
+				pollingEnabled: status.pollingEnabled,
+				pollingIntervalMins: status.pollingIntervalMins,
+			},
+		]);
+		let prisma!: PrismaClient;
+		prisma = new Proxy(
+			{},
+			{
+				get: (_target, property) => {
+					if (property === "$transaction") {
+						return async (operation: (tx: PrismaClient) => Promise<unknown>) => operation(prisma);
+					}
+					if (property === "librarySyncStatus") {
+						return { findMany: librarySyncFindMany };
+					}
+					return emptyDelegate;
+				},
+			},
+		) as unknown as PrismaClient;
+
+		const data = await exportDatabase(prisma);
+
+		expect(librarySyncFindMany).toHaveBeenCalledWith({
+			select: {
+				instanceId: true,
+				pollingEnabled: true,
+				pollingIntervalMins: true,
+			},
+		});
+		expect(data.librarySyncSettings).toEqual([
+			{
+				instanceId: "instance-1",
+				pollingEnabled: false,
+				pollingIntervalMins: 90,
+			},
+		]);
 	});
 
 	it("exports no-scan approvals awaiting terminal audit and resets nonportable audit markers", async () => {
@@ -248,6 +319,73 @@ describe("backup format 1.2", () => {
 		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
 			"does not contain complete configuration or recovery coverage",
 		);
+	});
+
+	it("rejects legacy omission over non-default library polling settings", async () => {
+		const findMany = vi.fn().mockResolvedValue([{ instanceId: "instance-1" }]);
+		const prisma = {
+			librarySyncStatus: { findMany },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.librarySyncSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).rejects.toThrow(
+			"does not contain complete configuration or recovery coverage",
+		);
+		expect(findMany).toHaveBeenCalledWith({
+			where: {
+				OR: [{ pollingEnabled: false }, { pollingIntervalMins: { not: 15 } }],
+			},
+			select: { instanceId: true },
+		});
+	});
+
+	it("allows legacy omission when library polling settings are defaults", async () => {
+		const prisma = {
+			librarySyncStatus: { findMany: vi.fn().mockResolvedValue([]) },
+		} as unknown as PrismaClient;
+		const legacyData = { ...baseBackup().data } as Record<string, unknown>;
+		delete legacyData.librarySyncSettings;
+
+		await expect(assertRestoreCompatibility(prisma, legacyData as never)).resolves.toBeUndefined();
+	});
+
+	it.each([
+		["non-boolean enabled state", { pollingEnabled: "false", pollingIntervalMins: 15 }],
+		["non-integer interval", { pollingEnabled: true, pollingIntervalMins: 15.5 }],
+		["too-short interval", { pollingEnabled: true, pollingIntervalMins: 4 }],
+		["too-long interval", { pollingEnabled: true, pollingIntervalMins: 1441 }],
+	])("rejects %s before opening the restore transaction", async (_label, settings) => {
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		await expect(
+			restoreDatabase(
+				prisma,
+				baseBackup({
+					librarySyncSettings: [{ instanceId: "instance-1", ...settings }],
+				}).data as never,
+			),
+		).rejects.toThrow(/librarySyncSettings/);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
+	it("rejects duplicate library polling settings before opening the restore transaction", async () => {
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+		const settings = {
+			instanceId: "instance-1",
+			pollingEnabled: true,
+			pollingIntervalMins: 15,
+		};
+
+		await expect(
+			restoreDatabase(
+				prisma,
+				baseBackup({ librarySyncSettings: [settings, settings] }).data as never,
+			),
+		).rejects.toThrow(/duplicate.*librarySyncSettings/i);
+		expect(transaction).not.toHaveBeenCalled();
 	});
 
 	it("rejects incomplete legacy coverage over partial stored backup-password state", async () => {

--- a/apps/api/src/lib/backup/__tests__/backup-mutation-gate.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-mutation-gate.test.ts
@@ -46,6 +46,37 @@ describe("backup request mutation gate", () => {
 		expect((await mutation).statusCode).toBe(200);
 	});
 
+	it("covers explicitly marked write-on-read handlers while leaving ordinary reads available", async () => {
+		const app = Fastify();
+		apps.push(app);
+		registerBackupMutationGuard(app);
+
+		let releaseWrite!: () => void;
+		const writeStarted = new Promise<void>((resolve) => {
+			app.get("/settings", { config: { backupMutation: true } }, async () => {
+				resolve();
+				await new Promise<void>((release) => {
+					releaseWrite = release;
+				});
+				return { saved: true };
+			});
+		});
+		app.get("/health", async () => ({ ok: true }));
+		await app.ready();
+
+		const writeOnRead = app.inject({ method: "GET", url: "/settings" });
+		await writeStarted;
+		const maintenanceWork = vi.fn();
+		await expect(withCleanupMaintenanceGuard(async () => maintenanceWork())).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(maintenanceWork).not.toHaveBeenCalled();
+		expect((await app.inject({ method: "GET", url: "/health" })).statusCode).toBe(200);
+
+		releaseWrite();
+		expect((await writeOnRead).statusCode).toBe(200);
+	});
+
 	it("upgrades the request's sole shared lease for a maintenance owner", async () => {
 		const app = Fastify();
 		apps.push(app);

--- a/apps/api/src/lib/backup/__tests__/backup-mutation-gate.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-mutation-gate.test.ts
@@ -1,0 +1,87 @@
+import Fastify from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerBackupMutationGuard } from "../backup-mutation-gate.js";
+import {
+	withCleanupMaintenanceGuard,
+	withCleanupOperationGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
+
+describe("backup request mutation gate", () => {
+	const apps: Array<ReturnType<typeof Fastify>> = [];
+
+	afterEach(async () => {
+		await Promise.all(apps.splice(0).map((app) => app.close()));
+	});
+
+	it("covers mutating child-plugin handlers while leaving reads available", async () => {
+		const app = Fastify();
+		apps.push(app);
+		registerBackupMutationGuard(app);
+
+		let releaseMutation!: () => void;
+		const mutationStarted = new Promise<void>((resolve) => {
+			app.register(async (child) => {
+				child.post("/config", async () => {
+					resolve();
+					await new Promise<void>((release) => {
+						releaseMutation = release;
+					});
+					return { saved: true };
+				});
+			});
+		});
+		app.get("/health", async () => ({ ok: true }));
+		await app.ready();
+
+		const mutation = app.inject({ method: "POST", url: "/config" });
+		await mutationStarted;
+		const maintenanceWork = vi.fn();
+		await expect(withCleanupMaintenanceGuard(async () => maintenanceWork())).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(maintenanceWork).not.toHaveBeenCalled();
+		expect((await app.inject({ method: "GET", url: "/health" })).statusCode).toBe(200);
+
+		releaseMutation();
+		expect((await mutation).statusCode).toBe(200);
+	});
+
+	it("upgrades the request's sole shared lease for a maintenance owner", async () => {
+		const app = Fastify();
+		apps.push(app);
+		registerBackupMutationGuard(app);
+
+		let releaseMaintenance!: () => void;
+		const maintenanceStarted = new Promise<void>((resolve) => {
+			app.post("/restore", async () =>
+				withCleanupMaintenanceGuard(async () => {
+					resolve();
+					await new Promise<void>((release) => {
+						releaseMaintenance = release;
+					});
+					return { restored: true };
+				}),
+			);
+		});
+		app.post("/config", async () => ({ saved: true }));
+		await app.ready();
+
+		const restore = app.inject({ method: "POST", url: "/restore" });
+		await maintenanceStarted;
+		const blocked = await app.inject({ method: "POST", url: "/config" });
+
+		expect(blocked.statusCode).toBe(409);
+		releaseMaintenance();
+		expect((await restore).statusCode).toBe(200);
+	});
+
+	it("does not weaken an existing shared operation owner", async () => {
+		const app = Fastify();
+		apps.push(app);
+		registerBackupMutationGuard(app);
+		app.post("/shared", async () => withCleanupOperationGuard(async () => ({ saved: true })));
+		await app.ready();
+
+		expect((await app.inject({ method: "POST", url: "/shared" })).statusCode).toBe(200);
+	});
+});

--- a/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
@@ -1,0 +1,703 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import { BackupCompatibilityError } from "../../errors.js";
+import type { PrismaClient } from "../../prisma.js";
+import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { BACKUP_VERSION, validateBackup } from "../backup-validation.js";
+
+const RUN_DB_TESTS = process.env.TEST_DB === "true";
+const execFileAsync = promisify(execFile);
+
+type DatabaseHandle = { prisma: PrismaClient; cleanup: () => Promise<void> };
+
+async function pushSqliteSchema(databasePath: string, apiDir: string): Promise<void> {
+	await execFileAsync(
+		"pnpm",
+		[
+			"exec",
+			"prisma",
+			"db",
+			"push",
+			"--schema",
+			"prisma/schema.prisma",
+			"--url",
+			`file:${databasePath}`,
+		],
+		{ cwd: apiDir, env: { ...process.env, DATABASE_URL: `file:${databasePath}` } },
+	);
+}
+
+function withPostgresSchema(connectionString: string, schema: string): string {
+	const url = new URL(connectionString);
+	url.searchParams.set("schema", schema);
+	return url.toString();
+}
+
+async function createPostgresDatabasePair(
+	connectionString: string,
+	tempDir: string,
+	apiDir: string,
+): Promise<{ source: DatabaseHandle; target: DatabaseHandle }> {
+	const suffix = `${process.pid}_${Date.now()}`;
+	const sourceSchema = `backup815_source_${suffix}`;
+	const targetSchema = `backup815_target_${suffix}`;
+	const pg = await import("pg");
+	const admin = new pg.default.Pool({ connectionString });
+	const schemaFile = path.join(tempDir, "postgres-schema.prisma");
+	const clientOutput = path.join(tempDir, "postgres-client");
+	const pools: InstanceType<typeof pg.default.Pool>[] = [];
+	const clients: PrismaClient[] = [];
+	try {
+		await admin.query(`CREATE SCHEMA "${sourceSchema}"`);
+		await admin.query(`CREATE SCHEMA "${targetSchema}"`);
+		const sourceSchemaText = await readFile(path.join(apiDir, "prisma/schema.prisma"), "utf8");
+		const postgresSchemaText = sourceSchemaText
+			.replace(
+				/generator client \{[\s\S]*?\}\n\n/,
+				`generator client {\n  provider = "prisma-client"\n  output = "${clientOutput}"\n}\n\n`,
+			)
+			.replace('provider = "sqlite"', 'provider = "postgresql"');
+		await writeFile(schemaFile, postgresSchemaText, "utf8");
+		await execFileAsync("pnpm", ["exec", "prisma", "generate", "--schema", schemaFile], {
+			cwd: apiDir,
+			env: process.env,
+		});
+		for (const schema of [sourceSchema, targetSchema]) {
+			const schemaUrl = withPostgresSchema(connectionString, schema);
+			await execFileAsync(
+				"pnpm",
+				["exec", "prisma", "db", "push", "--schema", schemaFile, "--url", schemaUrl],
+				{ cwd: apiDir, env: { ...process.env, DATABASE_URL: schemaUrl } },
+			);
+		}
+		const generatedModule = await import(
+			/* @vite-ignore */ pathToFileURL(path.join(clientOutput, "client.ts")).href
+		);
+		const generatedExports = (generatedModule.default ?? generatedModule) as {
+			PrismaClient: new (options: { adapter: unknown }) => PrismaClient;
+		};
+		const { PrismaPg } = await import("@prisma/adapter-pg");
+		for (const schema of [sourceSchema, targetSchema]) {
+			const pool = new pg.default.Pool({
+				connectionString: withPostgresSchema(connectionString, schema),
+			});
+			pools.push(pool);
+			clients.push(
+				new generatedExports.PrismaClient({
+					adapter: new PrismaPg(pool as never, { schema }),
+				}),
+			);
+		}
+		const [sourcePrisma, targetPrisma] = clients;
+		if (!sourcePrisma || !targetPrisma) throw new Error("PostgreSQL test clients were not created");
+		return {
+			source: {
+				prisma: sourcePrisma,
+				cleanup: async () => {
+					await sourcePrisma.$disconnect();
+					await pools[0]?.end();
+				},
+			},
+			target: {
+				prisma: targetPrisma,
+				cleanup: async () => {
+					await targetPrisma.$disconnect();
+					await pools[1]?.end();
+					await admin.query(`DROP SCHEMA "${sourceSchema}" CASCADE`);
+					await admin.query(`DROP SCHEMA "${targetSchema}" CASCADE`);
+					await admin.end();
+				},
+			},
+		};
+	} catch (error) {
+		await Promise.allSettled(clients.map((client) => client.$disconnect()));
+		await Promise.allSettled(pools.map((pool) => pool.end()));
+		await Promise.allSettled([
+			admin.query(`DROP SCHEMA IF EXISTS "${sourceSchema}" CASCADE`),
+			admin.query(`DROP SCHEMA IF EXISTS "${targetSchema}" CASCADE`),
+		]);
+		await admin.end().catch(() => undefined);
+		throw error;
+	}
+}
+
+async function createDatabasePair(): Promise<{
+	source: DatabaseHandle;
+	target: DatabaseHandle;
+	tempDir: string;
+}> {
+	const tempDir = await mkdtemp(path.join(os.tmpdir(), "backup-roundtrip-"));
+	const apiDir = path.resolve(import.meta.dirname, "../../../..");
+	const externalDatabaseUrl = process.env.TEST_DATABASE_URL;
+	if (externalDatabaseUrl?.startsWith("postgres")) {
+		return { ...(await createPostgresDatabasePair(externalDatabaseUrl, tempDir, apiDir)), tempDir };
+	}
+	const sourcePath = path.join(tempDir, "source.db");
+	const targetPath = path.join(tempDir, "target.db");
+	await pushSqliteSchema(sourcePath, apiDir);
+	await pushSqliteSchema(targetPath, apiDir);
+	return {
+		source: (() => {
+			const prisma = createTestPrismaClient(sourcePath);
+			return { prisma, cleanup: () => prisma.$disconnect() };
+		})(),
+		target: (() => {
+			const prisma = createTestPrismaClient(targetPath);
+			return { prisma, cleanup: () => prisma.$disconnect() };
+		})(),
+		tempDir,
+	};
+}
+
+async function seedDurableSource(prisma: PrismaClient): Promise<void> {
+	const userId = "issue815-roundtrip-user";
+	const instanceId = "issue815-roundtrip-instance";
+	const coordinationCreatedAt = new Date("2026-08-31T00:00:00.000Z");
+	const coordinationUpdatedAt = new Date("2026-08-31T00:01:00.000Z");
+	await prisma.user.create({
+		data: {
+			id: userId,
+			username: userId,
+			hashedPassword: "password-hash",
+			encryptedTmdbApiKey: "tmdb-ciphertext",
+			tmdbEncryptionIv: "tmdb-iv",
+			encryptedTraktAccessToken: "trakt-ciphertext",
+			traktTokenIv: "trakt-iv",
+		},
+	});
+	await prisma.session.create({
+		data: { id: "issue815-session", userId, expiresAt: new Date("2030-01-01T00:00:00.000Z") },
+	});
+	await prisma.serviceTag.create({ data: { id: "issue815-tag", name: "issue815" } });
+	await prisma.serviceInstance.create({
+		data: {
+			id: instanceId,
+			userId,
+			service: "RADARR",
+			label: "Issue 815 Radarr",
+			baseUrl: "http://radarr.example",
+			encryptedApiKey: "api-ciphertext",
+			encryptionIv: "api-iv",
+			encryptedHttpAuthCredentials: "http-auth-ciphertext",
+			httpAuthEncryptionIv: "http-auth-iv",
+		},
+	});
+	await prisma.serviceInstanceTag.create({ data: { instanceId, tagId: "issue815-tag" } });
+	await prisma.oIDCProvider.create({
+		data: {
+			id: 1,
+			displayName: "Issue 815 OIDC",
+			clientId: "client-id",
+			encryptedClientSecret: "oidc-ciphertext",
+			clientSecretIv: "oidc-iv",
+			issuer: "https://issuer.example",
+			redirectUri: "https://dashboard.example/callback",
+		},
+	});
+	await prisma.oIDCAccount.create({
+		data: { id: "issue815-oidc-account", userId, providerUserId: "provider-user" },
+	});
+	await prisma.webAuthnCredential.create({
+		data: { id: "issue815-credential", userId, publicKey: "passkey-public", counter: 3 },
+	});
+	await prisma.systemSettings.create({ data: { id: 1, appName: "Issue 815" } });
+	await prisma.backupSettings.create({
+		data: {
+			id: 1,
+			enabled: true,
+			intervalType: "DAILY",
+			encryptedPassword: "backup-password-ciphertext",
+			passwordIv: "backup-password-iv",
+		},
+	});
+	await prisma.vapidKeys.create({
+		data: {
+			id: 1,
+			publicKey: "vapid-public",
+			encryptedPrivateKey: "vapid-ciphertext",
+			privateKeyIv: "vapid-iv",
+		},
+	});
+	await prisma.trashCache.create({
+		data: {
+			id: "issue815-target-era-trash-cache",
+			serviceType: "RADARR",
+			configType: "CUSTOM_FORMATS",
+			data: '{"targetEra":true}',
+		},
+	});
+	await prisma.libraryCleanupMediaServerScanLease.create({
+		data: {
+			operationKey: "issue815:shared-server:library",
+			userId,
+			executionToken: "issue815-target-era-lease",
+		},
+	});
+
+	const template = await prisma.trashTemplate.create({
+		data: {
+			id: "issue815-template",
+			userId,
+			name: "Issue 815 template",
+			serviceType: "RADARR",
+			configData: '{"customFormats":[]}',
+		},
+	});
+	await prisma.trashSettings.create({ data: { id: "issue815-trash-settings", userId } });
+	await prisma.trashSyncSchedule.create({
+		data: {
+			id: "issue815-schedule",
+			userId,
+			instanceId,
+			templateId: template.id,
+			frequency: "DAILY",
+		},
+	});
+	await prisma.templateQualityProfileMapping.create({
+		data: {
+			id: "issue815-profile-mapping",
+			templateId: template.id,
+			instanceId,
+			qualityProfileId: 10,
+			qualityProfileName: "Issue 815 profile",
+		},
+	});
+	await prisma.instanceQualityProfileOverride.create({
+		data: {
+			id: "issue815-score-intent",
+			instanceId,
+			qualityProfileId: 10,
+			customFormatId: 20,
+			score: 42,
+			status: "PENDING",
+			intentOperation: "SET_SCORE",
+			intendedScore: 42,
+			userId,
+			connectionGeneration: 2,
+			connectionStateToken: "state-token",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.standaloneCFDeployment.create({
+		data: {
+			id: "issue815-standalone-cf",
+			userId,
+			instanceId,
+			cfTrashId: "issue815-cf",
+			cfName: "Issue 815 CF",
+			serviceType: "RADARR",
+			commitHash: "commit",
+		},
+	});
+	await prisma.qualitySizeMapping.create({
+		data: {
+			id: "issue815-quality-size",
+			instanceId,
+			userId,
+			presetTrashId: "issue815-preset",
+			presetType: "movie",
+			serviceType: "RADARR",
+			lastAppliedAt: new Date("2025-01-01T00:00:00.000Z"),
+		},
+	});
+	await prisma.huntConfig.create({
+		data: { id: "issue815-hunt", instanceId, huntMissingEnabled: true, missingBatchSize: 2 },
+	});
+	await prisma.queueCleanerConfig.create({
+		data: { id: "issue815-queue", instanceId, enabled: true, dryRunMode: false },
+	});
+	const cleanup = await prisma.libraryCleanupConfig.create({
+		data: { id: "issue815-cleanup", userId, enabled: true, dryRunMode: false },
+	});
+	await prisma.libraryCleanupRule.create({
+		data: {
+			id: "issue815-cleanup-rule",
+			configId: cleanup.id,
+			name: "Issue 815 rule",
+			ruleType: "age",
+			parameters: '{"days":30}',
+		},
+	});
+	await prisma.libraryCleanupApproval.create({
+		data: {
+			id: "issue815-active-approval",
+			configId: cleanup.id,
+			instanceId,
+			arrItemId: 815,
+			itemType: "movie",
+			title: "Issue 815 movie",
+			matchedRuleId: "issue815-cleanup-rule",
+			matchedRuleName: "Issue 815 rule",
+			reason: "age",
+			action: "delete",
+			sizeOnDisk: BigInt(1234),
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			status: "pending",
+			createdAt: coordinationCreatedAt,
+		},
+	});
+	await prisma.libraryCleanupApproval.create({
+		data: {
+			id: "issue815-executed-parent",
+			configId: cleanup.id,
+			instanceId,
+			arrItemId: 816,
+			itemType: "series",
+			title: "Issue 815 series",
+			matchedRuleId: "issue815-cleanup-rule",
+			matchedRuleName: "Issue 815 rule",
+			reason: "size",
+			action: "delete",
+			sizeOnDisk: BigInt(5678),
+			expiresAt: new Date("2030-01-01T00:00:00.000Z"),
+			status: "executed",
+			terminalAuditRecordedAt: new Date("2029-01-01T00:00:00.000Z"),
+			terminalAuditRecoveryAttemptedAt: new Date("2028-12-31T23:00:00.000Z"),
+			createdAt: coordinationCreatedAt,
+		},
+	});
+	await prisma.libraryCleanupMediaServerScan.create({
+		data: {
+			id: "issue815-pending-scan",
+			approvalId: "issue815-active-approval",
+			instanceId,
+			service: "PLEX",
+			mediaType: "movie",
+			targetKey: "movie:815",
+			status: "pending",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.libraryCleanupMediaServerScan.create({
+		data: {
+			id: "issue815-failed-scan",
+			approvalId: "issue815-executed-parent",
+			instanceId,
+			service: "PLEX",
+			mediaType: "show",
+			targetKey: "series:816",
+			status: "failed",
+			lastError: "test failure",
+			createdAt: coordinationCreatedAt,
+			updatedAt: coordinationUpdatedAt,
+		},
+	});
+	await prisma.userCustomFormat.create({
+		data: {
+			id: "issue815-custom-format",
+			userId,
+			name: "Issue 815 format",
+			serviceType: "RADARR",
+			specifications: "[]",
+			defaultScore: 42,
+		},
+	});
+	const channel = await prisma.notificationChannel.create({
+		data: {
+			id: "issue815-channel",
+			userId,
+			name: "Issue 815 channel",
+			type: "WEBHOOK",
+			encryptedConfig: "notification-ciphertext",
+			configIv: "notification-iv",
+		},
+	});
+	await prisma.notificationSubscription.create({
+		data: { channelId: channel.id, eventType: "BACKUP_FAILED" },
+	});
+	await prisma.notificationRule.create({
+		data: {
+			id: "issue815-notification-rule",
+			userId,
+			name: "Issue 815 rule",
+			action: "suppress",
+			conditions: "[]",
+		},
+	});
+	await prisma.notificationAggregationConfig.create({
+		data: { id: "issue815-aggregation", userId, eventType: "BACKUP_FAILED" },
+	});
+	await prisma.namingConfig.create({
+		data: {
+			id: "issue815-naming",
+			instanceId,
+			userId,
+			serviceType: "RADARR",
+			selectedPresets: "{}",
+		},
+	});
+	await prisma.labelSyncRule.create({
+		data: {
+			id: "issue815-label-sync",
+			userId,
+			name: "Issue 815 label sync",
+			sourceService: "radarr",
+			sourceTagName: "source",
+			destInstanceId: instanceId,
+			destTagName: "destination",
+		},
+	});
+	await prisma.autoTagRule.create({
+		data: {
+			id: "issue815-auto-tag",
+			userId,
+			name: "Issue 815 auto tag",
+			ruleType: "age",
+			parameters: "{}",
+			tagName: "issue815",
+		},
+	});
+	await prisma.namingDeployHistory.create({
+		data: {
+			id: "issue815-naming-history",
+			instanceId,
+			userId,
+			status: "SUCCESS",
+			selectedPresets: "{}",
+			resolvedPayload: "{}",
+			changedFields: 1,
+			totalFields: 1,
+			deployedAt: coordinationCreatedAt,
+		},
+	});
+}
+
+function normalizedRows(rows: unknown[]): string[] {
+	return rows
+		.map((row) =>
+			JSON.stringify(row, (_key, value) => {
+				if (value instanceof Date) return value.toISOString();
+				if (typeof value === "bigint") return value.toString();
+				return value;
+			}),
+		)
+		.sort();
+}
+
+const MODEL_EXPORTS = [
+	["users", "user"],
+	["sessions", "session"],
+	["serviceInstances", "serviceInstance"],
+	["serviceTags", "serviceTag"],
+	["serviceInstanceTags", "serviceInstanceTag"],
+	["oidcProviders", "oIDCProvider"],
+	["oidcAccounts", "oIDCAccount"],
+	["webAuthnCredentials", "webAuthnCredential"],
+	["systemSettings", "systemSettings"],
+	["backupSettings", "backupSettings"],
+	["vapidKeys", "vapidKeys"],
+	["trashTemplates", "trashTemplate"],
+	["trashSettings", "trashSettings"],
+	["trashSyncSchedules", "trashSyncSchedule"],
+	["templateQualityProfileMappings", "templateQualityProfileMapping"],
+	["instanceQualityProfileOverrides", "instanceQualityProfileOverride"],
+	["standaloneCFDeployments", "standaloneCFDeployment"],
+	["qualitySizeMappings", "qualitySizeMapping"],
+	["huntConfigs", "huntConfig"],
+	["queueCleanerConfig", "queueCleanerConfig"],
+	["libraryCleanupConfig", "libraryCleanupConfig"],
+	["libraryCleanupRule", "libraryCleanupRule"],
+	["libraryCleanupApproval", "libraryCleanupApproval"],
+	["libraryCleanupMediaServerScan", "libraryCleanupMediaServerScan"],
+	["userCustomFormat", "userCustomFormat"],
+	["notificationChannel", "notificationChannel"],
+	["notificationSubscription", "notificationSubscription"],
+	["notificationRule", "notificationRule"],
+	["notificationAggregationConfig", "notificationAggregationConfig"],
+	["namingConfig", "namingConfig"],
+	["namingDeployHistory", "namingDeployHistory"],
+	["labelSyncRule", "labelSyncRule"],
+	["autoTagRule", "autoTagRule"],
+] as const;
+
+(RUN_DB_TESTS ? describe : describe.skip)(
+	"backup format 1.2 independent database round-trip",
+	() => {
+		let source: DatabaseHandle;
+		let target: DatabaseHandle;
+		let tempDir: string;
+
+		beforeAll(async () => {
+			({ source, target, tempDir } = await createDatabasePair());
+			await seedDurableSource(source.prisma);
+			await seedDurableSource(target.prisma);
+		});
+
+		afterAll(async () => {
+			const cleanupErrors: unknown[] = [];
+			for (const cleanup of [source?.cleanup, target?.cleanup]) {
+				try {
+					await cleanup?.();
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+			}
+			try {
+				if (tempDir) await rm(tempDir, { recursive: true, force: true });
+			} catch (error) {
+				cleanupErrors.push(error);
+			}
+			if (cleanupErrors.length > 0) {
+				throw new AggregateError(cleanupErrors, "Backup round-trip cleanup failed");
+			}
+		});
+
+		it("rejects incomplete populated-target restores, then replaces complete and covered legacy state", async () => {
+			const exported = await exportDatabase(source.prisma, { excludeOperationalHistory: true });
+			const backup = {
+				version: BACKUP_VERSION,
+				appVersion: "2.24.2",
+				timestamp: new Date().toISOString(),
+				data: exported,
+				secrets: { encryptionKey: "key", sessionCookieSecret: "session" },
+			};
+			validateBackup(backup);
+
+			await target.prisma.queueCleanerConfig.update({
+				where: { id: "issue815-queue" },
+				data: { enabled: false },
+			});
+			await target.prisma.backupSettings.update({
+				where: { id: 1 },
+				data: {
+					encryptedPassword: "target-backup-ciphertext",
+					passwordIv: "target-backup-iv",
+				},
+			});
+			await target.prisma.notificationLog.create({
+				data: {
+					id: "issue815-post-snapshot-notification",
+					channelId: "issue815-channel",
+					channelType: "WEBHOOK",
+					eventType: "BACKUP_FAILED",
+					title: "Post-snapshot title",
+					body: "Post-snapshot body",
+					status: "sent",
+					sentAt: new Date("2026-09-01T00:00:00.000Z"),
+				},
+			});
+			const incompleteData = { ...exported } as Record<string, unknown>;
+			delete incompleteData.queueCleanerConfig;
+
+			await expect(restoreDatabase(target.prisma, incompleteData as never)).rejects.toBeInstanceOf(
+				BackupCompatibilityError,
+			);
+			expect(
+				await target.prisma.queueCleanerConfig.findUnique({ where: { id: "issue815-queue" } }),
+			).toMatchObject({ enabled: false });
+			expect(await target.prisma.backupSettings.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPassword: "target-backup-ciphertext",
+				passwordIv: "target-backup-iv",
+			});
+			expect(await target.prisma.libraryCleanupApproval.count()).toBe(2);
+			expect(await target.prisma.notificationLog.count()).toBe(1);
+			expect(await target.prisma.trashCache.count()).toBe(1);
+			expect(await target.prisma.libraryCleanupMediaServerScanLease.count()).toBe(1);
+
+			await restoreDatabase(target.prisma, backup.data);
+			expect(await target.prisma.notificationLog.count()).toBe(0);
+			expect(await target.prisma.trashCache.count()).toBe(0);
+			expect(await target.prisma.libraryCleanupMediaServerScanLease.count()).toBe(0);
+
+			for (const [exportKey, modelKey] of MODEL_EXPORTS) {
+				const model = (
+					target.prisma as unknown as Record<string, { findMany: () => Promise<unknown[]> }>
+				)[modelKey];
+				if (!model) throw new Error(`Missing Prisma model ${modelKey}`);
+				const targetRows = await model.findMany();
+				expect(normalizedRows(targetRows), modelKey).toEqual(
+					normalizedRows(exported[exportKey] as unknown[]),
+				);
+			}
+			expect(exported.notificationChannel?.[0]).toMatchObject({
+				encryptedConfig: "notification-ciphertext",
+				configIv: "notification-iv",
+			});
+			expect(exported.users[0]).toMatchObject({
+				encryptedTmdbApiKey: "tmdb-ciphertext",
+				tmdbEncryptionIv: "tmdb-iv",
+				encryptedTraktAccessToken: "trakt-ciphertext",
+				traktTokenIv: "trakt-iv",
+			});
+			expect(exported.oidcProviders?.[0]).toMatchObject({
+				encryptedClientSecret: "oidc-ciphertext",
+				clientSecretIv: "oidc-iv",
+			});
+			expect(exported.backupSettings?.[0]).toMatchObject({
+				encryptedPassword: "backup-password-ciphertext",
+				passwordIv: "backup-password-iv",
+			});
+			expect(exported.vapidKeys?.[0]).toMatchObject({
+				encryptedPrivateKey: "vapid-ciphertext",
+				privateKeyIv: "vapid-iv",
+			});
+			expect(exported.serviceInstances[0]).toMatchObject({
+				encryptedApiKey: "api-ciphertext",
+				encryptionIv: "api-iv",
+				encryptedHttpAuthCredentials: "http-auth-ciphertext",
+				httpAuthEncryptionIv: "http-auth-iv",
+			});
+			expect(exported.instanceQualityProfileOverrides?.[0]).toMatchObject({ status: "PENDING" });
+			expect(
+				(exported.libraryCleanupApproval as Array<Record<string, unknown>>).find(
+					(row) => row.id === "issue815-executed-parent",
+				),
+			).toMatchObject({
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			});
+
+			await target.prisma.notificationSubscription.deleteMany();
+			await target.prisma.notificationChannel.deleteMany();
+			await target.prisma.backupSettings.update({
+				where: { id: 1 },
+				data: { encryptedPassword: null, passwordIv: null },
+			});
+			await target.prisma.vapidKeys.update({
+				where: { id: 1 },
+				data: {
+					encryptedPrivateKey: "target-vapid-ciphertext",
+					privateKeyIv: "target-vapid-iv",
+				},
+			});
+			const coveredLegacyData = { ...exported } as Record<string, unknown>;
+			delete coveredLegacyData.notificationChannel;
+			delete coveredLegacyData.notificationSubscription;
+			coveredLegacyData.libraryCleanupApproval = (
+				exported.libraryCleanupApproval as Array<Record<string, unknown>>
+			).map((row) => ({
+				...row,
+				terminalAuditRecordedAt: "2031-01-01T00:00:00.000Z",
+				terminalAuditRecoveryAttemptedAt: "2031-01-01T01:00:00.000Z",
+			}));
+
+			await restoreDatabase(target.prisma, coveredLegacyData as never);
+			expect(await target.prisma.backupSettings.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPassword: "backup-password-ciphertext",
+				passwordIv: "backup-password-iv",
+			});
+			expect(await target.prisma.vapidKeys.findUnique({ where: { id: 1 } })).toMatchObject({
+				encryptedPrivateKey: "vapid-ciphertext",
+				privateKeyIv: "vapid-iv",
+			});
+			expect(await target.prisma.notificationChannel.count()).toBe(0);
+			expect(await target.prisma.notificationSubscription.count()).toBe(0);
+			expect(
+				await target.prisma.libraryCleanupApproval.findUnique({
+					where: { id: "issue815-executed-parent" },
+				}),
+			).toMatchObject({
+				terminalAuditRecordedAt: null,
+				terminalAuditRecoveryAttemptedAt: null,
+			});
+		});
+	},
+);

--- a/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
 import { BackupCompatibilityError } from "../../errors.js";
-import type { PrismaClient } from "../../prisma.js";
+import type { Prisma, PrismaClient } from "../../prisma.js";
 import { exportDatabase, restoreDatabase } from "../backup-database.js";
 import { BACKUP_VERSION, validateBackup } from "../backup-validation.js";
 
@@ -16,6 +16,39 @@ const ROUND_TRIP_HOOK_TIMEOUT_MS = 120_000;
 const execFileAsync = promisify(execFile);
 
 type DatabaseHandle = { prisma: PrismaClient; cleanup: () => Promise<void> };
+
+type InteractiveTransaction = (
+	operation: (tx: Prisma.TransactionClient) => Promise<unknown>,
+	options?: {
+		maxWait?: number;
+		timeout?: number;
+		isolationLevel?: Prisma.TransactionIsolationLevel;
+	},
+) => Promise<unknown>;
+
+function withInteractiveTransactionDefaultTimeout(
+	prisma: PrismaClient,
+	timeout: number,
+	startDelay: number,
+): PrismaClient {
+	const rootTransaction = prisma.$transaction.bind(prisma) as InteractiveTransaction;
+	return new Proxy(prisma, {
+		get(target, property) {
+			if (property === "$transaction") {
+				return (
+					operation: (tx: Prisma.TransactionClient) => Promise<unknown>,
+					options?: Parameters<InteractiveTransaction>[1],
+				) =>
+					rootTransaction(async (tx) => {
+						await new Promise((resolve) => setTimeout(resolve, startDelay));
+						return operation(tx);
+					}, options ?? { timeout });
+			}
+			const value = Reflect.get(target, property, target);
+			return typeof value === "function" ? value.bind(target) : value;
+		},
+	}) as PrismaClient;
+}
 
 async function pushSqliteSchema(databasePath: string, apiDir: string): Promise<void> {
 	await execFileAsync(
@@ -699,6 +732,15 @@ const MODEL_EXPORTS = [
 				terminalAuditRecordedAt: null,
 				terminalAuditRecoveryAttemptedAt: null,
 			});
+		});
+
+		it("overrides a short client transaction default for a populated restore", async () => {
+			const exported = await exportDatabase(source.prisma, { excludeOperationalHistory: true });
+			const constrainedTarget = withInteractiveTransactionDefaultTimeout(target.prisma, 1, 25);
+
+			await expect(restoreDatabase(constrainedTarget, exported)).resolves.toBeUndefined();
+			expect(await target.prisma.queueCleanerConfig.count()).toBe(1);
+			expect(await target.prisma.notificationChannel.count()).toBe(1);
 		});
 	},
 );

--- a/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
@@ -12,6 +12,7 @@ import { exportDatabase, restoreDatabase } from "../backup-database.js";
 import { BACKUP_VERSION, validateBackup } from "../backup-validation.js";
 
 const RUN_DB_TESTS = process.env.TEST_DB === "true";
+const ROUND_TRIP_HOOK_TIMEOUT_MS = 120_000;
 const execFileAsync = promisify(execFile);
 
 type DatabaseHandle = { prisma: PrismaClient; cleanup: () => Promise<void> };
@@ -529,7 +530,7 @@ const MODEL_EXPORTS = [
 			({ source, target, tempDir } = await createDatabasePair());
 			await seedDurableSource(source.prisma);
 			await seedDurableSource(target.prisma);
-		});
+		}, ROUND_TRIP_HOOK_TIMEOUT_MS);
 
 		afterAll(async () => {
 			const cleanupErrors: unknown[] = [];
@@ -548,7 +549,7 @@ const MODEL_EXPORTS = [
 			if (cleanupErrors.length > 0) {
 				throw new AggregateError(cleanupErrors, "Backup round-trip cleanup failed");
 			}
-		});
+		}, ROUND_TRIP_HOOK_TIMEOUT_MS);
 
 		it("rejects incomplete populated-target restores, then replaces complete and covered legacy state", async () => {
 			const exported = await exportDatabase(source.prisma, { excludeOperationalHistory: true });

--- a/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-roundtrip.test.ts
@@ -223,6 +223,20 @@ async function seedDurableSource(prisma: PrismaClient): Promise<void> {
 		},
 	});
 	await prisma.serviceInstanceTag.create({ data: { instanceId, tagId: "issue815-tag" } });
+	await prisma.librarySyncStatus.create({
+		data: {
+			id: "issue815-library-sync-status",
+			instanceId,
+			pollingEnabled: false,
+			pollingIntervalMins: 90,
+			lastFullSync: coordinationCreatedAt,
+			lastIncrementalSync: coordinationUpdatedAt,
+			syncInProgress: true,
+			lastSyncDurationMs: 815,
+			lastError: "source-era sync error",
+			itemCount: 123,
+		},
+	});
 	await prisma.oIDCProvider.create({
 		data: {
 			id: 1,
@@ -586,11 +600,22 @@ const MODEL_EXPORTS = [
 
 		it("rejects incomplete populated-target restores, then replaces complete and covered legacy state", async () => {
 			const exported = await exportDatabase(source.prisma, { excludeOperationalHistory: true });
+			const exportedLibrarySyncSettings = exported.librarySyncSettings as Array<
+				Record<string, unknown>
+			>;
 			const backup = {
 				version: BACKUP_VERSION,
 				appVersion: "2.24.2",
 				timestamp: new Date().toISOString(),
-				data: exported,
+				data: {
+					...exported,
+					librarySyncSettings: exportedLibrarySyncSettings.map((settings) => ({
+						...settings,
+						syncInProgress: true,
+						lastError: "injected stale state",
+						itemCount: 999,
+					})),
+				},
 				secrets: { encryptionKey: "key", sessionCookieSecret: "session" },
 			};
 			validateBackup(backup);
@@ -640,6 +665,28 @@ const MODEL_EXPORTS = [
 			expect(await target.prisma.notificationLog.count()).toBe(0);
 			expect(await target.prisma.trashCache.count()).toBe(0);
 			expect(await target.prisma.libraryCleanupMediaServerScanLease.count()).toBe(0);
+			expect(exported.librarySyncSettings).toEqual([
+				{
+					instanceId: "issue815-roundtrip-instance",
+					pollingEnabled: false,
+					pollingIntervalMins: 90,
+				},
+			]);
+			expect(
+				await target.prisma.librarySyncStatus.findUnique({
+					where: { instanceId: "issue815-roundtrip-instance" },
+				}),
+			).toMatchObject({
+				instanceId: "issue815-roundtrip-instance",
+				pollingEnabled: false,
+				pollingIntervalMins: 90,
+				lastFullSync: null,
+				lastIncrementalSync: null,
+				syncInProgress: false,
+				lastSyncDurationMs: null,
+				lastError: null,
+				itemCount: 0,
+			});
 
 			for (const [exportKey, modelKey] of MODEL_EXPORTS) {
 				const model = (

--- a/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
@@ -45,6 +45,7 @@ const TABLE_NAMES = [
 	"queueCleanerConfig",
 	"libraryCleanupConfig",
 	"libraryCleanupRule",
+	"librarySyncStatus",
 	"libraryCleanupApproval",
 	"libraryCleanupMediaServerScan",
 	"namingConfig",

--- a/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
@@ -2,12 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loggers } from "../../logger.js";
-import type { PrismaClient } from "../../prisma.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,
 } from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { loggers } from "../../logger.js";
+import type { PrismaClient } from "../../prisma.js";
 import { decryptBackupData, type EncryptedBackupEnvelope } from "../backup-crypto.js";
 import { BackupService } from "../backup-service.js";
 
@@ -21,6 +21,8 @@ const TABLE_NAMES = [
 	"oIDCAccount",
 	"webAuthnCredential",
 	"systemSettings",
+	"backupSettings",
+	"vapidKeys",
 	"trashTemplate",
 	"trashSettings",
 	"trashSyncSchedule",
@@ -34,6 +36,20 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+	"namingConfig",
+	"namingDeployHistory",
+	"userCustomFormat",
 ] as const;
 
 function makePrismaWithCoordinationEvidence(): PrismaClient {
@@ -67,7 +83,10 @@ function makePrismaWithCoordinationEvidence(): PrismaClient {
 			expiresAt: new Date("2020-01-02T00:00:00.000Z"),
 		},
 	]);
-	prisma.backupSettings = { findUnique: vi.fn().mockResolvedValue(null) };
+	prisma.backupSettings = {
+		findMany: vi.fn().mockResolvedValue([]),
+		findUnique: vi.fn().mockResolvedValue(null),
+	};
 
 	return prisma as unknown as PrismaClient;
 }
@@ -147,7 +166,7 @@ describe("BackupService coordination safety", () => {
 			};
 
 			expect(envelope.version).toBe("1.0");
-			expect(payload.version).toBe("1.1");
+			expect(payload.version).toBe("1.2");
 			expect(payload.data.trashSyncHistory).toEqual([
 				expect.objectContaining({ id: "rollback-active" }),
 			]);
@@ -161,9 +180,15 @@ describe("BackupService coordination safety", () => {
 				expect.objectContaining({
 					backupType: "scheduled",
 					skippedTables: ["huntLog", "huntSearchHistory"],
-					preservedTables: ["trashSyncHistory", "templateDeploymentHistory", "trashBackup"],
+					preservedTables: [
+						"trashSyncHistory",
+						"templateDeploymentHistory",
+						"trashBackup",
+						"libraryCleanupApproval",
+						"libraryCleanupMediaServerScan",
+					],
 				}),
-				"Backup excluded disposable operational history while preserving nonterminal TRaSH coordination evidence",
+				"Backup excluded disposable operational history while preserving nonterminal safety coordination evidence",
 			);
 		} finally {
 			await fs.rm(tempDir, { recursive: true, force: true });

--- a/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
@@ -87,6 +87,9 @@ function makePrismaWithCoordinationEvidence(): PrismaClient {
 		findMany: vi.fn().mockResolvedValue([]),
 		findUnique: vi.fn().mockResolvedValue(null),
 	};
+	prisma.$transaction = vi.fn(async (operation: (tx: unknown) => Promise<unknown>) =>
+		operation(prisma),
+	);
 
 	return prisma as unknown as PrismaClient;
 }

--- a/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
@@ -2,12 +2,25 @@ import type { FastifyBaseLogger } from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "../../../lib/prisma.js";
 import type { Encryptor } from "../../auth/encryption.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+	withCleanupOperationGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { BackupScheduler } from "../backup-scheduler.js";
 import { BackupPasswordConfigurationError } from "../backup-service.js";
 
 afterEach(() => {
 	vi.unstubAllEnvs();
 });
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
 
 function schedulerPasswordService(
 	settings: { encryptedPassword: string | null; passwordIv: string | null },
@@ -147,5 +160,107 @@ describe("BackupScheduler database password wiring", () => {
 		await expect(backupService.getBackupPassword()).rejects.toBeInstanceOf(
 			BackupPasswordConfigurationError,
 		);
+	});
+});
+
+describe("BackupScheduler restore coordination", () => {
+	it("holds mutation ownership through bookkeeping and the completion notification", async () => {
+		const updateStarted = deferred<void>();
+		const finishUpdate = deferred<void>();
+		const notificationStarted = deferred<void>();
+		const finishNotification = deferred<void>();
+		const prisma = {
+			backupSettings: {
+				findUnique: vi.fn().mockResolvedValue({
+					enabled: true,
+					intervalType: "HOURLY",
+					intervalValue: 1,
+					retentionCount: 3,
+					nextRunAt: new Date(0),
+				}),
+				update: vi.fn().mockImplementation(async () => {
+					updateStarted.resolve();
+					await finishUpdate.promise;
+				}),
+			},
+		} as unknown as PrismaClient;
+		const logger = {
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as FastifyBaseLogger;
+		const scheduler = new BackupScheduler(prisma, logger, "/unused/secrets.json", async () =>
+			withCleanupOperationGuard(async () => {
+				notificationStarted.resolve();
+				await finishNotification.promise;
+			}),
+		);
+		vi.spyOn(
+			scheduler as unknown as { runScheduledBackup(retentionCount: number): Promise<void> },
+			"runScheduledBackup",
+		).mockResolvedValue(undefined);
+		const checkAndRunBackup = (
+			scheduler as unknown as { checkAndRunBackup(): Promise<void> }
+		).checkAndRunBackup.bind(scheduler);
+
+		const scheduledTick = checkAndRunBackup();
+		await updateStarted.promise;
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		finishUpdate.resolve();
+		await notificationStarted.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		const maintenanceAttempt = withCleanupMaintenanceGuard(async () => undefined);
+		finishNotification.resolve();
+		await scheduledTick;
+		await expect(maintenanceAttempt).rejects.toBeInstanceOf(CleanupMaintenanceConflictError);
+	});
+
+	it("holds mutation ownership through the failure notification", async () => {
+		const notificationStarted = deferred<void>();
+		const finishNotification = deferred<void>();
+		const prisma = {
+			backupSettings: {
+				findUnique: vi.fn().mockResolvedValue({
+					enabled: true,
+					intervalType: "HOURLY",
+					intervalValue: 1,
+					retentionCount: 3,
+					nextRunAt: new Date(0),
+				}),
+			},
+		} as unknown as PrismaClient;
+		const logger = {
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as FastifyBaseLogger;
+		const scheduler = new BackupScheduler(prisma, logger, "/unused/secrets.json", async () =>
+			withCleanupOperationGuard(async () => {
+				notificationStarted.resolve();
+				await finishNotification.promise;
+			}),
+		);
+		vi.spyOn(
+			scheduler as unknown as { runScheduledBackup(retentionCount: number): Promise<void> },
+			"runScheduledBackup",
+		).mockRejectedValue(new Error("synthetic backup failure"));
+		const checkAndRunBackup = (
+			scheduler as unknown as { checkAndRunBackup(): Promise<void> }
+		).checkAndRunBackup.bind(scheduler);
+
+		const scheduledTick = checkAndRunBackup();
+		await notificationStarted.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		const maintenanceAttempt = withCleanupMaintenanceGuard(async () => undefined);
+		finishNotification.resolve();
+		await scheduledTick;
+		await expect(maintenanceAttempt).rejects.toBeInstanceOf(CleanupMaintenanceConflictError);
 	});
 });

--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -1029,6 +1029,7 @@ describe("BackupService - legacy restore normalization", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: vi.fn(),
 			restoreDatabase: restoreSpy,
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService: IsolatedBackupService } = await import("../backup-service.js");
@@ -1136,6 +1137,116 @@ describe("BackupService - cleanup maintenance exclusion", () => {
 
 		releaseCleanup();
 		await cleanup;
+	});
+});
+
+describe("BackupService - coordination preflight", () => {
+	const durableArrays = [
+		"oidcProviders",
+		"systemSettings",
+		"trashTemplates",
+		"trashSettings",
+		"trashSyncSchedules",
+		"templateQualityProfileMappings",
+		"instanceQualityProfileOverrides",
+		"standaloneCFDeployments",
+		"qualitySizeMappings",
+		"trashSyncHistory",
+		"templateDeploymentHistory",
+		"trashBackups",
+		"huntConfigs",
+		"huntLogs",
+		"huntSearchHistory",
+		"backupSettings",
+		"vapidKeys",
+		"notificationChannel",
+		"notificationSubscription",
+		"notificationRule",
+		"notificationAggregationConfig",
+		"autoTagRule",
+		"labelSyncRule",
+		"queueCleanerConfig",
+		"libraryCleanupConfig",
+		"libraryCleanupRule",
+		"namingConfig",
+		"userCustomFormat",
+		"namingDeployHistory",
+		"libraryCleanupApproval",
+		"libraryCleanupMediaServerScan",
+	] as const;
+
+	function makeCompleteBackup() {
+		return {
+			version: "1.2",
+			appVersion: "2.24.2",
+			timestamp: new Date().toISOString(),
+			data: {
+				users: [],
+				sessions: [],
+				serviceInstances: [],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+				...Object.fromEntries(durableArrays.map((field) => [field, []])),
+			},
+			secrets: { encryptionKey: "replacement-key", sessionCookieSecret: "replacement-session" },
+		};
+	}
+
+	it("rejects a current coordination mismatch before writing replacement secrets", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-preflight-"));
+		const secretsPath = path.join(tempDir, "secrets.json");
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "current-sync", status: "RUNNING", instanceId: "i", userId: "u" },
+					]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		} as unknown as PrismaClient;
+
+		try {
+			const service = new BackupService(prisma, secretsPath);
+			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toThrow(
+				"cannot safely replace",
+			);
+			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
+			expect(prisma.$transaction).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves a coordination query failure before writing replacement secrets", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-query-"));
+		const secretsPath = path.join(tempDir, "secrets.json");
+		const queryError = new Error("database unavailable during coordination preflight");
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockRejectedValue(queryError) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		} as unknown as PrismaClient;
+
+		try {
+			const service = new BackupService(prisma, secretsPath);
+			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toBe(
+				queryError,
+			);
+			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
+			expect(prisma.$transaction).not.toHaveBeenCalled();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -1255,6 +1366,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		// Reload the BackupService module so it picks up the mock.
 		vi.resetModules();
@@ -1300,6 +1412,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");
@@ -1344,6 +1457,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");
@@ -1386,6 +1500,7 @@ describe("BackupService - createBackup type-based defaulting (Unit)", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: exportSpy,
 			restoreDatabase: vi.fn(),
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService } = await import("../backup-service.js");

--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -12,13 +12,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Encryptor } from "../../../lib/auth/encryption.js";
 import type { PrismaClient } from "../../../lib/prisma.js";
 import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
-import {
-	CleanupMaintenanceConflictError,
-	withCleanupOperationGuard,
-} from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { generateBackupId } from "../backup-file-utils.js";
 import {
 	BackupPasswordConfigurationError,
+	BackupRestoreUnavailableError,
 	BackupService,
 	estimateBackupBytes,
 } from "../backup-service.js";
@@ -1023,230 +1020,27 @@ describe("BackupService - backup password status (Unit)", () => {
 	});
 });
 
-describe("BackupService - legacy restore normalization", () => {
-	it("restores a v1.0 snapshotless partial undeploy as snapshot-free uncertain audit history", async () => {
-		const restoreSpy = vi.fn().mockResolvedValue(undefined);
-		vi.doMock("../backup-database.js", () => ({
-			exportDatabase: vi.fn(),
-			restoreDatabase: restoreSpy,
-			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
-		}));
-		vi.resetModules();
-		const { BackupService: IsolatedBackupService } = await import("../backup-service.js");
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "legacy-restore-normalize-"));
-		const secretsPath = path.join(tempDir, "secrets.json");
-		await fs.writeFile(
-			secretsPath,
-			JSON.stringify({
-				encryptionKey: "current-encryption-key",
-				sessionCookieSecret: "current-session-secret",
+describe("BackupService - fail-closed restore containment", () => {
+	it("fails closed before parsing, filesystem access, or database access", async () => {
+		const prisma = new Proxy(
+			{},
+			{
+				get() {
+					throw new Error("database access must remain unreachable");
+				},
+			},
+		) as PrismaClient;
+		const backupService = new BackupService(prisma, "/unreachable/secrets.json");
+
+		await expect(backupService.restoreBackup("not-json")).rejects.toEqual(
+			expect.objectContaining({
+				name: "BackupRestoreUnavailableError",
+				statusCode: 503,
 			}),
 		);
-		const legacyBackup = {
-			version: "1.0",
-			appVersion: "2.23.0",
-			timestamp: new Date().toISOString(),
-			data: {
-				users: [],
-				sessions: [],
-				serviceInstances: [{ id: "instance-1", userId: "user-1" }],
-				serviceTags: [],
-				serviceInstanceTags: [],
-				oidcAccounts: [],
-				webAuthnCredentials: [],
-				trashTemplates: [{ id: "template-1", userId: "user-1" }],
-				templateDeploymentHistory: [
-					{
-						id: "legacy-partial-undeploy",
-						instanceId: "instance-1",
-						templateId: "template-1",
-						userId: "user-1",
-						status: "PARTIAL_UNDEPLOY",
-						undeployStatus: "PARTIAL",
-						backupId: "missing-snapshot",
-						canRollback: true,
-					},
-				],
-				trashBackups: [],
-			},
-			secrets: {
-				encryptionKey: "restored-encryption-key",
-				sessionCookieSecret: "restored-session-secret",
-			},
-		};
-
-		try {
-			const service = new IsolatedBackupService({} as PrismaClient, secretsPath);
-			await service.restoreBackup(JSON.stringify(legacyBackup));
-
-			const restoredData = restoreSpy.mock.calls[0]?.[1];
-			expect(restoredData.templateDeploymentHistory).toEqual([
-				expect.objectContaining({
-					id: "legacy-partial-undeploy",
-					status: "UNCERTAIN",
-					undeployStatus: null,
-					backupId: null,
-					canRollback: false,
-				}),
-			]);
-			expect(() =>
-				validateBackup({
-					...legacyBackup,
-					version: "1.1",
-					data: restoredData,
-				}),
-			).not.toThrow();
-		} finally {
-			await fs.rm(tempDir, { recursive: true, force: true });
-			vi.doUnmock("../backup-database.js");
-			vi.resetModules();
-		}
-	});
-});
-
-describe("BackupService - cleanup maintenance exclusion", () => {
-	it("rejects a validated restore before changing secrets or database state", async () => {
-		let releaseCleanup!: () => void;
-		const cleanupBlocked = new Promise<void>((resolve) => {
-			releaseCleanup = resolve;
-		});
-		const cleanup = withCleanupOperationGuard(() => cleanupBlocked);
-		const backupService = new BackupService({} as PrismaClient, "/unused/secrets.json");
-		const backup = {
-			version: "1.0",
-			appVersion: "2.23.0",
-			timestamp: new Date().toISOString(),
-			data: {
-				users: [],
-				sessions: [],
-				serviceInstances: [],
-				serviceTags: [],
-				serviceInstanceTags: [],
-				oidcAccounts: [],
-				webAuthnCredentials: [],
-			},
-			secrets: {
-				encryptionKey: "test-encryption-key-32-bytes-hex",
-				sessionCookieSecret: "test-session-cookie-secret",
-			},
-		};
-
-		await expect(backupService.restoreBackup(JSON.stringify(backup))).rejects.toBeInstanceOf(
-			CleanupMaintenanceConflictError,
+		await expect(backupService.restoreBackupFromFile("missing-backup")).rejects.toBeInstanceOf(
+			BackupRestoreUnavailableError,
 		);
-
-		releaseCleanup();
-		await cleanup;
-	});
-});
-
-describe("BackupService - coordination preflight", () => {
-	const durableArrays = [
-		"oidcProviders",
-		"systemSettings",
-		"trashTemplates",
-		"trashSettings",
-		"trashSyncSchedules",
-		"templateQualityProfileMappings",
-		"instanceQualityProfileOverrides",
-		"standaloneCFDeployments",
-		"qualitySizeMappings",
-		"trashSyncHistory",
-		"templateDeploymentHistory",
-		"trashBackups",
-		"huntConfigs",
-		"huntLogs",
-		"huntSearchHistory",
-		"backupSettings",
-		"vapidKeys",
-		"notificationChannel",
-		"notificationSubscription",
-		"notificationRule",
-		"notificationAggregationConfig",
-		"autoTagRule",
-		"labelSyncRule",
-		"queueCleanerConfig",
-		"libraryCleanupConfig",
-		"libraryCleanupRule",
-		"namingConfig",
-		"userCustomFormat",
-		"namingDeployHistory",
-		"libraryCleanupApproval",
-		"libraryCleanupMediaServerScan",
-	] as const;
-
-	function makeCompleteBackup() {
-		return {
-			version: "1.2",
-			appVersion: "2.24.2",
-			timestamp: new Date().toISOString(),
-			data: {
-				users: [],
-				sessions: [],
-				serviceInstances: [],
-				serviceTags: [],
-				serviceInstanceTags: [],
-				oidcAccounts: [],
-				webAuthnCredentials: [],
-				...Object.fromEntries(durableArrays.map((field) => [field, []])),
-			},
-			secrets: { encryptionKey: "replacement-key", sessionCookieSecret: "replacement-session" },
-		};
-	}
-
-	it("rejects a current coordination mismatch before writing replacement secrets", async () => {
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-preflight-"));
-		const secretsPath = path.join(tempDir, "secrets.json");
-		const prisma = {
-			trashSyncHistory: {
-				findMany: vi
-					.fn()
-					.mockResolvedValue([
-						{ id: "current-sync", status: "RUNNING", instanceId: "i", userId: "u" },
-					]),
-			},
-			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
-			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
-			$transaction: vi.fn(),
-		} as unknown as PrismaClient;
-
-		try {
-			const service = new BackupService(prisma, secretsPath);
-			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toThrow(
-				"cannot safely replace",
-			);
-			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
-			expect(prisma.$transaction).not.toHaveBeenCalled();
-		} finally {
-			await fs.rm(tempDir, { recursive: true, force: true });
-		}
-	});
-
-	it("preserves a coordination query failure before writing replacement secrets", async () => {
-		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "backup-coordination-query-"));
-		const secretsPath = path.join(tempDir, "secrets.json");
-		const queryError = new Error("database unavailable during coordination preflight");
-		const prisma = {
-			trashSyncHistory: { findMany: vi.fn().mockRejectedValue(queryError) },
-			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
-			namingDeployHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			trashBackup: { findMany: vi.fn().mockResolvedValue([]) },
-			$transaction: vi.fn(),
-		} as unknown as PrismaClient;
-
-		try {
-			const service = new BackupService(prisma, secretsPath);
-			await expect(service.restoreBackup(JSON.stringify(makeCompleteBackup()))).rejects.toBe(
-				queryError,
-			);
-			expect(await fs.stat(secretsPath).catch(() => null)).toBeNull();
-			expect(prisma.$transaction).not.toHaveBeenCalled();
-		} finally {
-			await fs.rm(tempDir, { recursive: true, force: true });
-		}
 	});
 });
 

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -6,11 +6,14 @@
  */
 
 import type { BackupData } from "@arr/shared";
+import { BackupCompatibilityError } from "../errors.js";
 import { loggers } from "../logger.js";
 import type { Prisma, PrismaClient, TrashBackup } from "../prisma.js";
 import {
 	isNonterminalRollback,
 	isNonterminalUndeploy,
+	LEGACY_RELATIONAL_CONFIG_DELEGATES,
+	LEGACY_RELATIONAL_CONFIG_FIELDS,
 	validateCoordinationEvidence,
 	validateRecords,
 } from "./backup-validation.js";
@@ -35,8 +38,192 @@ export interface ExportDatabaseOptions {
 	historyRetentionLimit?: number;
 }
 
+async function targetHasDurableConfig(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	missingFields: readonly string[],
+): Promise<boolean> {
+	const client = prisma as unknown as Record<string, { count?: () => Promise<number> }>;
+	for (const [payloadField, delegate] of LEGACY_RELATIONAL_CONFIG_DELEGATES) {
+		if (!missingFields.includes(payloadField)) continue;
+		if (
+			payloadField === "libraryCleanupApproval" ||
+			payloadField === "libraryCleanupMediaServerScan"
+		) {
+			continue;
+		}
+		const accessor = client[delegate];
+		if (accessor?.count && (await accessor.count()) > 0) return true;
+	}
+	return false;
+}
+
+const ACTIVE_APPROVAL_STATUSES = [
+	"pending",
+	"approved",
+	"retry_pending",
+	"executing",
+	"retry_executing",
+] as const;
+const ACTIVE_SCAN_STATUSES = ["pending", "triggering", "failed"] as const;
+
+function activeCleanupApprovalWhere() {
+	return {
+		OR: [
+			{ status: { in: [...ACTIVE_APPROVAL_STATUSES] } },
+			{ status: "executed", terminalAuditRecordedAt: null },
+		],
+	};
+}
+
+async function targetHasUncoveredSingletonSecretState(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	data: BackupData["data"],
+): Promise<boolean> {
+	const record = data as Record<string, unknown>;
+	const client = prisma as unknown as Record<
+		string,
+		{
+			findFirst?: (args: unknown) => Promise<Record<string, unknown> | null>;
+		}
+	>;
+	if (!Array.isArray(record.backupSettings)) {
+		const backupSettings = await client.backupSettings?.findFirst?.({
+			select: { encryptedPassword: true, passwordIv: true },
+		});
+		if (backupSettings?.encryptedPassword != null || backupSettings?.passwordIv != null) {
+			return true;
+		}
+	}
+
+	if (!Array.isArray(record.vapidKeys)) {
+		const vapidKeys = await client.vapidKeys?.findFirst?.({
+			select: { encryptedPrivateKey: true, privateKeyIv: true },
+		});
+		if (vapidKeys?.encryptedPrivateKey != null || vapidKeys?.privateKeyIv != null) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+async function targetHasOmittedOidcProvider(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const provider = (prisma as unknown as Record<string, { count?: () => Promise<number> }>)
+		.oIDCProvider;
+	return provider?.count ? (await provider.count()) > 0 : false;
+}
+
+async function targetHasActiveCleanupCoordination(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	missingFields: readonly string[],
+): Promise<boolean> {
+	const client = prisma as unknown as Record<
+		string,
+		{ findMany?: (args: unknown) => Promise<unknown[]> }
+	>;
+	const approval = client.libraryCleanupApproval;
+	const scan = client.libraryCleanupMediaServerScan;
+	let activeScans: Array<Record<string, unknown>> = [];
+
+	if (missingFields.includes("libraryCleanupMediaServerScan") && scan?.findMany) {
+		activeScans = (await scan.findMany({
+			where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+			select: { id: true, approvalId: true },
+		})) as Array<Record<string, unknown>>;
+		if (activeScans.length > 0) return true;
+	}
+
+	if (!missingFields.includes("libraryCleanupApproval") || !approval?.findMany) return false;
+	const activeApprovals = await approval.findMany({
+		where: activeCleanupApprovalWhere(),
+		select: { id: true },
+	});
+	if (activeApprovals.length > 0) return true;
+
+	if (!scan?.findMany) return false;
+	activeScans = (await scan.findMany({
+		where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+		select: { approvalId: true },
+	})) as Array<Record<string, unknown>>;
+	const approvalIds = activeScans
+		.map((row) => row.approvalId)
+		.filter((id): id is string => typeof id === "string" && id.length > 0);
+	if (approvalIds.length === 0) return false;
+	const parentApprovals = await approval.findMany({
+		where: { id: { in: [...new Set(approvalIds)] } },
+		select: { id: true },
+	});
+	return parentApprovals.length > 0;
+}
+
+async function targetHasActiveNamingRecovery(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const model = (
+		prisma as unknown as Record<string, { findMany?: (args: unknown) => Promise<unknown[]> }>
+	).namingDeployHistory;
+	if (!model?.findMany) return false;
+	const rows = await model.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+		select: { id: true },
+	});
+	return rows.length > 0;
+}
+
+/**
+ * Reject incomplete legacy payloads before restore mutation. Singleton rows
+ * that do not carry secrets may be preserved, but omitted ciphertext must not
+ * survive replacement of the installation encryption key.
+ */
+export async function assertRestoreCompatibility(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	data: BackupData["data"],
+): Promise<void> {
+	const record = data as Record<string, unknown>;
+	const missingFields = LEGACY_RELATIONAL_CONFIG_FIELDS.filter(
+		(field) => !Array.isArray(record[field]),
+	);
+	if (missingFields.length > 0 && (await targetHasDurableConfig(prisma, missingFields))) {
+		throw new BackupCompatibilityError();
+	}
+	if (await targetHasUncoveredSingletonSecretState(prisma, data)) {
+		throw new BackupCompatibilityError();
+	}
+	if (!Array.isArray(record.oidcProviders) && (await targetHasOmittedOidcProvider(prisma))) {
+		throw new BackupCompatibilityError();
+	}
+	if (
+		missingFields.some(
+			(field) => field === "libraryCleanupApproval" || field === "libraryCleanupMediaServerScan",
+		) &&
+		(await targetHasActiveCleanupCoordination(prisma, missingFields))
+	) {
+		throw new BackupCompatibilityError();
+	}
+	if (!Array.isArray(record.namingDeployHistory) && (await targetHasActiveNamingRecovery(prisma))) {
+		throw new BackupCompatibilityError();
+	}
+	try {
+		await validateCurrentCoordinationPreserved(prisma, data);
+	} catch (error) {
+		if (error instanceof CoordinationMismatchError) {
+			throw new BackupCompatibilityError(error);
+		}
+		throw error;
+	}
+}
+
 type CoordinationKind = "rollback" | "undeploy";
 type CoordinationRow = Record<string, unknown> & { id: string };
+
+class CoordinationMismatchError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "CoordinationMismatchError";
+	}
+}
 
 function isAuditOnlyUncertainSync(record: Record<string, unknown>): boolean {
 	return (
@@ -63,6 +250,7 @@ const COORDINATION_FIELDS: Record<CoordinationKind, readonly string[]> = {
 		"rollbackAttemptedAt",
 		"rollbackProgress",
 		"backupId",
+		"startedAt",
 	],
 	undeploy: [
 		"userId",
@@ -77,8 +265,120 @@ const COORDINATION_FIELDS: Record<CoordinationKind, readonly string[]> = {
 		"undeployAttemptedAt",
 		"undeployProgress",
 		"backupId",
+		"deployedAt",
 	],
 };
+
+const SCORE_INTENT_FIELDS = [
+	"userId",
+	"instanceId",
+	"qualityProfileId",
+	"customFormatId",
+	"score",
+	"status",
+	"intentOperation",
+	"intendedScore",
+	"connectionGeneration",
+	"connectionStateToken",
+	"createdAt",
+	"updatedAt",
+] as const;
+
+const ACTIVE_NAMING_FIELDS = [
+	"instanceId",
+	"userId",
+	"status",
+	"selectedPresets",
+	"resolvedPayload",
+	"deployedHash",
+	"previousConfig",
+	"changedFields",
+	"totalFields",
+	"errorMessage",
+	"rolledBack",
+	"rolledBackAt",
+	"deployedAt",
+] as const;
+
+const ACTIVE_NAMING_INSTANCE_FIELDS = [
+	"userId",
+	"service",
+	"baseUrl",
+	"encryptedApiKey",
+	"encryptionIv",
+	"encryptedHttpAuthCredentials",
+	"httpAuthEncryptionIv",
+] as const;
+
+const ACTIVE_NAMING_EXPORT_CHANGED =
+	"Cannot create backup: active naming recovery changed during export; retry";
+
+const ACTIVE_APPROVAL_FIELDS = [
+	"configId",
+	"instanceId",
+	"arrItemId",
+	"itemType",
+	"targetScope",
+	"arrEpisodeId",
+	"episodeFileId",
+	"seasonNumber",
+	"episodeNumber",
+	"episodeTitle",
+	"title",
+	"matchedRuleId",
+	"matchedRuleName",
+	"reason",
+	"action",
+	"scanMediaServerAfterDelete",
+	"sizeOnDisk",
+	"year",
+	"rating",
+	"status",
+	"executionToken",
+	"executionAuditCorrelationId",
+	"reconciledWithoutMutation",
+	"safetySnapshot",
+	"lastExecutionError",
+	"reviewedAt",
+	"executedAt",
+	"expiresAt",
+	"createdAt",
+] as const;
+
+const ACTIVE_SCAN_FIELDS = [
+	"approvalId",
+	"instanceId",
+	"service",
+	"serverIdentity",
+	"mediaType",
+	"plannedSectionIds",
+	"targetKey",
+	"status",
+	"executionToken",
+	"attemptCount",
+	"completedSectionIds",
+	"lastError",
+	"nextAttemptAt",
+	"requestStartedAt",
+	"triggeredAt",
+	"createdAt",
+	"updatedAt",
+] as const;
+
+const COORDINATION_DATE_FIELDS = new Set([
+	"startedAt",
+	"rollbackAttemptedAt",
+	"undeployAttemptedAt",
+	"deployedAt",
+	"createdAt",
+	"updatedAt",
+	"reviewedAt",
+	"executedAt",
+	"expiresAt",
+	"nextAttemptAt",
+	"requestStartedAt",
+	"triggeredAt",
+]);
 
 function recordsById(value: unknown): Map<string, CoordinationRow> {
 	const records = new Map<string, CoordinationRow>();
@@ -105,33 +405,45 @@ function assertCurrentUndeployFallbackPreserved(
 		return;
 	}
 	if (typeof current.templateId !== "string" || current.templateId.length === 0) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current nonterminal coordination row ${current.id} has no undeploy template authority`,
 		);
 	}
 	const currentTemplate = current.template;
 	if (typeof currentTemplate !== "object" || currentTemplate === null) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current undeploy fallback template ${current.templateId} is missing from the database`,
 		);
 	}
 	const incomingTemplate = incomingTemplates.get(current.templateId);
 	if (!incomingTemplate) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current undeploy fallback template ${current.templateId} is missing from incoming data`,
 		);
 	}
 	for (const field of ["userId", "serviceType", "configData"] as const) {
 		if (incomingTemplate[field] !== (currentTemplate as Record<string, unknown>)[field]) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current undeploy fallback template ${current.templateId} changed ${field}`,
 			);
 		}
 	}
 }
 
-function comparableCoordinationValue(value: unknown): unknown {
-	return value instanceof Date ? value.toISOString() : value;
+function comparableCoordinationValue(value: unknown, field?: string): unknown {
+	if (field === "sizeOnDisk" && (typeof value === "bigint" || typeof value === "string")) {
+		try {
+			return BigInt(value).toString();
+		} catch {
+			return value;
+		}
+	}
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === "string" && field && COORDINATION_DATE_FIELDS.has(field)) {
+		const parsed = new Date(value);
+		if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+	}
+	return value;
 }
 
 function assertCurrentRowPreserved(
@@ -141,28 +453,148 @@ function assertCurrentRowPreserved(
 ): void {
 	const incoming = incomingRows.get(current.id);
 	if (!incoming) {
-		throw new Error(
+		throw new CoordinationMismatchError(
 			`Cannot restore backup: current nonterminal coordination row ${current.id} is missing from incoming data`,
 		);
 	}
 
 	for (const field of COORDINATION_FIELDS[kind]) {
 		if (
-			comparableCoordinationValue(incoming[field]) !== comparableCoordinationValue(current[field])
+			comparableCoordinationValue(incoming[field], field) !==
+			comparableCoordinationValue(current[field], field)
 		) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current nonterminal coordination row ${current.id} changed ${field}`,
 			);
 		}
 	}
 }
 
+function assertCurrentSpecialRowPreserved(
+	label: string,
+	current: CoordinationRow,
+	incomingRows: Map<string, CoordinationRow>,
+	fields: readonly string[],
+): void {
+	const incoming = incomingRows.get(current.id);
+	if (!incoming) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current ${label} ${current.id} is missing from incoming data`,
+		);
+	}
+	for (const field of fields) {
+		if (
+			comparableCoordinationValue(incoming[field], field) !==
+			comparableCoordinationValue(current[field], field)
+		) {
+			throw new CoordinationMismatchError(
+				`Cannot restore backup: current ${label} ${current.id} changed ${field}`,
+			);
+		}
+	}
+}
+
+function namingInstanceFieldMatches(field: string, left: unknown, right: unknown): boolean {
+	return field === "baseUrl" && typeof left === "string" && typeof right === "string"
+		? `${left.replace(/\/$/, "")}/api/v3/config/naming` ===
+				`${right.replace(/\/$/, "")}/api/v3/config/naming`
+		: left === right;
+}
+
+function assertCurrentNamingInstancePreserved(
+	history: CoordinationRow,
+	currentInstances: Map<string, CoordinationRow>,
+	incomingInstances: Map<string, CoordinationRow>,
+): void {
+	if (typeof history.instanceId !== "string" || history.instanceId.length === 0) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} has no service instance identity`,
+		);
+	}
+	const currentInstance = currentInstances.get(history.instanceId);
+	if (!currentInstance) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} references missing service instance ${history.instanceId}`,
+		);
+	}
+	const incomingInstance = incomingInstances.get(history.instanceId);
+	if (!incomingInstance) {
+		throw new CoordinationMismatchError(
+			`Cannot restore backup: current active naming recovery ${history.id} service instance ${history.instanceId} is missing from incoming data`,
+		);
+	}
+	for (const field of ACTIVE_NAMING_INSTANCE_FIELDS) {
+		const incomingValue = incomingInstance[field];
+		const currentValue = currentInstance[field];
+		if (!namingInstanceFieldMatches(field, incomingValue, currentValue)) {
+			throw new CoordinationMismatchError(
+				`Cannot restore backup: current active naming recovery ${history.id} changed service instance ${field}`,
+			);
+		}
+	}
+}
+
+function assertActiveNamingExportStable(
+	capturedHistory: CoordinationRow[],
+	latestHistory: CoordinationRow[],
+	capturedInstances: CoordinationRow[],
+	latestInstances: CoordinationRow[],
+): void {
+	const capturedHistoryById = recordsById(capturedHistory);
+	const latestHistoryById = recordsById(latestHistory);
+	if (capturedHistoryById.size !== latestHistoryById.size) {
+		throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+	}
+	for (const captured of capturedHistoryById.values()) {
+		const latest = latestHistoryById.get(captured.id);
+		if (!latest) throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		for (const field of ACTIVE_NAMING_FIELDS) {
+			if (
+				comparableCoordinationValue(captured[field], field) !==
+				comparableCoordinationValue(latest[field], field)
+			) {
+				throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+			}
+		}
+	}
+
+	const capturedInstancesById = recordsById(capturedInstances);
+	const latestInstancesById = recordsById(latestInstances);
+	for (const history of capturedHistoryById.values()) {
+		if (typeof history.instanceId !== "string" || history.instanceId.length === 0) {
+			throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		}
+		const captured = capturedInstancesById.get(history.instanceId);
+		const latest = latestInstancesById.get(history.instanceId);
+		if (!captured || !latest) throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+		for (const field of ACTIVE_NAMING_INSTANCE_FIELDS) {
+			if (!namingInstanceFieldMatches(field, captured[field], latest[field])) {
+				throw new Error(ACTIVE_NAMING_EXPORT_CHANGED);
+			}
+		}
+	}
+}
+
 async function validateCurrentCoordinationPreserved(
-	tx: Prisma.TransactionClient,
+	tx: Prisma.TransactionClient | PrismaClient,
 	data: BackupData["data"],
 ): Promise<void> {
+	const db = tx as Prisma.TransactionClient;
+	const optionalModels = tx as unknown as Record<
+		string,
+		{ findMany?: (args: unknown) => Promise<unknown[]> }
+	>;
+	if (
+		!optionalModels.trashSyncHistory?.findMany ||
+		!optionalModels.templateDeploymentHistory?.findMany ||
+		!optionalModels.instanceQualityProfileOverride?.findMany ||
+		!optionalModels.namingDeployHistory?.findMany ||
+		!optionalModels.trashBackup?.findMany
+	) {
+		return;
+	}
 	const currentRollbackRows = (
-		await tx.trashSyncHistory.findMany({
+		await db.trashSyncHistory.findMany({
 			where: {
 				OR: [
 					{ rollbackStatus: { not: "COMPLETED" } },
@@ -173,7 +605,7 @@ async function validateCurrentCoordinationPreserved(
 		})
 	).filter(shouldPreserveSyncHistory) as CoordinationRow[];
 	const currentUndeployRows = (
-		await tx.templateDeploymentHistory.findMany({
+		await db.templateDeploymentHistory.findMany({
 			where: {
 				OR: [
 					{ undeployStatus: { not: "COMPLETED" } },
@@ -187,9 +619,60 @@ async function validateCurrentCoordinationPreserved(
 			},
 		})
 	).filter(isNonterminalUndeploy) as CoordinationRow[];
+	const currentScoreIntents = (await db.instanceQualityProfileOverride.findMany({
+		where: { status: { in: ["PENDING", "UNCERTAIN"] } },
+	})) as CoordinationRow[];
+	const currentActiveNaming = (await db.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	})) as CoordinationRow[];
+	const currentNamingInstances = recordsById(
+		currentActiveNaming.length > 0
+			? await db.serviceInstance.findMany({
+					where: {
+						id: {
+							in: [
+								...new Set(
+									currentActiveNaming
+										.map((row) => row.instanceId)
+										.filter((id): id is string => typeof id === "string" && id.length > 0),
+								),
+							],
+						},
+					},
+				})
+			: [],
+	);
+	const currentActiveApprovals = optionalModels.libraryCleanupApproval?.findMany
+		? ((await optionalModels.libraryCleanupApproval.findMany({
+				where: activeCleanupApprovalWhere(),
+			})) as CoordinationRow[])
+		: [];
+	const currentActiveScans = optionalModels.libraryCleanupMediaServerScan?.findMany
+		? ((await optionalModels.libraryCleanupMediaServerScan.findMany({
+				where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+			})) as CoordinationRow[])
+		: [];
+	const scanApprovalIds = [
+		...new Set(
+			currentActiveScans
+				.map((row) => row.approvalId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const currentScanParentApprovals =
+		scanApprovalIds.length > 0 && optionalModels.libraryCleanupApproval?.findMany
+			? ((await optionalModels.libraryCleanupApproval.findMany({
+					where: { id: { in: scanApprovalIds } },
+				})) as CoordinationRow[])
+			: [];
 	const incomingRollbackRows = recordsById(data.trashSyncHistory);
 	const incomingUndeployRows = recordsById(data.templateDeploymentHistory);
 	const incomingTemplates = recordsById(data.trashTemplates);
+	const incomingScoreIntents = recordsById(data.instanceQualityProfileOverrides);
+	const incomingActiveNaming = recordsById(data.namingDeployHistory);
+	const incomingInstances = recordsById(data.serviceInstances);
+	const incomingApprovals = recordsById(data.libraryCleanupApproval);
+	const incomingScans = recordsById(data.libraryCleanupMediaServerScan);
 
 	for (const row of currentRollbackRows) {
 		assertCurrentRowPreserved("rollback", row, incomingRollbackRows);
@@ -197,6 +680,39 @@ async function validateCurrentCoordinationPreserved(
 	for (const row of currentUndeployRows) {
 		assertCurrentRowPreserved("undeploy", row, incomingUndeployRows);
 		assertCurrentUndeployFallbackPreserved(row, incomingTemplates);
+	}
+	for (const row of currentScoreIntents) {
+		assertCurrentSpecialRowPreserved(
+			"pending or uncertain quality-score intent",
+			row,
+			incomingScoreIntents,
+			SCORE_INTENT_FIELDS,
+		);
+	}
+	for (const row of currentActiveNaming) {
+		assertCurrentSpecialRowPreserved(
+			"active naming recovery",
+			row,
+			incomingActiveNaming,
+			ACTIVE_NAMING_FIELDS,
+		);
+		assertCurrentNamingInstancePreserved(row, currentNamingInstances, incomingInstances);
+	}
+	for (const row of [...currentActiveApprovals, ...currentScanParentApprovals]) {
+		assertCurrentSpecialRowPreserved(
+			"active cleanup approval",
+			row,
+			incomingApprovals,
+			ACTIVE_APPROVAL_FIELDS,
+		);
+	}
+	for (const row of currentActiveScans) {
+		assertCurrentSpecialRowPreserved(
+			"active media-server scan",
+			row,
+			incomingScans,
+			ACTIVE_SCAN_FIELDS,
+		);
 	}
 
 	const currentRecoveryRows = [
@@ -211,7 +727,7 @@ async function validateCurrentCoordinationPreserved(
 	];
 	const requiredSnapshotIds = currentRecoveryRows.map((row) => {
 		if (typeof row.backupId !== "string" || row.backupId.length === 0) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current nonterminal coordination row ${row.id} has no required recovery snapshot reference`,
 			);
 		}
@@ -220,25 +736,25 @@ async function validateCurrentCoordinationPreserved(
 	if (requiredSnapshotIds.length === 0) return;
 
 	const currentSnapshots = recordsById(
-		await tx.trashBackup.findMany({ where: { id: { in: [...new Set(requiredSnapshotIds)] } } }),
+		await db.trashBackup.findMany({ where: { id: { in: [...new Set(requiredSnapshotIds)] } } }),
 	);
 	const incomingSnapshots = recordsById(data.trashBackups);
 	for (const snapshotId of new Set(requiredSnapshotIds)) {
 		const current = currentSnapshots.get(snapshotId);
 		if (!current) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current recovery snapshot ${snapshotId} is missing from the database`,
 			);
 		}
 		const incoming = incomingSnapshots.get(snapshotId);
 		if (!incoming) {
-			throw new Error(
+			throw new CoordinationMismatchError(
 				`Cannot restore backup: current recovery snapshot ${snapshotId} is missing from incoming data`,
 			);
 		}
 		for (const field of ["userId", "instanceId", "backupData"] as const) {
 			if (incoming[field] !== current[field]) {
-				throw new Error(
+				throw new CoordinationMismatchError(
 					`Cannot restore backup: current recovery snapshot ${snapshotId} changed ${field}`,
 				);
 			}
@@ -283,6 +799,8 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 
 	// System settings (singleton-ish)
 	const systemSettings = await prisma.systemSettings.findMany();
+	const backupSettings = await prisma.backupSettings.findMany();
+	const vapidKeys = await prisma.vapidKeys.findMany();
 
 	// TRaSH Guides configuration (always full — these are config, not history)
 	const trashTemplates = await prisma.trashTemplate.findMany();
@@ -292,6 +810,49 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 	const instanceQualityProfileOverrides = await prisma.instanceQualityProfileOverride.findMany();
 	const standaloneCFDeployments = await prisma.standaloneCFDeployment.findMany();
 	const qualitySizeMappings = await prisma.qualitySizeMapping.findMany();
+
+	// Durable user and instance configuration (always full, including empty
+	// arrays so v1.2 distinguishes complete coverage from legacy omission).
+	const notificationChannel = await prisma.notificationChannel.findMany();
+	const notificationSubscription = await prisma.notificationSubscription.findMany();
+	const notificationRule = await prisma.notificationRule.findMany();
+	const notificationAggregationConfig = await prisma.notificationAggregationConfig.findMany();
+	const autoTagRule = await prisma.autoTagRule.findMany();
+	const labelSyncRule = await prisma.labelSyncRule.findMany();
+	const queueCleanerConfig = await prisma.queueCleanerConfig.findMany();
+	const libraryCleanupConfig = await prisma.libraryCleanupConfig.findMany();
+	const libraryCleanupRule = await prisma.libraryCleanupRule.findMany();
+	const namingConfig = await prisma.namingConfig.findMany();
+	const userCustomFormat = await prisma.userCustomFormat.findMany();
+	const activeCleanupApprovals = await prisma.libraryCleanupApproval.findMany({
+		where: activeCleanupApprovalWhere(),
+	});
+	const activeCleanupScans = await prisma.libraryCleanupMediaServerScan.findMany({
+		where: { status: { in: [...ACTIVE_SCAN_STATUSES] } },
+	});
+	const cleanupScanApprovalIds = [
+		...new Set(
+			activeCleanupScans
+				.map((row) => row.approvalId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const cleanupScanParentApprovals =
+		cleanupScanApprovalIds.length > 0
+			? await prisma.libraryCleanupApproval.findMany({
+					where: { id: { in: cleanupScanApprovalIds } },
+				})
+			: [];
+	const serializeCleanupApproval = (row: (typeof activeCleanupApprovals)[number]) => ({
+		...row,
+		sizeOnDisk: row.sizeOnDisk.toString(),
+		terminalAuditRecordedAt: null,
+		terminalAuditRecoveryAttemptedAt: null,
+	});
+	const libraryCleanupApproval = mergeRowsById(
+		activeCleanupApprovals.map(serializeCleanupApproval),
+		cleanupScanParentApprovals.map(serializeCleanupApproval),
+	);
 
 	// TRaSH Guides history/audit — operational, capped or skipped.
 	// When capped, log a warn so operators can correlate restore-time gaps to
@@ -335,6 +896,9 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 			},
 		})
 	).filter(isNonterminalUndeploy);
+	const activeNamingDeployHistory = await prisma.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	});
 
 	const cappedTrashSyncHistory = skipHistory
 		? []
@@ -356,6 +920,14 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		cappedTemplateDeploymentHistory,
 		nonterminalUndeployHistory,
 	);
+	const cappedNamingDeployHistory = skipHistory
+		? []
+		: await fetchCappedHistory(
+				"namingDeployHistory",
+				() => prisma.namingDeployHistory.count(),
+				(take) => prisma.namingDeployHistory.findMany({ take, orderBy: { deployedAt: "desc" } }),
+			);
+	const namingDeployHistory = mergeRowsById(cappedNamingDeployHistory, activeNamingDeployHistory);
 
 	// Hunting feature: configs are config (always full); logs/history are operational
 	const huntConfigs = await prisma.huntConfig.findMany();
@@ -410,6 +982,32 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		trashBackups = mergeRowsById(trashBackups, requiredSnapshots);
 	}
 
+	// Active naming rows carry rollback authority. Re-read their recovery
+	// fields and referenced connection authority at the publication boundary so
+	// a concurrent change cannot produce a backup assembled from two states.
+	const latestActiveNamingDeployHistory = await prisma.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	});
+	const activeNamingInstanceIds = [
+		...new Set(
+			activeNamingDeployHistory
+				.map((row) => row.instanceId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const latestActiveNamingInstances =
+		activeNamingInstanceIds.length > 0
+			? await prisma.serviceInstance.findMany({
+					where: { id: { in: activeNamingInstanceIds } },
+				})
+			: [];
+	assertActiveNamingExportStable(
+		activeNamingDeployHistory as CoordinationRow[],
+		latestActiveNamingDeployHistory as CoordinationRow[],
+		serviceInstances as CoordinationRow[],
+		latestActiveNamingInstances as CoordinationRow[],
+	);
+
 	validateCoordinationEvidence({
 		serviceInstances,
 		trashTemplates,
@@ -430,6 +1028,8 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		webAuthnCredentials,
 		// System settings
 		systemSettings,
+		backupSettings,
+		vapidKeys,
 		// TRaSH Guides configuration
 		trashTemplates,
 		trashSettings,
@@ -442,12 +1042,27 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		// TRaSH Guides history/audit
 		trashSyncHistory,
 		templateDeploymentHistory,
+		namingDeployHistory,
 		// TRaSH instance backups (optional)
 		trashBackups,
 		// Hunting feature
 		huntConfigs,
 		huntLogs,
 		huntSearchHistory,
+		// Durable configuration
+		notificationChannel,
+		notificationSubscription,
+		notificationRule,
+		notificationAggregationConfig,
+		autoTagRule,
+		labelSyncRule,
+		queueCleanerConfig,
+		libraryCleanupConfig,
+		libraryCleanupRule,
+		namingConfig,
+		userCustomFormat,
+		libraryCleanupApproval,
+		libraryCleanupMediaServerScan: activeCleanupScans,
 	};
 }
 
@@ -462,7 +1077,10 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 export async function restoreDatabase(prisma: PrismaClient, data: BackupData["data"]) {
 	// Use a transaction to ensure atomicity
 	await prisma.$transaction(async (tx) => {
-		await validateCurrentCoordinationPreserved(tx, data);
+		// Recheck inside the transaction immediately before any delete. The
+		// service-level preflight closes the filesystem TOCTOU window; this check
+		// protects direct callers and races between preflight and transaction.
+		await assertRestoreCompatibility(tx, data);
 
 		// =================================================================
 		// DELETE all existing data (in reverse order of dependencies)
@@ -476,6 +1094,8 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		// TRaSH history/audit (depends on templates, instances, backups)
 		await tx.templateDeploymentHistory.deleteMany();
 		await tx.trashSyncHistory.deleteMany();
+		await tx.namingDeployHistory.deleteMany();
+		await tx.trashCache.deleteMany();
 
 		// TRaSH configuration (depends on templates, instances)
 		await tx.qualitySizeMapping.deleteMany();
@@ -487,8 +1107,37 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		await tx.trashTemplate.deleteMany();
 		await tx.trashSettings.deleteMany();
 
-		// System settings (singleton)
-		await tx.systemSettings.deleteMany();
+		// Durable configuration, children before parents.
+		await tx.libraryCleanupMediaServerScanLease.deleteMany();
+		await tx.libraryCleanupMediaServerScan.deleteMany();
+		await tx.libraryCleanupApproval.deleteMany();
+		await tx.notificationLog.deleteMany();
+		await tx.notificationSubscription.deleteMany();
+		await tx.libraryCleanupRule.deleteMany();
+		await tx.notificationChannel.deleteMany();
+		await tx.notificationRule.deleteMany();
+		await tx.notificationAggregationConfig.deleteMany();
+		await tx.autoTagRule.deleteMany();
+		await tx.labelSyncRule.deleteMany();
+		await tx.queueCleanerConfig.deleteMany();
+		await tx.libraryCleanupConfig.deleteMany();
+		await tx.namingConfig.deleteMany();
+		await tx.userCustomFormat.deleteMany();
+
+		// These singleton rows are not removed by user/instance cascades. Each
+		// incoming array independently authorizes replacement of its own model.
+		if (Array.isArray(data.backupSettings)) {
+			await tx.backupSettings.deleteMany();
+		}
+		if (Array.isArray(data.vapidKeys)) {
+			await tx.vapidKeys.deleteMany();
+		}
+
+		// System settings are independent of user/instance cascades. Preserve
+		// them for legacy files that predate this payload coverage.
+		if (Array.isArray(data.systemSettings)) {
+			await tx.systemSettings.deleteMany();
+		}
 
 		// Core tables (existing)
 		await tx.serviceInstanceTag.deleteMany();
@@ -496,7 +1145,11 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 		await tx.serviceInstance.deleteMany();
 		await tx.webAuthnCredential.deleteMany();
 		await tx.oIDCAccount.deleteMany();
-		await tx.oIDCProvider.deleteMany();
+		// OIDC providers are independent of the user/instance cascades too.
+		// Legacy files may omit them, so do not turn omission into deletion.
+		if (Array.isArray(data.oidcProviders)) {
+			await tx.oIDCProvider.deleteMany();
+		}
 		await tx.session.deleteMany();
 		await tx.user.deleteMany();
 
@@ -577,6 +1230,18 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			await tx.systemSettings.create({
 				data: { ...settingsData, id: 1 },
 			});
+		}
+
+		if (Array.isArray(data.backupSettings) && data.backupSettings.length > 0) {
+			validateRecords(data.backupSettings, "backupSettings", ["id"]);
+			const settings = data.backupSettings[0] as Prisma.BackupSettingsCreateInput;
+			await tx.backupSettings.create({ data: { ...settings, id: 1 } });
+		}
+
+		if (Array.isArray(data.vapidKeys) && data.vapidKeys.length > 0) {
+			validateRecords(data.vapidKeys, "vapidKeys", ["id", "publicKey"]);
+			const keys = data.vapidKeys[0] as Prisma.VapidKeysCreateInput;
+			await tx.vapidKeys.create({ data: { ...keys, id: 1 } });
 		}
 
 		// --- TRaSH Guides configuration ---
@@ -672,6 +1337,18 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			});
 		}
 
+		if (data.namingDeployHistory && data.namingDeployHistory.length > 0) {
+			validateRecords(data.namingDeployHistory, "namingDeployHistory", [
+				"id",
+				"instanceId",
+				"userId",
+				"status",
+			]);
+			await tx.namingDeployHistory.createMany({
+				data: data.namingDeployHistory as Prisma.NamingDeployHistoryCreateManyInput[],
+			});
+		}
+
 		// --- Hunting feature ---
 
 		if (data.huntConfigs && data.huntConfigs.length > 0) {
@@ -692,6 +1369,115 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			validateRecords(data.huntSearchHistory, "huntSearchHistory", ["id", "configId"]);
 			await tx.huntSearchHistory.createMany({
 				data: data.huntSearchHistory as Prisma.HuntSearchHistoryCreateManyInput[],
+			});
+		}
+
+		// Durable configuration (dependency order).
+		if (data.notificationChannel && data.notificationChannel.length > 0) {
+			validateRecords(data.notificationChannel, "notificationChannel", ["id", "userId"]);
+			await tx.notificationChannel.createMany({
+				data: data.notificationChannel as Prisma.NotificationChannelCreateManyInput[],
+			});
+		}
+		if (data.notificationSubscription && data.notificationSubscription.length > 0) {
+			validateRecords(data.notificationSubscription, "notificationSubscription", [
+				"channelId",
+				"eventType",
+			]);
+			await tx.notificationSubscription.createMany({
+				data: data.notificationSubscription as Prisma.NotificationSubscriptionCreateManyInput[],
+			});
+		}
+		if (data.notificationRule && data.notificationRule.length > 0) {
+			validateRecords(data.notificationRule, "notificationRule", ["id", "userId"]);
+			await tx.notificationRule.createMany({
+				data: data.notificationRule as Prisma.NotificationRuleCreateManyInput[],
+			});
+		}
+		if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
+			validateRecords(data.notificationAggregationConfig, "notificationAggregationConfig", [
+				"id",
+				"userId",
+			]);
+			await tx.notificationAggregationConfig.createMany({
+				data: data.notificationAggregationConfig as Prisma.NotificationAggregationConfigCreateManyInput[],
+			});
+		}
+		if (data.autoTagRule && data.autoTagRule.length > 0) {
+			validateRecords(data.autoTagRule, "autoTagRule", ["id", "userId"]);
+			await tx.autoTagRule.createMany({
+				data: data.autoTagRule as Prisma.AutoTagRuleCreateManyInput[],
+			});
+		}
+		if (data.labelSyncRule && data.labelSyncRule.length > 0) {
+			validateRecords(data.labelSyncRule, "labelSyncRule", ["id", "userId"]);
+			await tx.labelSyncRule.createMany({
+				data: data.labelSyncRule as Prisma.LabelSyncRuleCreateManyInput[],
+			});
+		}
+		if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
+			validateRecords(data.queueCleanerConfig, "queueCleanerConfig", ["id", "instanceId"]);
+			await tx.queueCleanerConfig.createMany({
+				data: data.queueCleanerConfig as Prisma.QueueCleanerConfigCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
+			validateRecords(data.libraryCleanupConfig, "libraryCleanupConfig", ["id", "userId"]);
+			await tx.libraryCleanupConfig.createMany({
+				data: data.libraryCleanupConfig as Prisma.LibraryCleanupConfigCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
+			validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
+			await tx.libraryCleanupRule.createMany({
+				data: data.libraryCleanupRule as Prisma.LibraryCleanupRuleCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupApproval && data.libraryCleanupApproval.length > 0) {
+			validateRecords(data.libraryCleanupApproval, "libraryCleanupApproval", [
+				"id",
+				"configId",
+				"instanceId",
+				"status",
+				"sizeOnDisk",
+				"expiresAt",
+			]);
+			await tx.libraryCleanupApproval.createMany({
+				data: data.libraryCleanupApproval.map((row) => ({
+					...(row as Prisma.LibraryCleanupApprovalCreateManyInput),
+					terminalAuditRecordedAt: null,
+					terminalAuditRecoveryAttemptedAt: null,
+					sizeOnDisk:
+						typeof (row as Record<string, unknown>).sizeOnDisk === "string"
+							? BigInt((row as Record<string, unknown>).sizeOnDisk as string)
+							: (row as Prisma.LibraryCleanupApprovalCreateManyInput).sizeOnDisk,
+				})) as Prisma.LibraryCleanupApprovalCreateManyInput[],
+			});
+		}
+		if (data.libraryCleanupMediaServerScan && data.libraryCleanupMediaServerScan.length > 0) {
+			validateRecords(data.libraryCleanupMediaServerScan, "libraryCleanupMediaServerScan", [
+				"id",
+				"approvalId",
+				"instanceId",
+				"service",
+				"mediaType",
+				"targetKey",
+				"status",
+			]);
+			await tx.libraryCleanupMediaServerScan.createMany({
+				data: data.libraryCleanupMediaServerScan as Prisma.LibraryCleanupMediaServerScanCreateManyInput[],
+			});
+		}
+		if (data.namingConfig && data.namingConfig.length > 0) {
+			validateRecords(data.namingConfig, "namingConfig", ["id", "instanceId", "userId"]);
+			await tx.namingConfig.createMany({
+				data: data.namingConfig as Prisma.NamingConfigCreateManyInput[],
+			});
+		}
+		if (data.userCustomFormat && data.userCustomFormat.length > 0) {
+			validateRecords(data.userCustomFormat, "userCustomFormat", ["id", "userId"]);
+			await tx.userCustomFormat.createMany({
+				data: data.userCustomFormat as Prisma.UserCustomFormatCreateManyInput[],
 			});
 		}
 	});

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -16,6 +16,7 @@ import {
 	LEGACY_RELATIONAL_CONFIG_FIELDS,
 	validateCoordinationEvidence,
 	validateRecords,
+	validateSingletonCollections,
 } from "./backup-validation.js";
 
 const log = loggers.backup;
@@ -783,7 +784,10 @@ function mergeRowsById<T extends { id: string }>(rows: T[], preservedRows: T[]):
  * to keep peak heap bounded. Nonterminal rollback/undeploy coordination is
  * always exported because it is required to resume safely after restore.
  */
-export async function exportDatabase(prisma: PrismaClient, options: ExportDatabaseOptions = {}) {
+async function exportDatabaseSnapshot(
+	prisma: Prisma.TransactionClient,
+	options: ExportDatabaseOptions,
+) {
 	const skipHistory = options.excludeOperationalHistory ?? false;
 	const historyLimit = options.historyRetentionLimit ?? 1000;
 
@@ -982,32 +986,6 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		trashBackups = mergeRowsById(trashBackups, requiredSnapshots);
 	}
 
-	// Active naming rows carry rollback authority. Re-read their recovery
-	// fields and referenced connection authority at the publication boundary so
-	// a concurrent change cannot produce a backup assembled from two states.
-	const latestActiveNamingDeployHistory = await prisma.namingDeployHistory.findMany({
-		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
-	});
-	const activeNamingInstanceIds = [
-		...new Set(
-			activeNamingDeployHistory
-				.map((row) => row.instanceId)
-				.filter((id): id is string => typeof id === "string" && id.length > 0),
-		),
-	];
-	const latestActiveNamingInstances =
-		activeNamingInstanceIds.length > 0
-			? await prisma.serviceInstance.findMany({
-					where: { id: { in: activeNamingInstanceIds } },
-				})
-			: [];
-	assertActiveNamingExportStable(
-		activeNamingDeployHistory as CoordinationRow[],
-		latestActiveNamingDeployHistory as CoordinationRow[],
-		serviceInstances as CoordinationRow[],
-		latestActiveNamingInstances as CoordinationRow[],
-	);
-
 	validateCoordinationEvidence({
 		serviceInstances,
 		trashTemplates,
@@ -1016,7 +994,7 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		trashBackups,
 	});
 
-	return {
+	const data = {
 		// Core authentication & services
 		users,
 		sessions,
@@ -1064,6 +1042,44 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		libraryCleanupApproval,
 		libraryCleanupMediaServerScan: activeCleanupScans,
 	};
+
+	return { data, activeNamingDeployHistory, serviceInstances };
+}
+
+/**
+ * Capture all portable tables from one coherent database snapshot, then
+ * recheck active naming recovery authority at the publication boundary.
+ */
+export async function exportDatabase(prisma: PrismaClient, options: ExportDatabaseOptions = {}) {
+	const snapshot = await prisma.$transaction((tx) => exportDatabaseSnapshot(tx, options), {
+		isolationLevel: "Serializable",
+		timeout: 60_000,
+	});
+
+	const latestActiveNamingDeployHistory = await prisma.namingDeployHistory.findMany({
+		where: { status: { in: ["PENDING", "SUCCESS"] }, rolledBack: false },
+	});
+	const activeNamingInstanceIds = [
+		...new Set(
+			snapshot.activeNamingDeployHistory
+				.map((row) => row.instanceId)
+				.filter((id): id is string => typeof id === "string" && id.length > 0),
+		),
+	];
+	const latestActiveNamingInstances =
+		activeNamingInstanceIds.length > 0
+			? await prisma.serviceInstance.findMany({
+					where: { id: { in: activeNamingInstanceIds } },
+				})
+			: [];
+	assertActiveNamingExportStable(
+		snapshot.activeNamingDeployHistory as CoordinationRow[],
+		latestActiveNamingDeployHistory as CoordinationRow[],
+		snapshot.serviceInstances as CoordinationRow[],
+		latestActiveNamingInstances as CoordinationRow[],
+	);
+
+	return snapshot.data;
 }
 
 /**
@@ -1075,6 +1091,7 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
  * - Transaction ensures atomicity but can be long-running for large datasets
  */
 export async function restoreDatabase(prisma: PrismaClient, data: BackupData["data"]) {
+	validateSingletonCollections(data);
 	// Use a transaction to ensure atomicity
 	await prisma.$transaction(async (tx) => {
 		// Recheck inside the transaction immediately before any delete. The

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -21,6 +21,11 @@ import {
 
 const log = loggers.backup;
 
+// Restores accept encrypted payloads up to 200 MB. Keep the destructive
+// transaction bounded while allowing a supported populated restore to exceed
+// Prisma's five-second interactive-transaction default on slower storage.
+const RESTORE_TRANSACTION_TIMEOUT_MS = 5 * 60 * 1000;
+
 export interface ExportDatabaseOptions {
 	/** Include TRaSH ARR config snapshots (can be large) */
 	includeTrashBackups?: boolean;
@@ -1082,6 +1087,177 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 	return snapshot.data;
 }
 
+function validateRestoreRecords(data: BackupData["data"]): void {
+	if (data.users.length > 0) validateRecords(data.users, "user", ["id", "username"]);
+	if (data.sessions.length > 0) {
+		validateRecords(data.sessions, "session", ["id", "userId", "expiresAt"]);
+	}
+	if (data.oidcProviders && data.oidcProviders.length > 0) {
+		validateRecords(data.oidcProviders, "oidcProvider", ["id", "clientId", "issuer"]);
+	}
+	if (data.oidcAccounts.length > 0) {
+		validateRecords(data.oidcAccounts, "oidcAccount", ["id", "userId", "providerUserId"]);
+	}
+	if (data.webAuthnCredentials.length > 0) {
+		validateRecords(data.webAuthnCredentials, "webAuthnCredential", ["id", "userId", "publicKey"]);
+	}
+	if (data.serviceInstances.length > 0) {
+		validateRecords(data.serviceInstances, "serviceInstance", ["id", "service", "baseUrl"]);
+	}
+	if (data.serviceTags.length > 0) {
+		validateRecords(data.serviceTags, "serviceTag", ["id", "name"]);
+	}
+	if (data.serviceInstanceTags.length > 0) {
+		validateRecords(data.serviceInstanceTags, "serviceInstanceTag", ["instanceId", "tagId"]);
+	}
+	if (data.systemSettings && data.systemSettings.length > 0) {
+		validateRecords(data.systemSettings, "systemSettings", ["id"]);
+	}
+	if (Array.isArray(data.backupSettings) && data.backupSettings.length > 0) {
+		validateRecords(data.backupSettings, "backupSettings", ["id"]);
+	}
+	if (Array.isArray(data.vapidKeys) && data.vapidKeys.length > 0) {
+		validateRecords(data.vapidKeys, "vapidKeys", ["id", "publicKey"]);
+	}
+	if (data.trashSettings && data.trashSettings.length > 0) {
+		validateRecords(data.trashSettings, "trashSettings", ["id", "userId"]);
+	}
+	if (data.trashTemplates && data.trashTemplates.length > 0) {
+		validateRecords(data.trashTemplates, "trashTemplate", ["id", "name", "serviceType"]);
+	}
+	if (data.trashSyncSchedules && data.trashSyncSchedules.length > 0) {
+		validateRecords(data.trashSyncSchedules, "trashSyncSchedule", ["id", "userId"]);
+	}
+	if (data.trashBackups && data.trashBackups.length > 0) {
+		validateRecords(data.trashBackups, "trashBackup", ["id", "instanceId", "userId"]);
+	}
+	if (data.templateQualityProfileMappings && data.templateQualityProfileMappings.length > 0) {
+		validateRecords(data.templateQualityProfileMappings, "templateQualityProfileMapping", [
+			"id",
+			"templateId",
+			"instanceId",
+		]);
+	}
+	if (data.instanceQualityProfileOverrides && data.instanceQualityProfileOverrides.length > 0) {
+		validateRecords(data.instanceQualityProfileOverrides, "instanceQualityProfileOverride", [
+			"id",
+			"instanceId",
+		]);
+	}
+	if (data.standaloneCFDeployments && data.standaloneCFDeployments.length > 0) {
+		validateRecords(data.standaloneCFDeployments, "standaloneCFDeployment", [
+			"id",
+			"instanceId",
+			"cfTrashId",
+		]);
+	}
+	if (data.qualitySizeMappings && data.qualitySizeMappings.length > 0) {
+		validateRecords(data.qualitySizeMappings, "qualitySizeMapping", ["id", "instanceId", "userId"]);
+	}
+	if (data.trashSyncHistory && data.trashSyncHistory.length > 0) {
+		validateRecords(data.trashSyncHistory, "trashSyncHistory", ["id", "instanceId", "userId"]);
+	}
+	if (data.templateDeploymentHistory && data.templateDeploymentHistory.length > 0) {
+		validateRecords(data.templateDeploymentHistory, "templateDeploymentHistory", [
+			"id",
+			"templateId",
+			"instanceId",
+		]);
+	}
+	if (data.namingDeployHistory && data.namingDeployHistory.length > 0) {
+		validateRecords(data.namingDeployHistory, "namingDeployHistory", [
+			"id",
+			"instanceId",
+			"userId",
+			"status",
+		]);
+	}
+	if (data.huntConfigs && data.huntConfigs.length > 0) {
+		validateRecords(data.huntConfigs, "huntConfig", ["id", "instanceId"]);
+	}
+	if (data.huntLogs && data.huntLogs.length > 0) {
+		validateRecords(data.huntLogs, "huntLog", ["id", "instanceId"]);
+	}
+	if (data.huntSearchHistory && data.huntSearchHistory.length > 0) {
+		validateRecords(data.huntSearchHistory, "huntSearchHistory", ["id", "configId"]);
+	}
+	if (data.notificationChannel && data.notificationChannel.length > 0) {
+		validateRecords(data.notificationChannel, "notificationChannel", ["id", "userId"]);
+	}
+	if (data.notificationSubscription && data.notificationSubscription.length > 0) {
+		validateRecords(data.notificationSubscription, "notificationSubscription", [
+			"channelId",
+			"eventType",
+		]);
+	}
+	if (data.notificationRule && data.notificationRule.length > 0) {
+		validateRecords(data.notificationRule, "notificationRule", ["id", "userId"]);
+	}
+	if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
+		validateRecords(data.notificationAggregationConfig, "notificationAggregationConfig", [
+			"id",
+			"userId",
+		]);
+	}
+	if (data.autoTagRule && data.autoTagRule.length > 0) {
+		validateRecords(data.autoTagRule, "autoTagRule", ["id", "userId"]);
+	}
+	if (data.labelSyncRule && data.labelSyncRule.length > 0) {
+		validateRecords(data.labelSyncRule, "labelSyncRule", ["id", "userId"]);
+	}
+	if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
+		validateRecords(data.queueCleanerConfig, "queueCleanerConfig", ["id", "instanceId"]);
+	}
+	if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
+		validateRecords(data.libraryCleanupConfig, "libraryCleanupConfig", ["id", "userId"]);
+	}
+	if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
+		validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
+	}
+	if (data.libraryCleanupApproval && data.libraryCleanupApproval.length > 0) {
+		validateRecords(data.libraryCleanupApproval, "libraryCleanupApproval", [
+			"id",
+			"configId",
+			"instanceId",
+			"status",
+			"sizeOnDisk",
+			"expiresAt",
+		]);
+	}
+	if (data.libraryCleanupMediaServerScan && data.libraryCleanupMediaServerScan.length > 0) {
+		validateRecords(data.libraryCleanupMediaServerScan, "libraryCleanupMediaServerScan", [
+			"id",
+			"approvalId",
+			"instanceId",
+			"service",
+			"mediaType",
+			"targetKey",
+			"status",
+		]);
+	}
+	if (data.namingConfig && data.namingConfig.length > 0) {
+		validateRecords(data.namingConfig, "namingConfig", ["id", "instanceId", "userId"]);
+	}
+	if (data.userCustomFormat && data.userCustomFormat.length > 0) {
+		validateRecords(data.userCustomFormat, "userCustomFormat", ["id", "userId"]);
+	}
+}
+
+function prepareLibraryCleanupApprovals(
+	data: BackupData["data"],
+): Prisma.LibraryCleanupApprovalCreateManyInput[] {
+	if (!data.libraryCleanupApproval) return [];
+	return data.libraryCleanupApproval.map((row) => ({
+		...(row as Prisma.LibraryCleanupApprovalCreateManyInput),
+		terminalAuditRecordedAt: null,
+		terminalAuditRecoveryAttemptedAt: null,
+		sizeOnDisk:
+			typeof (row as Record<string, unknown>).sizeOnDisk === "string"
+				? BigInt((row as Record<string, unknown>).sizeOnDisk as string)
+				: (row as Prisma.LibraryCleanupApprovalCreateManyInput).sizeOnDisk,
+	}));
+}
+
 /**
  * Restore database from backup data
  * Uses bulk inserts for better performance and validates data before restoration
@@ -1092,410 +1268,320 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
  */
 export async function restoreDatabase(prisma: PrismaClient, data: BackupData["data"]) {
 	validateSingletonCollections(data);
+	validateRestoreRecords(data);
+	const libraryCleanupApprovals = prepareLibraryCleanupApprovals(data);
 	// Use a transaction to ensure atomicity
-	await prisma.$transaction(async (tx) => {
-		// Recheck inside the transaction immediately before any delete. The
-		// service-level preflight closes the filesystem TOCTOU window; this check
-		// protects direct callers and races between preflight and transaction.
-		await assertRestoreCompatibility(tx, data);
+	await prisma.$transaction(
+		async (tx) => {
+			// Recheck inside the transaction immediately before any delete. The
+			// service-level preflight closes the filesystem TOCTOU window; this check
+			// protects direct callers and races between preflight and transaction.
+			await assertRestoreCompatibility(tx, data);
 
-		// =================================================================
-		// DELETE all existing data (in reverse order of dependencies)
-		// =================================================================
+			// =================================================================
+			// DELETE all existing data (in reverse order of dependencies)
+			// =================================================================
 
-		// Hunting feature (HuntSearchHistory → HuntLog → HuntConfig)
-		await tx.huntSearchHistory.deleteMany();
-		await tx.huntLog.deleteMany();
-		await tx.huntConfig.deleteMany();
+			// Hunting feature (HuntSearchHistory → HuntLog → HuntConfig)
+			await tx.huntSearchHistory.deleteMany();
+			await tx.huntLog.deleteMany();
+			await tx.huntConfig.deleteMany();
 
-		// TRaSH history/audit (depends on templates, instances, backups)
-		await tx.templateDeploymentHistory.deleteMany();
-		await tx.trashSyncHistory.deleteMany();
-		await tx.namingDeployHistory.deleteMany();
-		await tx.trashCache.deleteMany();
+			// TRaSH history/audit (depends on templates, instances, backups)
+			await tx.templateDeploymentHistory.deleteMany();
+			await tx.trashSyncHistory.deleteMany();
+			await tx.namingDeployHistory.deleteMany();
+			await tx.trashCache.deleteMany();
 
-		// TRaSH configuration (depends on templates, instances)
-		await tx.qualitySizeMapping.deleteMany();
-		await tx.templateQualityProfileMapping.deleteMany();
-		await tx.instanceQualityProfileOverride.deleteMany();
-		await tx.standaloneCFDeployment.deleteMany();
-		await tx.trashBackup.deleteMany();
-		await tx.trashSyncSchedule.deleteMany();
-		await tx.trashTemplate.deleteMany();
-		await tx.trashSettings.deleteMany();
+			// TRaSH configuration (depends on templates, instances)
+			await tx.qualitySizeMapping.deleteMany();
+			await tx.templateQualityProfileMapping.deleteMany();
+			await tx.instanceQualityProfileOverride.deleteMany();
+			await tx.standaloneCFDeployment.deleteMany();
+			await tx.trashBackup.deleteMany();
+			await tx.trashSyncSchedule.deleteMany();
+			await tx.trashTemplate.deleteMany();
+			await tx.trashSettings.deleteMany();
 
-		// Durable configuration, children before parents.
-		await tx.libraryCleanupMediaServerScanLease.deleteMany();
-		await tx.libraryCleanupMediaServerScan.deleteMany();
-		await tx.libraryCleanupApproval.deleteMany();
-		await tx.notificationLog.deleteMany();
-		await tx.notificationSubscription.deleteMany();
-		await tx.libraryCleanupRule.deleteMany();
-		await tx.notificationChannel.deleteMany();
-		await tx.notificationRule.deleteMany();
-		await tx.notificationAggregationConfig.deleteMany();
-		await tx.autoTagRule.deleteMany();
-		await tx.labelSyncRule.deleteMany();
-		await tx.queueCleanerConfig.deleteMany();
-		await tx.libraryCleanupConfig.deleteMany();
-		await tx.namingConfig.deleteMany();
-		await tx.userCustomFormat.deleteMany();
+			// Durable configuration, children before parents.
+			await tx.libraryCleanupMediaServerScanLease.deleteMany();
+			await tx.libraryCleanupMediaServerScan.deleteMany();
+			await tx.libraryCleanupApproval.deleteMany();
+			await tx.notificationLog.deleteMany();
+			await tx.notificationSubscription.deleteMany();
+			await tx.libraryCleanupRule.deleteMany();
+			await tx.notificationChannel.deleteMany();
+			await tx.notificationRule.deleteMany();
+			await tx.notificationAggregationConfig.deleteMany();
+			await tx.autoTagRule.deleteMany();
+			await tx.labelSyncRule.deleteMany();
+			await tx.queueCleanerConfig.deleteMany();
+			await tx.libraryCleanupConfig.deleteMany();
+			await tx.namingConfig.deleteMany();
+			await tx.userCustomFormat.deleteMany();
 
-		// These singleton rows are not removed by user/instance cascades. Each
-		// incoming array independently authorizes replacement of its own model.
-		if (Array.isArray(data.backupSettings)) {
-			await tx.backupSettings.deleteMany();
-		}
-		if (Array.isArray(data.vapidKeys)) {
-			await tx.vapidKeys.deleteMany();
-		}
+			// These singleton rows are not removed by user/instance cascades. Each
+			// incoming array independently authorizes replacement of its own model.
+			if (Array.isArray(data.backupSettings)) {
+				await tx.backupSettings.deleteMany();
+			}
+			if (Array.isArray(data.vapidKeys)) {
+				await tx.vapidKeys.deleteMany();
+			}
 
-		// System settings are independent of user/instance cascades. Preserve
-		// them for legacy files that predate this payload coverage.
-		if (Array.isArray(data.systemSettings)) {
-			await tx.systemSettings.deleteMany();
-		}
+			// System settings are independent of user/instance cascades. Preserve
+			// them for legacy files that predate this payload coverage.
+			if (Array.isArray(data.systemSettings)) {
+				await tx.systemSettings.deleteMany();
+			}
 
-		// Core tables (existing)
-		await tx.serviceInstanceTag.deleteMany();
-		await tx.serviceTag.deleteMany();
-		await tx.serviceInstance.deleteMany();
-		await tx.webAuthnCredential.deleteMany();
-		await tx.oIDCAccount.deleteMany();
-		// OIDC providers are independent of the user/instance cascades too.
-		// Legacy files may omit them, so do not turn omission into deletion.
-		if (Array.isArray(data.oidcProviders)) {
-			await tx.oIDCProvider.deleteMany();
-		}
-		await tx.session.deleteMany();
-		await tx.user.deleteMany();
+			// Core tables (existing)
+			await tx.serviceInstanceTag.deleteMany();
+			await tx.serviceTag.deleteMany();
+			await tx.serviceInstance.deleteMany();
+			await tx.webAuthnCredential.deleteMany();
+			await tx.oIDCAccount.deleteMany();
+			// OIDC providers are independent of the user/instance cascades too.
+			// Legacy files may omit them, so do not turn omission into deletion.
+			if (Array.isArray(data.oidcProviders)) {
+				await tx.oIDCProvider.deleteMany();
+			}
+			await tx.session.deleteMany();
+			await tx.user.deleteMany();
 
-		// =================================================================
-		// RESTORE data (in order of dependencies)
-		// =================================================================
+			// =================================================================
+			// RESTORE data (in order of dependencies)
+			// =================================================================
 
-		// --- Core authentication (no dependencies) ---
+			// --- Core authentication (no dependencies) ---
 
-		if (data.users.length > 0) {
-			validateRecords(data.users, "user", ["id", "username"]);
-			await tx.user.createMany({
-				data: data.users as Prisma.UserCreateManyInput[],
-			});
-		}
+			if (data.users.length > 0) {
+				await tx.user.createMany({
+					data: data.users as Prisma.UserCreateManyInput[],
+				});
+			}
 
-		if (data.sessions.length > 0) {
-			validateRecords(data.sessions, "session", ["id", "userId", "expiresAt"]);
-			await tx.session.createMany({
-				data: data.sessions as Prisma.SessionCreateManyInput[],
-			});
-		}
+			if (data.sessions.length > 0) {
+				await tx.session.createMany({
+					data: data.sessions as Prisma.SessionCreateManyInput[],
+				});
+			}
 
-		if (data.oidcProviders && data.oidcProviders.length > 0) {
-			validateRecords(data.oidcProviders, "oidcProvider", ["id", "clientId", "issuer"]);
-			const providerData = data.oidcProviders[0] as Prisma.OIDCProviderCreateInput;
-			await tx.oIDCProvider.create({
-				data: { ...providerData, id: 1 },
-			});
-		}
+			if (data.oidcProviders && data.oidcProviders.length > 0) {
+				const providerData = data.oidcProviders[0] as Prisma.OIDCProviderCreateInput;
+				await tx.oIDCProvider.create({
+					data: { ...providerData, id: 1 },
+				});
+			}
 
-		if (data.oidcAccounts.length > 0) {
-			validateRecords(data.oidcAccounts, "oidcAccount", ["id", "userId", "providerUserId"]);
-			await tx.oIDCAccount.createMany({
-				data: data.oidcAccounts as Prisma.OIDCAccountCreateManyInput[],
-			});
-		}
+			if (data.oidcAccounts.length > 0) {
+				await tx.oIDCAccount.createMany({
+					data: data.oidcAccounts as Prisma.OIDCAccountCreateManyInput[],
+				});
+			}
 
-		if (data.webAuthnCredentials.length > 0) {
-			validateRecords(data.webAuthnCredentials, "webAuthnCredential", [
-				"id",
-				"userId",
-				"publicKey",
-			]);
-			await tx.webAuthnCredential.createMany({
-				data: data.webAuthnCredentials as Prisma.WebAuthnCredentialCreateManyInput[],
-			});
-		}
+			if (data.webAuthnCredentials.length > 0) {
+				await tx.webAuthnCredential.createMany({
+					data: data.webAuthnCredentials as Prisma.WebAuthnCredentialCreateManyInput[],
+				});
+			}
 
-		// --- Service instances & tags ---
+			// --- Service instances & tags ---
 
-		if (data.serviceInstances.length > 0) {
-			validateRecords(data.serviceInstances, "serviceInstance", ["id", "service", "baseUrl"]);
-			await tx.serviceInstance.createMany({
-				data: data.serviceInstances as Prisma.ServiceInstanceCreateManyInput[],
-			});
-		}
+			if (data.serviceInstances.length > 0) {
+				await tx.serviceInstance.createMany({
+					data: data.serviceInstances as Prisma.ServiceInstanceCreateManyInput[],
+				});
+			}
 
-		if (data.serviceTags.length > 0) {
-			validateRecords(data.serviceTags, "serviceTag", ["id", "name"]);
-			await tx.serviceTag.createMany({
-				data: data.serviceTags as Prisma.ServiceTagCreateManyInput[],
-			});
-		}
+			if (data.serviceTags.length > 0) {
+				await tx.serviceTag.createMany({
+					data: data.serviceTags as Prisma.ServiceTagCreateManyInput[],
+				});
+			}
 
-		if (data.serviceInstanceTags.length > 0) {
-			validateRecords(data.serviceInstanceTags, "serviceInstanceTag", ["instanceId", "tagId"]);
-			await tx.serviceInstanceTag.createMany({
-				data: data.serviceInstanceTags as Prisma.ServiceInstanceTagCreateManyInput[],
-			});
-		}
+			if (data.serviceInstanceTags.length > 0) {
+				await tx.serviceInstanceTag.createMany({
+					data: data.serviceInstanceTags as Prisma.ServiceInstanceTagCreateManyInput[],
+				});
+			}
 
-		// --- System settings (singleton) ---
+			// --- System settings (singleton) ---
 
-		if (data.systemSettings && data.systemSettings.length > 0) {
-			validateRecords(data.systemSettings, "systemSettings", ["id"]);
-			const settingsData = data.systemSettings[0] as Prisma.SystemSettingsCreateInput;
-			await tx.systemSettings.create({
-				data: { ...settingsData, id: 1 },
-			});
-		}
+			if (data.systemSettings && data.systemSettings.length > 0) {
+				const settingsData = data.systemSettings[0] as Prisma.SystemSettingsCreateInput;
+				await tx.systemSettings.create({
+					data: { ...settingsData, id: 1 },
+				});
+			}
 
-		if (Array.isArray(data.backupSettings) && data.backupSettings.length > 0) {
-			validateRecords(data.backupSettings, "backupSettings", ["id"]);
-			const settings = data.backupSettings[0] as Prisma.BackupSettingsCreateInput;
-			await tx.backupSettings.create({ data: { ...settings, id: 1 } });
-		}
+			if (Array.isArray(data.backupSettings) && data.backupSettings.length > 0) {
+				const settings = data.backupSettings[0] as Prisma.BackupSettingsCreateInput;
+				await tx.backupSettings.create({ data: { ...settings, id: 1 } });
+			}
 
-		if (Array.isArray(data.vapidKeys) && data.vapidKeys.length > 0) {
-			validateRecords(data.vapidKeys, "vapidKeys", ["id", "publicKey"]);
-			const keys = data.vapidKeys[0] as Prisma.VapidKeysCreateInput;
-			await tx.vapidKeys.create({ data: { ...keys, id: 1 } });
-		}
+			if (Array.isArray(data.vapidKeys) && data.vapidKeys.length > 0) {
+				const keys = data.vapidKeys[0] as Prisma.VapidKeysCreateInput;
+				await tx.vapidKeys.create({ data: { ...keys, id: 1 } });
+			}
 
-		// --- TRaSH Guides configuration ---
+			// --- TRaSH Guides configuration ---
 
-		if (data.trashSettings && data.trashSettings.length > 0) {
-			validateRecords(data.trashSettings, "trashSettings", ["id", "userId"]);
-			await tx.trashSettings.createMany({
-				data: data.trashSettings as Prisma.TrashSettingsCreateManyInput[],
-			});
-		}
+			if (data.trashSettings && data.trashSettings.length > 0) {
+				await tx.trashSettings.createMany({
+					data: data.trashSettings as Prisma.TrashSettingsCreateManyInput[],
+				});
+			}
 
-		if (data.trashTemplates && data.trashTemplates.length > 0) {
-			validateRecords(data.trashTemplates, "trashTemplate", ["id", "name", "serviceType"]);
-			await tx.trashTemplate.createMany({
-				data: data.trashTemplates as Prisma.TrashTemplateCreateManyInput[],
-			});
-		}
+			if (data.trashTemplates && data.trashTemplates.length > 0) {
+				await tx.trashTemplate.createMany({
+					data: data.trashTemplates as Prisma.TrashTemplateCreateManyInput[],
+				});
+			}
 
-		if (data.trashSyncSchedules && data.trashSyncSchedules.length > 0) {
-			validateRecords(data.trashSyncSchedules, "trashSyncSchedule", ["id", "userId"]);
-			await tx.trashSyncSchedule.createMany({
-				data: data.trashSyncSchedules as Prisma.TrashSyncScheduleCreateManyInput[],
-			});
-		}
+			if (data.trashSyncSchedules && data.trashSyncSchedules.length > 0) {
+				await tx.trashSyncSchedule.createMany({
+					data: data.trashSyncSchedules as Prisma.TrashSyncScheduleCreateManyInput[],
+				});
+			}
 
-		if (data.trashBackups && data.trashBackups.length > 0) {
-			validateRecords(data.trashBackups, "trashBackup", ["id", "instanceId", "userId"]);
-			await tx.trashBackup.createMany({
-				data: data.trashBackups as Prisma.TrashBackupCreateManyInput[],
-			});
-		}
+			if (data.trashBackups && data.trashBackups.length > 0) {
+				await tx.trashBackup.createMany({
+					data: data.trashBackups as Prisma.TrashBackupCreateManyInput[],
+				});
+			}
 
-		if (data.templateQualityProfileMappings && data.templateQualityProfileMappings.length > 0) {
-			validateRecords(data.templateQualityProfileMappings, "templateQualityProfileMapping", [
-				"id",
-				"templateId",
-				"instanceId",
-			]);
-			await tx.templateQualityProfileMapping.createMany({
-				data: data.templateQualityProfileMappings as Prisma.TemplateQualityProfileMappingCreateManyInput[],
-			});
-		}
+			if (data.templateQualityProfileMappings && data.templateQualityProfileMappings.length > 0) {
+				await tx.templateQualityProfileMapping.createMany({
+					data: data.templateQualityProfileMappings as Prisma.TemplateQualityProfileMappingCreateManyInput[],
+				});
+			}
 
-		if (data.instanceQualityProfileOverrides && data.instanceQualityProfileOverrides.length > 0) {
-			validateRecords(data.instanceQualityProfileOverrides, "instanceQualityProfileOverride", [
-				"id",
-				"instanceId",
-			]);
-			await tx.instanceQualityProfileOverride.createMany({
-				data: data.instanceQualityProfileOverrides as Prisma.InstanceQualityProfileOverrideCreateManyInput[],
-			});
-		}
+			if (data.instanceQualityProfileOverrides && data.instanceQualityProfileOverrides.length > 0) {
+				await tx.instanceQualityProfileOverride.createMany({
+					data: data.instanceQualityProfileOverrides as Prisma.InstanceQualityProfileOverrideCreateManyInput[],
+				});
+			}
 
-		if (data.standaloneCFDeployments && data.standaloneCFDeployments.length > 0) {
-			validateRecords(data.standaloneCFDeployments, "standaloneCFDeployment", [
-				"id",
-				"instanceId",
-				"cfTrashId",
-			]);
-			await tx.standaloneCFDeployment.createMany({
-				data: data.standaloneCFDeployments as Prisma.StandaloneCFDeploymentCreateManyInput[],
-			});
-		}
+			if (data.standaloneCFDeployments && data.standaloneCFDeployments.length > 0) {
+				await tx.standaloneCFDeployment.createMany({
+					data: data.standaloneCFDeployments as Prisma.StandaloneCFDeploymentCreateManyInput[],
+				});
+			}
 
-		if (data.qualitySizeMappings && data.qualitySizeMappings.length > 0) {
-			validateRecords(data.qualitySizeMappings, "qualitySizeMapping", [
-				"id",
-				"instanceId",
-				"userId",
-			]);
-			await tx.qualitySizeMapping.createMany({
-				data: data.qualitySizeMappings as Prisma.QualitySizeMappingCreateManyInput[],
-			});
-		}
+			if (data.qualitySizeMappings && data.qualitySizeMappings.length > 0) {
+				await tx.qualitySizeMapping.createMany({
+					data: data.qualitySizeMappings as Prisma.QualitySizeMappingCreateManyInput[],
+				});
+			}
 
-		// --- TRaSH Guides history/audit ---
+			// --- TRaSH Guides history/audit ---
 
-		if (data.trashSyncHistory && data.trashSyncHistory.length > 0) {
-			validateRecords(data.trashSyncHistory, "trashSyncHistory", ["id", "instanceId", "userId"]);
-			await tx.trashSyncHistory.createMany({
-				data: data.trashSyncHistory as Prisma.TrashSyncHistoryCreateManyInput[],
-			});
-		}
+			if (data.trashSyncHistory && data.trashSyncHistory.length > 0) {
+				await tx.trashSyncHistory.createMany({
+					data: data.trashSyncHistory as Prisma.TrashSyncHistoryCreateManyInput[],
+				});
+			}
 
-		if (data.templateDeploymentHistory && data.templateDeploymentHistory.length > 0) {
-			validateRecords(data.templateDeploymentHistory, "templateDeploymentHistory", [
-				"id",
-				"templateId",
-				"instanceId",
-			]);
-			await tx.templateDeploymentHistory.createMany({
-				data: data.templateDeploymentHistory as Prisma.TemplateDeploymentHistoryCreateManyInput[],
-			});
-		}
+			if (data.templateDeploymentHistory && data.templateDeploymentHistory.length > 0) {
+				await tx.templateDeploymentHistory.createMany({
+					data: data.templateDeploymentHistory as Prisma.TemplateDeploymentHistoryCreateManyInput[],
+				});
+			}
 
-		if (data.namingDeployHistory && data.namingDeployHistory.length > 0) {
-			validateRecords(data.namingDeployHistory, "namingDeployHistory", [
-				"id",
-				"instanceId",
-				"userId",
-				"status",
-			]);
-			await tx.namingDeployHistory.createMany({
-				data: data.namingDeployHistory as Prisma.NamingDeployHistoryCreateManyInput[],
-			});
-		}
+			if (data.namingDeployHistory && data.namingDeployHistory.length > 0) {
+				await tx.namingDeployHistory.createMany({
+					data: data.namingDeployHistory as Prisma.NamingDeployHistoryCreateManyInput[],
+				});
+			}
 
-		// --- Hunting feature ---
+			// --- Hunting feature ---
 
-		if (data.huntConfigs && data.huntConfigs.length > 0) {
-			validateRecords(data.huntConfigs, "huntConfig", ["id", "instanceId"]);
-			await tx.huntConfig.createMany({
-				data: data.huntConfigs as Prisma.HuntConfigCreateManyInput[],
-			});
-		}
+			if (data.huntConfigs && data.huntConfigs.length > 0) {
+				await tx.huntConfig.createMany({
+					data: data.huntConfigs as Prisma.HuntConfigCreateManyInput[],
+				});
+			}
 
-		if (data.huntLogs && data.huntLogs.length > 0) {
-			validateRecords(data.huntLogs, "huntLog", ["id", "instanceId"]);
-			await tx.huntLog.createMany({
-				data: data.huntLogs as Prisma.HuntLogCreateManyInput[],
-			});
-		}
+			if (data.huntLogs && data.huntLogs.length > 0) {
+				await tx.huntLog.createMany({
+					data: data.huntLogs as Prisma.HuntLogCreateManyInput[],
+				});
+			}
 
-		if (data.huntSearchHistory && data.huntSearchHistory.length > 0) {
-			validateRecords(data.huntSearchHistory, "huntSearchHistory", ["id", "configId"]);
-			await tx.huntSearchHistory.createMany({
-				data: data.huntSearchHistory as Prisma.HuntSearchHistoryCreateManyInput[],
-			});
-		}
+			if (data.huntSearchHistory && data.huntSearchHistory.length > 0) {
+				await tx.huntSearchHistory.createMany({
+					data: data.huntSearchHistory as Prisma.HuntSearchHistoryCreateManyInput[],
+				});
+			}
 
-		// Durable configuration (dependency order).
-		if (data.notificationChannel && data.notificationChannel.length > 0) {
-			validateRecords(data.notificationChannel, "notificationChannel", ["id", "userId"]);
-			await tx.notificationChannel.createMany({
-				data: data.notificationChannel as Prisma.NotificationChannelCreateManyInput[],
-			});
-		}
-		if (data.notificationSubscription && data.notificationSubscription.length > 0) {
-			validateRecords(data.notificationSubscription, "notificationSubscription", [
-				"channelId",
-				"eventType",
-			]);
-			await tx.notificationSubscription.createMany({
-				data: data.notificationSubscription as Prisma.NotificationSubscriptionCreateManyInput[],
-			});
-		}
-		if (data.notificationRule && data.notificationRule.length > 0) {
-			validateRecords(data.notificationRule, "notificationRule", ["id", "userId"]);
-			await tx.notificationRule.createMany({
-				data: data.notificationRule as Prisma.NotificationRuleCreateManyInput[],
-			});
-		}
-		if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
-			validateRecords(data.notificationAggregationConfig, "notificationAggregationConfig", [
-				"id",
-				"userId",
-			]);
-			await tx.notificationAggregationConfig.createMany({
-				data: data.notificationAggregationConfig as Prisma.NotificationAggregationConfigCreateManyInput[],
-			});
-		}
-		if (data.autoTagRule && data.autoTagRule.length > 0) {
-			validateRecords(data.autoTagRule, "autoTagRule", ["id", "userId"]);
-			await tx.autoTagRule.createMany({
-				data: data.autoTagRule as Prisma.AutoTagRuleCreateManyInput[],
-			});
-		}
-		if (data.labelSyncRule && data.labelSyncRule.length > 0) {
-			validateRecords(data.labelSyncRule, "labelSyncRule", ["id", "userId"]);
-			await tx.labelSyncRule.createMany({
-				data: data.labelSyncRule as Prisma.LabelSyncRuleCreateManyInput[],
-			});
-		}
-		if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
-			validateRecords(data.queueCleanerConfig, "queueCleanerConfig", ["id", "instanceId"]);
-			await tx.queueCleanerConfig.createMany({
-				data: data.queueCleanerConfig as Prisma.QueueCleanerConfigCreateManyInput[],
-			});
-		}
-		if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
-			validateRecords(data.libraryCleanupConfig, "libraryCleanupConfig", ["id", "userId"]);
-			await tx.libraryCleanupConfig.createMany({
-				data: data.libraryCleanupConfig as Prisma.LibraryCleanupConfigCreateManyInput[],
-			});
-		}
-		if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
-			validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
-			await tx.libraryCleanupRule.createMany({
-				data: data.libraryCleanupRule as Prisma.LibraryCleanupRuleCreateManyInput[],
-			});
-		}
-		if (data.libraryCleanupApproval && data.libraryCleanupApproval.length > 0) {
-			validateRecords(data.libraryCleanupApproval, "libraryCleanupApproval", [
-				"id",
-				"configId",
-				"instanceId",
-				"status",
-				"sizeOnDisk",
-				"expiresAt",
-			]);
-			await tx.libraryCleanupApproval.createMany({
-				data: data.libraryCleanupApproval.map((row) => ({
-					...(row as Prisma.LibraryCleanupApprovalCreateManyInput),
-					terminalAuditRecordedAt: null,
-					terminalAuditRecoveryAttemptedAt: null,
-					sizeOnDisk:
-						typeof (row as Record<string, unknown>).sizeOnDisk === "string"
-							? BigInt((row as Record<string, unknown>).sizeOnDisk as string)
-							: (row as Prisma.LibraryCleanupApprovalCreateManyInput).sizeOnDisk,
-				})) as Prisma.LibraryCleanupApprovalCreateManyInput[],
-			});
-		}
-		if (data.libraryCleanupMediaServerScan && data.libraryCleanupMediaServerScan.length > 0) {
-			validateRecords(data.libraryCleanupMediaServerScan, "libraryCleanupMediaServerScan", [
-				"id",
-				"approvalId",
-				"instanceId",
-				"service",
-				"mediaType",
-				"targetKey",
-				"status",
-			]);
-			await tx.libraryCleanupMediaServerScan.createMany({
-				data: data.libraryCleanupMediaServerScan as Prisma.LibraryCleanupMediaServerScanCreateManyInput[],
-			});
-		}
-		if (data.namingConfig && data.namingConfig.length > 0) {
-			validateRecords(data.namingConfig, "namingConfig", ["id", "instanceId", "userId"]);
-			await tx.namingConfig.createMany({
-				data: data.namingConfig as Prisma.NamingConfigCreateManyInput[],
-			});
-		}
-		if (data.userCustomFormat && data.userCustomFormat.length > 0) {
-			validateRecords(data.userCustomFormat, "userCustomFormat", ["id", "userId"]);
-			await tx.userCustomFormat.createMany({
-				data: data.userCustomFormat as Prisma.UserCustomFormatCreateManyInput[],
-			});
-		}
-	});
+			// Durable configuration (dependency order).
+			if (data.notificationChannel && data.notificationChannel.length > 0) {
+				await tx.notificationChannel.createMany({
+					data: data.notificationChannel as Prisma.NotificationChannelCreateManyInput[],
+				});
+			}
+			if (data.notificationSubscription && data.notificationSubscription.length > 0) {
+				await tx.notificationSubscription.createMany({
+					data: data.notificationSubscription as Prisma.NotificationSubscriptionCreateManyInput[],
+				});
+			}
+			if (data.notificationRule && data.notificationRule.length > 0) {
+				await tx.notificationRule.createMany({
+					data: data.notificationRule as Prisma.NotificationRuleCreateManyInput[],
+				});
+			}
+			if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
+				await tx.notificationAggregationConfig.createMany({
+					data: data.notificationAggregationConfig as Prisma.NotificationAggregationConfigCreateManyInput[],
+				});
+			}
+			if (data.autoTagRule && data.autoTagRule.length > 0) {
+				await tx.autoTagRule.createMany({
+					data: data.autoTagRule as Prisma.AutoTagRuleCreateManyInput[],
+				});
+			}
+			if (data.labelSyncRule && data.labelSyncRule.length > 0) {
+				await tx.labelSyncRule.createMany({
+					data: data.labelSyncRule as Prisma.LabelSyncRuleCreateManyInput[],
+				});
+			}
+			if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
+				await tx.queueCleanerConfig.createMany({
+					data: data.queueCleanerConfig as Prisma.QueueCleanerConfigCreateManyInput[],
+				});
+			}
+			if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
+				await tx.libraryCleanupConfig.createMany({
+					data: data.libraryCleanupConfig as Prisma.LibraryCleanupConfigCreateManyInput[],
+				});
+			}
+			if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
+				await tx.libraryCleanupRule.createMany({
+					data: data.libraryCleanupRule as Prisma.LibraryCleanupRuleCreateManyInput[],
+				});
+			}
+			if (libraryCleanupApprovals.length > 0) {
+				await tx.libraryCleanupApproval.createMany({
+					data: libraryCleanupApprovals,
+				});
+			}
+			if (data.libraryCleanupMediaServerScan && data.libraryCleanupMediaServerScan.length > 0) {
+				await tx.libraryCleanupMediaServerScan.createMany({
+					data: data.libraryCleanupMediaServerScan as Prisma.LibraryCleanupMediaServerScanCreateManyInput[],
+				});
+			}
+			if (data.namingConfig && data.namingConfig.length > 0) {
+				await tx.namingConfig.createMany({
+					data: data.namingConfig as Prisma.NamingConfigCreateManyInput[],
+				});
+			}
+			if (data.userCustomFormat && data.userCustomFormat.length > 0) {
+				await tx.userCustomFormat.createMany({
+					data: data.userCustomFormat as Prisma.UserCustomFormatCreateManyInput[],
+				});
+			}
+		},
+		{ timeout: RESTORE_TRANSACTION_TIMEOUT_MS },
+	);
 }

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -121,6 +121,27 @@ async function targetHasOmittedOidcProvider(
 	return provider?.count ? (await provider.count()) > 0 : false;
 }
 
+async function targetHasOmittedLibrarySyncSettings(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const model = (
+		prisma as unknown as Record<
+			string,
+			{
+				findMany?: (args: unknown) => Promise<unknown[]>;
+			}
+		>
+	).librarySyncStatus;
+	if (!model?.findMany) return false;
+	const rows = await model.findMany({
+		where: {
+			OR: [{ pollingEnabled: false }, { pollingIntervalMins: { not: 15 } }],
+		},
+		select: { instanceId: true },
+	});
+	return rows.length > 0;
+}
+
 async function targetHasActiveCleanupCoordination(
 	prisma: Prisma.TransactionClient | PrismaClient,
 	missingFields: readonly string[],
@@ -198,6 +219,12 @@ export async function assertRestoreCompatibility(
 		throw new BackupCompatibilityError();
 	}
 	if (!Array.isArray(record.oidcProviders) && (await targetHasOmittedOidcProvider(prisma))) {
+		throw new BackupCompatibilityError();
+	}
+	if (
+		!Array.isArray(record.librarySyncSettings) &&
+		(await targetHasOmittedLibrarySyncSettings(prisma))
+	) {
 		throw new BackupCompatibilityError();
 	}
 	if (
@@ -831,6 +858,13 @@ async function exportDatabaseSnapshot(
 	const queueCleanerConfig = await prisma.queueCleanerConfig.findMany();
 	const libraryCleanupConfig = await prisma.libraryCleanupConfig.findMany();
 	const libraryCleanupRule = await prisma.libraryCleanupRule.findMany();
+	const librarySyncSettings = await prisma.librarySyncStatus.findMany({
+		select: {
+			instanceId: true,
+			pollingEnabled: true,
+			pollingIntervalMins: true,
+		},
+	});
 	const namingConfig = await prisma.namingConfig.findMany();
 	const userCustomFormat = await prisma.userCustomFormat.findMany();
 	const activeCleanupApprovals = await prisma.libraryCleanupApproval.findMany({
@@ -1042,6 +1076,7 @@ async function exportDatabaseSnapshot(
 		queueCleanerConfig,
 		libraryCleanupConfig,
 		libraryCleanupRule,
+		librarySyncSettings,
 		namingConfig,
 		userCustomFormat,
 		libraryCleanupApproval,
@@ -1214,6 +1249,13 @@ function validateRestoreRecords(data: BackupData["data"]): void {
 	if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
 		validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
 	}
+	if (data.librarySyncSettings && data.librarySyncSettings.length > 0) {
+		validateRecords(data.librarySyncSettings, "librarySyncSettings", [
+			"instanceId",
+			"pollingEnabled",
+			"pollingIntervalMins",
+		]);
+	}
 	if (data.libraryCleanupApproval && data.libraryCleanupApproval.length > 0) {
 		validateRecords(data.libraryCleanupApproval, "libraryCleanupApproval", [
 			"id",
@@ -1258,6 +1300,51 @@ function prepareLibraryCleanupApprovals(
 	}));
 }
 
+function prepareLibrarySyncSettings(
+	data: BackupData["data"],
+): Prisma.LibrarySyncStatusCreateManyInput[] {
+	if (!data.librarySyncSettings) return [];
+	const seenInstanceIds = new Set<string>();
+	return data.librarySyncSettings.map((row, index) => {
+		if (typeof row !== "object" || row === null) {
+			throw new Error(`Invalid librarySyncSettings record at index ${index}: not an object`);
+		}
+		const record = row as Record<string, unknown>;
+		if (typeof record.instanceId !== "string" || record.instanceId.length === 0) {
+			throw new Error(
+				`Invalid librarySyncSettings record at index ${index}: instanceId must be a non-empty string`,
+			);
+		}
+		if (seenInstanceIds.has(record.instanceId)) {
+			throw new Error(
+				`Invalid backup format: duplicate librarySyncSettings instanceId ${record.instanceId}`,
+			);
+		}
+		if (typeof record.pollingEnabled !== "boolean") {
+			throw new Error(
+				`Invalid librarySyncSettings record at index ${index}: pollingEnabled must be a boolean`,
+			);
+		}
+		if (
+			typeof record.pollingIntervalMins !== "number" ||
+			!Number.isInteger(record.pollingIntervalMins) ||
+			record.pollingIntervalMins < 5 ||
+			record.pollingIntervalMins > 1440
+		) {
+			throw new Error(
+				`Invalid librarySyncSettings record at index ${index}: pollingIntervalMins must be an integer from 5 to 1440`,
+			);
+		}
+
+		seenInstanceIds.add(record.instanceId);
+		return {
+			instanceId: record.instanceId,
+			pollingEnabled: record.pollingEnabled,
+			pollingIntervalMins: record.pollingIntervalMins,
+		};
+	});
+}
+
 /**
  * Restore database from backup data
  * Uses bulk inserts for better performance and validates data before restoration
@@ -1270,6 +1357,7 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 	validateSingletonCollections(data);
 	validateRestoreRecords(data);
 	const libraryCleanupApprovals = prepareLibraryCleanupApprovals(data);
+	const librarySyncSettings = prepareLibrarySyncSettings(data);
 	// Use a transaction to ensure atomicity
 	await prisma.$transaction(
 		async (tx) => {
@@ -1403,6 +1491,12 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			if (data.serviceInstanceTags.length > 0) {
 				await tx.serviceInstanceTag.createMany({
 					data: data.serviceInstanceTags as Prisma.ServiceInstanceTagCreateManyInput[],
+				});
+			}
+
+			if (librarySyncSettings.length > 0) {
+				await tx.librarySyncStatus.createMany({
+					data: librarySyncSettings,
 				});
 			}
 

--- a/apps/api/src/lib/backup/backup-mutation-gate.ts
+++ b/apps/api/src/lib/backup/backup-mutation-gate.ts
@@ -1,0 +1,19 @@
+import type { FastifyInstance, HTTPMethods, RouteHandlerMethod } from "fastify";
+import { withCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
+
+const MUTATING_METHODS = new Set<HTTPMethods>(["DELETE", "PATCH", "POST", "PUT"]);
+
+/** Serialize every HTTP mutation handler against backup creation and restore. */
+export function registerBackupMutationGuard(app: FastifyInstance): void {
+	app.addHook("onRoute", (routeOptions) => {
+		const methods = Array.isArray(routeOptions.method)
+			? routeOptions.method
+			: [routeOptions.method];
+		if (!methods.some((method) => MUTATING_METHODS.has(method))) return;
+
+		const handler = routeOptions.handler;
+		routeOptions.handler = function guardedBackupMutation(request, reply) {
+			return withCleanupOperationGuard(async () => handler.call(this, request, reply));
+		} as RouteHandlerMethod;
+	});
+}

--- a/apps/api/src/lib/backup/backup-mutation-gate.ts
+++ b/apps/api/src/lib/backup/backup-mutation-gate.ts
@@ -3,13 +3,23 @@ import { withCleanupOperationGuard } from "../library-cleanup/cleanup-maintenanc
 
 const MUTATING_METHODS = new Set<HTTPMethods>(["DELETE", "PATCH", "POST", "PUT"]);
 
+declare module "fastify" {
+	interface FastifyContextConfig {
+		/** The handler performs a durable write despite using a read HTTP method. */
+		backupMutation?: boolean;
+	}
+}
+
 /** Serialize every HTTP mutation handler against backup creation and restore. */
 export function registerBackupMutationGuard(app: FastifyInstance): void {
 	app.addHook("onRoute", (routeOptions) => {
 		const methods = Array.isArray(routeOptions.method)
 			? routeOptions.method
 			: [routeOptions.method];
-		if (!methods.some((method) => MUTATING_METHODS.has(method))) return;
+		const mutatesDurableState =
+			routeOptions.config?.backupMutation === true ||
+			methods.some((method) => MUTATING_METHODS.has(method));
+		if (!mutatesDurableState) return;
 
 		const handler = routeOptions.handler;
 		routeOptions.handler = function guardedBackupMutation(request, reply) {

--- a/apps/api/src/lib/backup/backup-scheduler.ts
+++ b/apps/api/src/lib/backup/backup-scheduler.ts
@@ -1,6 +1,7 @@
 import type { FastifyBaseLogger } from "fastify";
 import type { PrismaClient } from "../../lib/prisma.js";
 import type { Encryptor } from "../auth/encryption.js";
+import { withCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import type { NotificationPayload } from "../notifications/types.js";
 import {
 	passthroughTickWrapper,
@@ -90,6 +91,10 @@ export class BackupScheduler {
 	 * consider implementing a database advisory lock or a distributed lock mechanism.
 	 */
 	private async checkAndRunBackup() {
+		return withCleanupOperationGuard(() => this.checkAndRunBackupGuarded());
+	}
+
+	private async checkAndRunBackupGuarded() {
 		// In-flight guard: prevent overlapping backup runs
 		if (this.isRunning) {
 			this.logger.debug("Backup already running, skipping this check");
@@ -152,7 +157,7 @@ export class BackupScheduler {
 					"Scheduled backup completed",
 				);
 
-				this.notifyFn?.({
+				await this.notifyFn?.({
 					eventType: "BACKUP_COMPLETED",
 					title: "Scheduled backup completed",
 					body: `Next backup at ${nextRunAt.toISOString()}`,
@@ -172,7 +177,7 @@ export class BackupScheduler {
 		} catch (error) {
 			this.logger.error({ err: error }, "Error checking/running scheduled backup");
 
-			this.notifyFn?.({
+			await this.notifyFn?.({
 				eventType: "BACKUP_FAILED",
 				title: "Scheduled backup failed",
 				body: getErrorMessage(error),

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -7,7 +7,7 @@
  * Features:
  * - Manual, scheduled, and auto-update backups
  * - Password-based encryption with configurable password
- * - Restore with validation and rollback capability
+ * - Fail-closed restore containment until crash-safe recovery is available
  * - Size limits to prevent memory exhaustion
  *
  * Implementation is decomposed into focused modules:
@@ -31,23 +31,15 @@ import type { PrismaClient } from "../../lib/prisma.js";
 import type { Encryptor } from "../auth/encryption.js";
 import { withCleanupMaintenanceGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import { loggers } from "../logger.js";
-import { getErrorMessage } from "../utils/error-message.js";
-import { decryptBackupData, encryptBackupData } from "./backup-crypto.js";
-import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "./backup-database.js";
+import { encryptBackupData } from "./backup-crypto.js";
+import { exportDatabase } from "./backup-database.js";
 import {
 	ensureBackupsDirectory,
 	generateBackupId,
 	parseTimestampFromFilename,
 	readSecrets,
-	writeSecrets,
 } from "./backup-file-utils.js";
-import {
-	BACKUP_VERSION,
-	isEncryptedBackupEnvelope,
-	isPlaintextBackup,
-	normalizeBackupForRestore,
-	validateBackup,
-} from "./backup-validation.js";
+import { BACKUP_VERSION } from "./backup-validation.js";
 
 const log = loggers.backup;
 
@@ -55,7 +47,6 @@ const log = loggers.backup;
 // These limits help prevent out-of-memory errors during JSON stringification and encryption
 const RECOMMENDED_MAX_BACKUP_SIZE_MB = 100; // 100 MB recommended limit for backup data
 const WARNING_BACKUP_SIZE_MB = 50; // Log warning when backup exceeds this size
-const MAX_RESTORE_SIZE_MB = 200; // Maximum size for restore operations (defense against malicious files)
 
 type BackupType = "manual" | "scheduled" | "update";
 
@@ -79,6 +70,17 @@ export class BackupPasswordConfigurationError extends Error {
 			"The stored backup password is invalid. Reset it in Settings > Backup or set the BACKUP_PASSWORD environment variable.",
 		);
 		this.name = "BackupPasswordConfigurationError";
+	}
+}
+
+export class BackupRestoreUnavailableError extends Error {
+	readonly statusCode = 503;
+
+	constructor() {
+		super(
+			"Restore is disabled because this version cannot yet guarantee crash-safe database and secrets recovery. No data was changed.",
+		);
+		this.name = "BackupRestoreUnavailableError";
 	}
 }
 
@@ -706,146 +708,13 @@ export class BackupService {
 		});
 	}
 
-	/**
-	 * Restore from a backup file on filesystem
-	 * Delegates to restoreBackup which handles both encrypted and plaintext formats
-	 */
-	async restoreBackupFromFile(id: string): Promise<BackupMetadata> {
-		const backup = await this.getBackupByIdInternal(id);
-		if (!backup) {
-			throw new Error(`Backup with ID ${id} not found`);
-		}
-
-		// Optional: Validate file size before reading (defense-in-depth against malicious files)
-		// While createBackup enforces ~100 MB limit, manually created or maliciously large backup files
-		// could cause OOM errors. Allow slightly larger files than creation limit for flexibility.
-		const sizeMB = backup.size / (1024 * 1024);
-		if (sizeMB > MAX_RESTORE_SIZE_MB) {
-			throw new Error(
-				`Backup file too large (${sizeMB.toFixed(1)} MB). Maximum allowed: ${MAX_RESTORE_SIZE_MB} MB`,
-			);
-		}
-
-		// Read backup file
-		const fileContent = await fs.readFile(backup.path, "utf-8");
-
-		// Delegate to restoreBackup which handles both encrypted and plaintext formats
-		return this.restoreBackup(fileContent);
+	/** Refuse stored-file restore before backup lookup or filesystem access. */
+	async restoreBackupFromFile(_id: string): Promise<BackupMetadata> {
+		throw new BackupRestoreUnavailableError();
 	}
 
-	/**
-	 * Restore from a backup (accepts both encrypted envelope or plaintext JSON)
-	 * For uploaded backups, this receives the base64-decoded backup data
-	 */
-	async restoreBackup(backupData: string): Promise<BackupMetadata> {
-		let parsed: unknown;
-
-		try {
-			// Try to parse JSON
-			parsed = JSON.parse(backupData);
-
-			// Strictly validate format with type checks to avoid misclassification
-			if (isEncryptedBackupEnvelope(parsed)) {
-				// It's an encrypted backup - decrypt it
-				const password = await this.getBackupPassword();
-				const decryptedBackupJson = await decryptBackupData(parsed, password);
-				// Re-parse after decryption
-				parsed = JSON.parse(decryptedBackupJson);
-			} else if (isPlaintextBackup(parsed)) {
-				// It's a plaintext backup (legacy format) - parsed already contains the backup data
-				// No need to parse again
-			} else {
-				throw new Error("Invalid backup format: unrecognized structure");
-			}
-		} catch (error) {
-			// Properly extract error message instead of stringifying which becomes "[object Object]"
-			const errorMessage = getErrorMessage(error);
-			throw new Error(`Failed to parse backup data: ${errorMessage}`);
-		}
-
-		// 1. Validate backup structure (parsed now contains the backup object)
-		const backup = parsed as BackupData;
-		validateBackup(backup);
-		const normalizedBackup = normalizeBackupForRestore(backup);
-		// A successful restore replaces credentials and scheduler state that are
-		// only reloaded on process start. Keep cleanup-sensitive mutations
-		// blocked until the required restart; failures release the guard.
-		return await withCleanupMaintenanceGuard(() => this.restoreValidatedBackup(normalizedBackup), {
-			holdAfterSuccess: true,
-		});
-	}
-
-	private async restoreValidatedBackup(backup: BackupData): Promise<BackupMetadata> {
-		// 2. Perform atomic restore with two-phase commit pattern to prevent partial restore
-		const secretsBackupPath = `${this.secretsPath}.restore-backup`;
-		let secretsBackedUp = false;
-
-		try {
-			// Compatibility must be checked before creating the secrets backup or
-			// writing replacement secrets. restoreDatabase repeats this check inside
-			// its transaction immediately before deletes.
-			await assertRestoreCompatibility(this.prisma, backup.data);
-
-			// Phase 1: Backup current secrets before making any changes
-			try {
-				const currentSecrets = await fs.readFile(this.secretsPath, "utf-8");
-				await fs.writeFile(secretsBackupPath, currentSecrets, { encoding: "utf-8", mode: 0o600 });
-				secretsBackedUp = true;
-			} catch (error) {
-				// If secrets file doesn't exist yet, that's okay - no need to back up
-				if (error && typeof error === "object" && "code" in error && error.code !== "ENOENT") {
-					throw new Error(`Failed to backup current secrets: ${error}`);
-				}
-			}
-
-			// Phase 2: Write new secrets
-			await writeSecrets(this.secretsPath, backup.secrets);
-
-			// Phase 3: Restore database (in a transaction for atomicity)
-			// If this fails, we need to restore the backed-up secrets
-			await restoreDatabase(this.prisma, backup.data);
-
-			// Phase 4: Success - clean up backup
-			if (secretsBackedUp) {
-				await fs.unlink(secretsBackupPath).catch((err) => {
-					log.debug(
-						{ err, path: secretsBackupPath },
-						"Failed to clean up secrets backup file (non-critical)",
-					);
-				});
-			}
-
-			// 3. Return metadata
-			return {
-				version: backup.version,
-				appVersion: backup.appVersion,
-				timestamp: backup.timestamp,
-				dataSize: JSON.stringify(backup).length,
-			};
-		} catch (error) {
-			// Rollback: Restore the backed-up secrets if database restore failed
-			if (secretsBackedUp) {
-				try {
-					const backedUpSecrets = await fs.readFile(secretsBackupPath, "utf-8");
-					await fs.writeFile(this.secretsPath, backedUpSecrets, { encoding: "utf-8", mode: 0o600 });
-					await fs.chmod(this.secretsPath, 0o600);
-					await fs.unlink(secretsBackupPath).catch((err) => {
-						log.debug(
-							{ err, path: secretsBackupPath },
-							"Failed to clean up secrets backup during rollback (non-critical)",
-						);
-					});
-				} catch (rollbackError) {
-					// Log rollback failure but throw original error
-					log.error(
-						{ err: rollbackError },
-						"CRITICAL: Failed to rollback secrets after restore failure",
-					);
-				}
-			}
-
-			// Re-throw the original error
-			throw error;
-		}
+	/** Refuse uploaded restore before parsing, decryption, filesystem, or database access. */
+	async restoreBackup(_backupData: string): Promise<BackupMetadata> {
+		throw new BackupRestoreUnavailableError();
 	}
 }

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -33,7 +33,7 @@ import { withCleanupMaintenanceGuard } from "../library-cleanup/cleanup-maintena
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { decryptBackupData, encryptBackupData } from "./backup-crypto.js";
-import { exportDatabase, restoreDatabase } from "./backup-database.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "./backup-database.js";
 import {
 	ensureBackupsDirectory,
 	generateBackupId,
@@ -433,9 +433,15 @@ export class BackupService {
 				{
 					backupType: type,
 					skippedTables: ["huntLog", "huntSearchHistory"],
-					preservedTables: ["trashSyncHistory", "templateDeploymentHistory", "trashBackup"],
+					preservedTables: [
+						"trashSyncHistory",
+						"templateDeploymentHistory",
+						"trashBackup",
+						"libraryCleanupApproval",
+						"libraryCleanupMediaServerScan",
+					],
 				},
-				"Backup excluded disposable operational history while preserving nonterminal TRaSH coordination evidence",
+				"Backup excluded disposable operational history while preserving nonterminal safety coordination evidence",
 			);
 		}
 
@@ -775,6 +781,11 @@ export class BackupService {
 		let secretsBackedUp = false;
 
 		try {
+			// Compatibility must be checked before creating the secrets backup or
+			// writing replacement secrets. restoreDatabase repeats this check inside
+			// its transaction immediately before deletes.
+			await assertRestoreCompatibility(this.prisma, backup.data);
+
 			// Phase 1: Backup current secrets before making any changes
 			try {
 				const currentSecrets = await fs.readFile(this.secretsPath, "utf-8");

--- a/apps/api/src/lib/backup/backup-validation.ts
+++ b/apps/api/src/lib/backup/backup-validation.ts
@@ -432,6 +432,26 @@ export function validateRecords(
 	}
 }
 
+const SINGLETON_PAYLOAD_FIELDS = [
+	"oidcProviders",
+	"systemSettings",
+	"backupSettings",
+	"vapidKeys",
+] as const;
+
+/** Reject payloads whose singleton selection would otherwise depend on array order. */
+export function validateSingletonCollections(
+	data: BackupData["data"] | Record<string, unknown>,
+): void {
+	const record = data as Record<string, unknown>;
+	for (const field of SINGLETON_PAYLOAD_FIELDS) {
+		const rows = record[field];
+		if (Array.isArray(rows) && rows.length > 1) {
+			throw new Error(`Invalid backup format: ${field} must contain at most one record`);
+		}
+	}
+}
+
 /**
  * Validate backup structure
  */
@@ -519,6 +539,8 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 			}
 		}
 	}
+
+	validateSingletonCollections(dataRecord);
 
 	if (b.version === BACKUP_VERSION || b.version === PRE_CONFIG_BACKUP_VERSION) {
 		validateCoordinationEvidence(dataRecord);

--- a/apps/api/src/lib/backup/backup-validation.ts
+++ b/apps/api/src/lib/backup/backup-validation.ts
@@ -8,10 +8,85 @@
 import type { BackupData } from "@arr/shared";
 import type { EncryptedBackupEnvelope } from "./backup-crypto.js";
 
-export const BACKUP_VERSION = "1.1";
+export const BACKUP_VERSION = "1.2";
 export const LEGACY_BACKUP_VERSION = "1.0";
+export const PRE_CONFIG_BACKUP_VERSION = "1.1";
 
-const SUPPORTED_BACKUP_VERSIONS = new Set([LEGACY_BACKUP_VERSION, BACKUP_VERSION]);
+const SUPPORTED_BACKUP_VERSIONS = new Set([
+	LEGACY_BACKUP_VERSION,
+	PRE_CONFIG_BACKUP_VERSION,
+	BACKUP_VERSION,
+]);
+
+/** Durable configuration collections added to the v1.2 backup contract. */
+export const DURABLE_CONFIG_PAYLOAD_FIELDS = [
+	"backupSettings",
+	"vapidKeys",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+	"namingDeployHistory",
+	"libraryCleanupApproval",
+	"libraryCleanupMediaServerScan",
+] as const;
+
+/** Every optional array emitted by exportDatabase and required by v1.2. */
+export const COMPLETE_V1_2_PAYLOAD_FIELDS = [
+	"oidcProviders",
+	"systemSettings",
+	"trashTemplates",
+	"trashSettings",
+	"trashSyncSchedules",
+	"templateQualityProfileMappings",
+	"instanceQualityProfileOverrides",
+	"standaloneCFDeployments",
+	"qualitySizeMappings",
+	"trashSyncHistory",
+	"templateDeploymentHistory",
+	"trashBackups",
+	"huntConfigs",
+	"huntLogs",
+	"huntSearchHistory",
+	...DURABLE_CONFIG_PAYLOAD_FIELDS,
+] as const;
+
+/** Explicit payload-to-Prisma mapping for relational legacy coverage checks. */
+export const LEGACY_RELATIONAL_CONFIG_DELEGATES = [
+	["trashTemplates", "trashTemplate"],
+	["trashSettings", "trashSettings"],
+	["trashSyncSchedules", "trashSyncSchedule"],
+	["templateQualityProfileMappings", "templateQualityProfileMapping"],
+	["instanceQualityProfileOverrides", "instanceQualityProfileOverride"],
+	["standaloneCFDeployments", "standaloneCFDeployment"],
+	["qualitySizeMappings", "qualitySizeMapping"],
+	["huntConfigs", "huntConfig"],
+	["notificationChannel", "notificationChannel"],
+	["notificationSubscription", "notificationSubscription"],
+	["notificationRule", "notificationRule"],
+	["notificationAggregationConfig", "notificationAggregationConfig"],
+	["autoTagRule", "autoTagRule"],
+	["labelSyncRule", "labelSyncRule"],
+	["queueCleanerConfig", "queueCleanerConfig"],
+	["libraryCleanupConfig", "libraryCleanupConfig"],
+	["libraryCleanupRule", "libraryCleanupRule"],
+	["libraryCleanupApproval", "libraryCleanupApproval"],
+	["libraryCleanupMediaServerScan", "libraryCleanupMediaServerScan"],
+	["namingConfig", "namingConfig"],
+	["userCustomFormat", "userCustomFormat"],
+] as const;
+
+/** Relational durable configuration that legacy files cannot safely replace. */
+export const LEGACY_RELATIONAL_CONFIG_FIELDS = LEGACY_RELATIONAL_CONFIG_DELEGATES.map(
+	([payloadField]) => payloadField,
+);
 
 type CoordinationRecord = Record<string, unknown>;
 
@@ -425,6 +500,8 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 		"huntConfigs",
 		"huntLogs",
 		"huntSearchHistory",
+		// Durable configuration (required in v1.2, optional for legacy files)
+		...DURABLE_CONFIG_PAYLOAD_FIELDS,
 	];
 
 	for (const field of optionalArrayFields) {
@@ -434,6 +511,16 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 	}
 
 	if (b.version === BACKUP_VERSION) {
+		for (const field of COMPLETE_V1_2_PAYLOAD_FIELDS) {
+			if (!Array.isArray(dataRecord[field])) {
+				throw new Error(
+					`Invalid backup format: ${field} is required for version ${BACKUP_VERSION}`,
+				);
+			}
+		}
+	}
+
+	if (b.version === BACKUP_VERSION || b.version === PRE_CONFIG_BACKUP_VERSION) {
 		validateCoordinationEvidence(dataRecord);
 	}
 

--- a/apps/api/src/lib/backup/backup-validation.ts
+++ b/apps/api/src/lib/backup/backup-validation.ts
@@ -31,6 +31,7 @@ export const DURABLE_CONFIG_PAYLOAD_FIELDS = [
 	"queueCleanerConfig",
 	"libraryCleanupConfig",
 	"libraryCleanupRule",
+	"librarySyncSettings",
 	"namingConfig",
 	"userCustomFormat",
 	"namingDeployHistory",

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -28,6 +28,24 @@ export class ConflictError extends Error {
 	}
 }
 
+/**
+ * Thrown when a backup does not carry the configuration or recovery coverage
+ * needed to safely replace the current installation.
+ * Maps to a bounded HTTP 409 response without exposing backup contents.
+ */
+export class BackupCompatibilityError extends Error {
+	readonly statusCode = 409;
+	readonly code = "BACKUP_COMPATIBILITY_CONFLICT";
+
+	constructor(cause?: unknown) {
+		super(
+			"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		);
+		if (cause !== undefined) this.cause = cause;
+		this.name = "BackupCompatibilityError";
+	}
+}
+
 /** Thrown for application-level validation failures. Maps to HTTP 400. */
 export class AppValidationError extends Error {
 	readonly statusCode = 400;

--- a/apps/api/src/lib/hunting/__tests__/scheduler-restore-barrier.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/scheduler-restore-barrier.test.ts
@@ -1,0 +1,193 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { withCleanupMaintenanceGuard } from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { MAX_HUNT_DURATION_MS } from "../constants.js";
+
+const mocks = vi.hoisted(() => ({ executeHuntWithSdk: vi.fn() }));
+
+vi.mock("../hunt-executor.js", () => ({
+	executeHuntWithSdk: mocks.executeHuntWithSdk,
+}));
+
+import { getHuntingScheduler } from "../scheduler.js";
+
+describe("hunting background restore barrier", () => {
+	it("holds its lease until the uncancelled hunt executor settles", async () => {
+		mocks.executeHuntWithSdk.mockReset();
+		let releaseHunt!: (result: unknown) => void;
+		mocks.executeHuntWithSdk.mockReturnValue(
+			new Promise((resolve) => {
+				releaseHunt = resolve;
+			}),
+		);
+		const instance = { id: "hunt-instance", label: "Radarr", service: "RADARR" };
+		const app = {
+			prisma: {
+				huntConfig: {
+					findUnique: vi.fn().mockResolvedValue({ id: "config-1", instance }),
+					update: vi.fn().mockResolvedValue({}),
+				},
+				huntLog: {
+					findMany: vi.fn().mockResolvedValue([]),
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+					create: vi.fn().mockResolvedValue({ id: "log-1" }),
+					update: vi.fn().mockResolvedValue({}),
+				},
+			},
+			notificationService: { notify: vi.fn().mockResolvedValue(undefined) },
+		} as unknown as FastifyInstance;
+		const scheduler = getHuntingScheduler();
+		scheduler.initialize(app);
+		await Promise.resolve();
+		await Promise.resolve();
+		const run = (
+			scheduler as unknown as {
+				runHunt(instanceId: string, type: "missing" | "upgrade", manual: boolean): Promise<void>;
+			}
+		).runHunt(instance.id, "missing", true);
+		await vi.waitFor(() => expect(mocks.executeHuntWithSdk).toHaveBeenCalledTimes(1));
+
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+
+		releaseHunt({
+			itemsSearched: 0,
+			itemsGrabbed: 0,
+			searchedItems: [],
+			grabbedItems: [],
+			message: "No work",
+			status: "skipped",
+			apiCallsMade: 0,
+		});
+		await run;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("rejects a retrigger after timeout until the uncancelled executor settles", async () => {
+		vi.useFakeTimers();
+		try {
+			mocks.executeHuntWithSdk.mockReset();
+			let releaseHunt!: (result: unknown) => void;
+			mocks.executeHuntWithSdk.mockReturnValue(
+				new Promise((resolve) => {
+					releaseHunt = resolve;
+				}),
+			);
+			const instance = { id: "timed-hunt", label: "Radarr", service: "RADARR" };
+			const app = {
+				prisma: {
+					huntConfig: {
+						findUnique: vi.fn().mockResolvedValue({ id: "config-2", instance }),
+						update: vi.fn().mockResolvedValue({}),
+					},
+					huntLog: {
+						findMany: vi.fn().mockResolvedValue([]),
+						updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+						create: vi.fn().mockResolvedValue({ id: "log-2" }),
+						update: vi.fn().mockResolvedValue({}),
+					},
+				},
+				notificationService: { notify: vi.fn().mockResolvedValue(undefined) },
+			} as unknown as FastifyInstance;
+			const scheduler = getHuntingScheduler();
+			scheduler.initialize(app);
+			await vi.advanceTimersByTimeAsync(0);
+			const run = (
+				scheduler as unknown as {
+					runHunt(instanceId: string, type: "missing" | "upgrade", manual: boolean): Promise<void>;
+				}
+			).runHunt(instance.id, "missing", true);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(mocks.executeHuntWithSdk).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(MAX_HUNT_DURATION_MS + 1);
+			await run;
+
+			expect(scheduler.triggerManualHunt(instance.id, "missing")).toMatchObject({
+				queued: false,
+				message: expect.stringContaining("in progress"),
+			});
+			expect(mocks.executeHuntWithSdk).toHaveBeenCalledTimes(1);
+
+			releaseHunt({
+				itemsSearched: 0,
+				itemsGrabbed: 0,
+				searchedItems: [],
+				grabbedItems: [],
+				message: "late completion",
+				status: "skipped",
+				apiCallsMade: 0,
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(
+				(
+					scheduler as unknown as {
+						activeHuntExecutions: Map<string, Promise<unknown>>;
+					}
+				).activeHuntExecutions.has(instance.id),
+			).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("reserves the instance before an asynchronous config lookup", async () => {
+		mocks.executeHuntWithSdk.mockReset();
+		mocks.executeHuntWithSdk.mockResolvedValue({
+			itemsSearched: 0,
+			itemsGrabbed: 0,
+			searchedItems: [],
+			grabbedItems: [],
+			message: "No work",
+			status: "skipped",
+			apiCallsMade: 0,
+		});
+		let releaseConfig!: (config: unknown) => void;
+		const findUnique = vi.fn(
+			() =>
+				new Promise((resolve) => {
+					releaseConfig = resolve;
+				}),
+		);
+		const instance = { id: "lookup-race", label: "Radarr", service: "RADARR" };
+		const app = {
+			prisma: {
+				huntConfig: { findUnique, update: vi.fn().mockResolvedValue({}) },
+				huntLog: {
+					findMany: vi.fn().mockResolvedValue([]),
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+					create: vi.fn().mockResolvedValue({ id: "log-race" }),
+					update: vi.fn().mockResolvedValue({}),
+				},
+			},
+			notificationService: { notify: vi.fn().mockResolvedValue(undefined) },
+		} as unknown as FastifyInstance;
+		const scheduler = getHuntingScheduler();
+		scheduler.initialize(app);
+		await Promise.resolve();
+		await Promise.resolve();
+		const scheduled = (
+			scheduler as unknown as {
+				runHunt(instanceId: string, type: "missing" | "upgrade", manual: boolean): Promise<void>;
+			}
+		).runHunt(instance.id, "missing", false);
+		await vi.waitFor(() => expect(findUnique).toHaveBeenCalledTimes(1));
+
+		expect(scheduler.triggerManualHunt(instance.id, "missing")).toMatchObject({
+			queued: false,
+			message: expect.stringContaining("in progress"),
+		});
+		expect(mocks.executeHuntWithSdk).not.toHaveBeenCalled();
+
+		releaseConfig({ id: "config-race", instance });
+		await scheduled;
+		expect(mocks.executeHuntWithSdk).toHaveBeenCalledTimes(1);
+		expect(
+			(
+				scheduler as unknown as {
+					activeHuntExecutions: Set<string>;
+				}
+			).activeHuntExecutions.has(instance.id),
+		).toBe(false);
+	});
+});

--- a/apps/api/src/lib/hunting/scheduler.ts
+++ b/apps/api/src/lib/hunting/scheduler.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from "fastify";
+import { withIndependentCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import { loggers } from "../logger.js";
 import {
 	passthroughTickWrapper,
@@ -41,6 +42,9 @@ class HuntingScheduler {
 	// up and multiply paginator memory + API-cap pressure. See issue #457.
 	private inFlightTick: Promise<void> | null = null;
 	private skippedTicksWhileBusy = 0;
+	// withTimeout does not cancel ARR commands. Keep per-instance ownership
+	// until the raw executor settles so a later tick cannot duplicate it.
+	private activeHuntExecutions = new Set<string>();
 
 	/**
 	 * Wire an optional tick wrapper (used by the plugin to route ticks
@@ -60,7 +64,7 @@ class HuntingScheduler {
 		this.app = app;
 
 		// Clean up any stuck hunts from previous runs
-		this.cleanupStuckHunts().catch((error) => {
+		withIndependentCleanupOperationGuard(() => this.cleanupStuckHunts()).catch((error) => {
 			log.error({ err: error }, "Failed to cleanup stuck hunts on init");
 		});
 	}
@@ -187,6 +191,9 @@ class HuntingScheduler {
 		instanceId: string,
 		type: "missing" | "upgrade",
 	): { queued: boolean; message: string } {
+		if (this.activeHuntExecutions.has(instanceId)) {
+			return { queued: false, message: "Hunt already in progress for this instance" };
+		}
 		// Check cooldowns before running
 		const cooldownCheck = this.checkCooldown(instanceId, type, true);
 		if (!cooldownCheck.ok) {
@@ -372,204 +379,232 @@ class HuntingScheduler {
 		type: "missing" | "upgrade",
 		isManual = false,
 	): Promise<void> {
-		if (!this.app) return;
-
-		// For scheduled hunts, enforce cooldown check here
-		// For manual hunts, skip this check since triggerManualHunt already checked
-		// and called updateHuntTimes (which would cause this check to fail)
-		if (!isManual) {
-			const cooldownCheck = this.checkCooldown(instanceId, type, false);
-			if (!cooldownCheck.ok) {
-				return;
+		if (this.activeHuntExecutions.has(instanceId)) return;
+		this.activeHuntExecutions.add(instanceId);
+		let executionStarted = false;
+		let executionSettled = false;
+		let outerSettled = false;
+		const releaseOwnershipIfSettled = () => {
+			if (outerSettled && (!executionStarted || executionSettled)) {
+				this.activeHuntExecutions.delete(instanceId);
 			}
-		}
-
-		const startTime = Date.now();
-
-		// Get config and instance
-		const config = await this.app.prisma.huntConfig.findUnique({
-			where: { instanceId },
-			include: { instance: true },
-		});
-
-		if (!config) {
-			log.error({ instanceId }, "No config found for instance");
-			return;
-		}
-
-		// Create log entry with "running" status
-		const huntLogEntry = await this.app.prisma.huntLog.create({
-			data: {
-				instanceId,
-				huntType: type,
-				status: "running",
-				itemsSearched: 0,
-				itemsFound: 0,
-			},
-		});
-
-		// Update hunt times immediately to prevent race conditions
-		this.updateHuntTimes(instanceId, type);
-
+		};
 		try {
-			// Execute the actual hunt using hunt-executor with timeout protection
-			const result: HuntResult = await withTimeout(
-				executeHuntWithSdk(this.app, config.instance, config, type),
-				MAX_HUNT_DURATION_MS,
-				`Hunt timed out after ${MAX_HUNT_DURATION_MS / 1000} seconds`,
-			);
+			return await withIndependentCleanupOperationGuard(async () => {
+				if (!this.app) return;
 
-			// Update log with results
-			const durationMs = Date.now() - startTime;
-			await this.app.prisma.huntLog.update({
-				where: { id: huntLogEntry.id },
-				data: {
-					itemsSearched: result.itemsSearched,
-					itemsFound: result.itemsGrabbed,
-					// searchedItems = items we triggered searches for
-					searchedItems:
-						result.searchedItems.length > 0 ? JSON.stringify(result.searchedItems) : null,
-					// foundItems = items that were actually grabbed (reusing existing field)
-					foundItems: result.grabbedItems.length > 0 ? JSON.stringify(result.grabbedItems) : null,
-					status: result.status,
-					message: result.message,
-					durationMs,
-					completedAt: new Date(),
-				},
-			});
-
-			log.info(
-				{
-					instanceLabel: config.instance.label,
-					huntType: type,
-					status: result.status,
-					itemsSearched: result.itemsSearched,
-					itemsGrabbed: result.itemsGrabbed,
-					apiCalls: result.apiCallsMade,
-					durationMs,
-				},
-				"Hunt completed",
-			);
-
-			// Fire-and-forget notification for hunt results
-			const huntMeta = {
-				instance: config.instance.label,
-				service: config.instance.service,
-				huntType: type,
-				itemsSearched: result.itemsSearched,
-				itemsGrabbed: result.itemsGrabbed,
-				apiCalls: result.apiCallsMade,
-				durationMs,
-				grabbedItems: result.grabbedItems.slice(0, 5).map((g) => g.title),
-			};
-			if (result.itemsGrabbed > 0) {
-				this.app.notificationService
-					?.notify({
-						eventType: "HUNT_CONTENT_FOUND",
-						title: `Hunt found ${result.itemsGrabbed} item(s) on ${config.instance.label}`,
-						body: result.message,
-						url: "/hunting",
-						metadata: huntMeta,
-					})
-					.catch((err) => {
-						log.warn(
-							{ err, instanceLabel: config.instance.label },
-							"Hunt notification dispatch failed",
-						);
-					});
-			} else if (result.status === "completed") {
-				this.app.notificationService
-					?.notify({
-						eventType: "HUNT_COMPLETED",
-						title: `Hunt completed on ${config.instance.label}`,
-						body: result.message,
-						url: "/hunting",
-						metadata: huntMeta,
-					})
-					.catch((err) => {
-						log.warn(
-							{ err, instanceLabel: config.instance.label },
-							"Hunt notification dispatch failed",
-						);
-					});
-			} else if (result.status === "error") {
-				// A returned error result (e.g., queue-check connectivity failure)
-				// does not throw, so the outer catch below never fires for it.
-				// Surface it explicitly so an offline instance doesn't silently
-				// stop hunting. (Issue #438 follow-up.)
-				this.app.notificationService
-					?.notify({
-						eventType: "HUNT_FAILED",
-						title: `Hunt failed on ${config.instance.label}`,
-						body: result.message,
-						url: "/hunting",
-						metadata: huntMeta,
-					})
-					.catch((err) => {
-						log.warn(
-							{ err, instanceLabel: config.instance.label },
-							"Hunt failure notification dispatch failed",
-						);
-					});
-			}
-
-			// Update config timestamps and API call count (only if we actually made API calls)
-			if (result.status !== "skipped" && result.apiCallsMade > 0) {
-				const updateData: Record<string, unknown> = {
-					apiCallsThisHour: { increment: result.apiCallsMade },
-				};
-
-				if (type === "missing") {
-					updateData.lastMissingHunt = new Date();
-				} else {
-					updateData.lastUpgradeHunt = new Date();
+				// For scheduled hunts, enforce cooldown check here
+				// For manual hunts, skip this check since triggerManualHunt already checked
+				// and called updateHuntTimes (which would cause this check to fail)
+				if (!isManual) {
+					const cooldownCheck = this.checkCooldown(instanceId, type, false);
+					if (!cooldownCheck.ok) {
+						return;
+					}
 				}
 
-				if (!config.apiCallsResetAt) {
-					updateData.apiCallsResetAt = new Date(Date.now() + 60 * 60 * 1000);
-				}
+				const startTime = Date.now();
 
-				await this.app.prisma.huntConfig.update({
-					where: { id: config.id },
-					data: updateData,
+				// Get config and instance
+				const config = await this.app.prisma.huntConfig.findUnique({
+					where: { instanceId },
+					include: { instance: true },
 				});
-			}
-		} catch (error) {
-			const durationMs = Date.now() - startTime;
-			const message = getErrorMessage(error, "Unknown error");
 
-			await this.app.prisma.huntLog.update({
-				where: { id: huntLogEntry.id },
-				data: {
-					status: "error",
-					message,
-					durationMs,
-					completedAt: new Date(),
-				},
-			});
+				if (!config) {
+					log.error({ instanceId }, "No config found for instance");
+					return;
+				}
 
-			log.error({ err: error, instanceLabel: config.instance.label }, "Hunt error");
+				// Create log entry with "running" status
+				const huntLogEntry = await this.app.prisma.huntLog.create({
+					data: {
+						instanceId,
+						huntType: type,
+						status: "running",
+						itemsSearched: 0,
+						itemsFound: 0,
+					},
+				});
 
-			// Fire-and-forget notification for hunt failure
-			this.app.notificationService
-				?.notify({
-					eventType: "HUNT_FAILED",
-					title: `Hunt failed on ${config.instance.label}`,
-					body: message,
-					url: "/hunting",
-					metadata: {
+				// Update hunt times immediately to prevent race conditions
+				this.updateHuntTimes(instanceId, type);
+
+				try {
+					// Execute the actual hunt using hunt-executor with timeout protection
+					const execution = withIndependentCleanupOperationGuard(() =>
+						executeHuntWithSdk(this.app!, config.instance, config, type),
+					);
+					executionStarted = true;
+					void execution
+						.finally(() => {
+							executionSettled = true;
+							releaseOwnershipIfSettled();
+						})
+						.catch(() => undefined);
+					const result: HuntResult = await withTimeout(
+						execution,
+						MAX_HUNT_DURATION_MS,
+						`Hunt timed out after ${MAX_HUNT_DURATION_MS / 1000} seconds`,
+					);
+
+					// Update log with results
+					const durationMs = Date.now() - startTime;
+					await this.app.prisma.huntLog.update({
+						where: { id: huntLogEntry.id },
+						data: {
+							itemsSearched: result.itemsSearched,
+							itemsFound: result.itemsGrabbed,
+							// searchedItems = items we triggered searches for
+							searchedItems:
+								result.searchedItems.length > 0 ? JSON.stringify(result.searchedItems) : null,
+							// foundItems = items that were actually grabbed (reusing existing field)
+							foundItems:
+								result.grabbedItems.length > 0 ? JSON.stringify(result.grabbedItems) : null,
+							status: result.status,
+							message: result.message,
+							durationMs,
+							completedAt: new Date(),
+						},
+					});
+
+					log.info(
+						{
+							instanceLabel: config.instance.label,
+							huntType: type,
+							status: result.status,
+							itemsSearched: result.itemsSearched,
+							itemsGrabbed: result.itemsGrabbed,
+							apiCalls: result.apiCallsMade,
+							durationMs,
+						},
+						"Hunt completed",
+					);
+
+					// Fire-and-forget notification for hunt results
+					const huntMeta = {
 						instance: config.instance.label,
 						service: config.instance.service,
 						huntType: type,
+						itemsSearched: result.itemsSearched,
+						itemsGrabbed: result.itemsGrabbed,
+						apiCalls: result.apiCallsMade,
 						durationMs,
-					},
-				})
-				.catch((err) => {
-					log.warn(
-						{ err, instanceLabel: config.instance.label },
-						"Hunt failure notification dispatch failed",
-					);
-				});
+						grabbedItems: result.grabbedItems.slice(0, 5).map((g) => g.title),
+					};
+					if (result.itemsGrabbed > 0) {
+						await this.app.notificationService
+							?.notify({
+								eventType: "HUNT_CONTENT_FOUND",
+								title: `Hunt found ${result.itemsGrabbed} item(s) on ${config.instance.label}`,
+								body: result.message,
+								url: "/hunting",
+								metadata: huntMeta,
+							})
+							.catch((err) => {
+								log.warn(
+									{ err, instanceLabel: config.instance.label },
+									"Hunt notification dispatch failed",
+								);
+							});
+					} else if (result.status === "completed") {
+						await this.app.notificationService
+							?.notify({
+								eventType: "HUNT_COMPLETED",
+								title: `Hunt completed on ${config.instance.label}`,
+								body: result.message,
+								url: "/hunting",
+								metadata: huntMeta,
+							})
+							.catch((err) => {
+								log.warn(
+									{ err, instanceLabel: config.instance.label },
+									"Hunt notification dispatch failed",
+								);
+							});
+					} else if (result.status === "error") {
+						// A returned error result (e.g., queue-check connectivity failure)
+						// does not throw, so the outer catch below never fires for it.
+						// Surface it explicitly so an offline instance doesn't silently
+						// stop hunting. (Issue #438 follow-up.)
+						await this.app.notificationService
+							?.notify({
+								eventType: "HUNT_FAILED",
+								title: `Hunt failed on ${config.instance.label}`,
+								body: result.message,
+								url: "/hunting",
+								metadata: huntMeta,
+							})
+							.catch((err) => {
+								log.warn(
+									{ err, instanceLabel: config.instance.label },
+									"Hunt failure notification dispatch failed",
+								);
+							});
+					}
+
+					// Update config timestamps and API call count (only if we actually made API calls)
+					if (result.status !== "skipped" && result.apiCallsMade > 0) {
+						const updateData: Record<string, unknown> = {
+							apiCallsThisHour: { increment: result.apiCallsMade },
+						};
+
+						if (type === "missing") {
+							updateData.lastMissingHunt = new Date();
+						} else {
+							updateData.lastUpgradeHunt = new Date();
+						}
+
+						if (!config.apiCallsResetAt) {
+							updateData.apiCallsResetAt = new Date(Date.now() + 60 * 60 * 1000);
+						}
+
+						await this.app.prisma.huntConfig.update({
+							where: { id: config.id },
+							data: updateData,
+						});
+					}
+				} catch (error) {
+					const durationMs = Date.now() - startTime;
+					const message = getErrorMessage(error, "Unknown error");
+
+					await this.app.prisma.huntLog.update({
+						where: { id: huntLogEntry.id },
+						data: {
+							status: "error",
+							message,
+							durationMs,
+							completedAt: new Date(),
+						},
+					});
+
+					log.error({ err: error, instanceLabel: config.instance.label }, "Hunt error");
+
+					// Fire-and-forget notification for hunt failure
+					await this.app.notificationService
+						?.notify({
+							eventType: "HUNT_FAILED",
+							title: `Hunt failed on ${config.instance.label}`,
+							body: message,
+							url: "/hunting",
+							metadata: {
+								instance: config.instance.label,
+								service: config.instance.service,
+								huntType: type,
+								durationMs,
+							},
+						})
+						.catch((err) => {
+							log.warn(
+								{ err, instanceLabel: config.instance.label },
+								"Hunt failure notification dispatch failed",
+							);
+						});
+				}
+			});
+		} finally {
+			outerSettled = true;
+			releaseOwnershipIfSettled();
 		}
 	}
 }

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
@@ -97,4 +97,35 @@ describe.sequential("cleanup maintenance gate", () => {
 
 		await expect(withCleanupOperationGuard(async () => "available")).resolves.toBe("available");
 	});
+
+	it("upgrades a sole shared lease to maintenance without admitting another operation", async () => {
+		let releaseMaintenance!: () => void;
+		let upgradedOperation!: Promise<void>;
+		const maintenanceStarted = new Promise<void>((resolve) => {
+			upgradedOperation = withCleanupOperationGuard(() =>
+				withCleanupMaintenanceGuard(async () => {
+					resolve();
+					await new Promise<void>((release) => {
+						releaseMaintenance = release;
+					});
+				}),
+			);
+		});
+
+		await maintenanceStarted;
+		await expect(withCleanupOperationGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+		releaseMaintenance();
+		await upgradedOperation;
+	});
+
+	it("rejects a shared-to-exclusive upgrade while another operation is active", async () => {
+		const releaseOther = acquireCleanupOperationGuard();
+
+		await expect(
+			withCleanupOperationGuard(() => withExclusiveCleanupOperationGuard(async () => undefined)),
+		).rejects.toBeInstanceOf(CleanupMaintenanceConflictError);
+		releaseOther();
+	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
 	acquireCleanupOperationGuard,
 	CleanupMaintenanceConflictError,
+	withIndependentCleanupOperationGuard,
 	withCleanupMaintenanceGuard,
 	withCleanupOperationGuard,
 	withExclusiveCleanupOperationGuard,
 } from "../cleanup-maintenance-gate.js";
+import { withTimeout } from "../../utils/delay.js";
 
 describe.sequential("cleanup maintenance gate", () => {
 	it("rejects restore while a cleanup-sensitive operation is active", async () => {
@@ -59,6 +61,42 @@ describe.sequential("cleanup maintenance gate", () => {
 
 		release();
 		release();
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("keeps an independent child lease after its parent operation returns", async () => {
+		let releaseChild!: () => void;
+		const childBlocked = new Promise<void>((resolve) => {
+			releaseChild = resolve;
+		});
+		let child!: Promise<void>;
+		await withCleanupOperationGuard(async () => {
+			child = withIndependentCleanupOperationGuard(() => childBlocked);
+		});
+
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		releaseChild();
+		await child;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("retains an independent lease when a non-cancelling timeout loses the race", async () => {
+		let releaseUnderlying!: () => void;
+		const underlying = new Promise<void>((resolve) => {
+			releaseUnderlying = resolve;
+		});
+		const leasedUnderlying = withIndependentCleanupOperationGuard(() => underlying);
+
+		await expect(withTimeout(leasedUnderlying, 1, "timed out")).rejects.toThrow("timed out");
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		releaseUnderlying();
+		await leasedUnderlying;
 		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
 	});
 

--- a/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
@@ -25,11 +25,13 @@ export class CleanupMaintenanceConflictError extends Error {
 }
 
 /** Acquire a shared operation guard that remains active until the returned release is called. */
-function acquireCleanupOperationGuardState(): {
+function acquireCleanupOperationGuardState(options: { allowNestedExclusive?: boolean } = {}): {
 	context: OperationGuardContext;
 	release: () => void;
 } {
-	if (maintenanceActive || exclusiveCleanupOperationActive) {
+	const nestedExclusiveOwner =
+		options.allowNestedExclusive === true && operationGuardContext.getStore()?.active === true;
+	if (maintenanceActive || (exclusiveCleanupOperationActive && !nestedExclusiveOwner)) {
 		throw new CleanupMaintenanceConflictError(
 			"Cleanup-sensitive changes are unavailable during database maintenance or ARR service deletion",
 		);
@@ -80,6 +82,23 @@ export async function withCleanupOperationGuard<T>(operation: () => Promise<T>):
 		return await operation();
 	}
 	const { context, release } = acquireCleanupOperationGuardState();
+	try {
+		return await operationGuardContext.run(context, operation);
+	} finally {
+		release();
+	}
+}
+
+/**
+ * Give a detached producer its own shared lease, even when it was launched
+ * from a request or scheduler callback that already owns one. The independent
+ * context prevents the parent from releasing the producer's lease when the
+ * parent returns before the producer settles.
+ */
+export async function withIndependentCleanupOperationGuard<T>(
+	operation: () => Promise<T>,
+): Promise<T> {
+	const { context, release } = acquireCleanupOperationGuardState({ allowNestedExclusive: true });
 	try {
 		return await operationGuardContext.run(context, operation);
 	} finally {

--- a/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 /**
  * In-process reader/writer gate around cleanup-sensitive mutations.
  *
@@ -10,6 +12,8 @@
 let activeCleanupOperations = 0;
 let maintenanceActive = false;
 let exclusiveCleanupOperationActive = false;
+type OperationGuardContext = { active: boolean };
+const operationGuardContext = new AsyncLocalStorage<OperationGuardContext>();
 
 export class CleanupMaintenanceConflictError extends Error {
 	readonly statusCode = 409;
@@ -21,7 +25,10 @@ export class CleanupMaintenanceConflictError extends Error {
 }
 
 /** Acquire a shared operation guard that remains active until the returned release is called. */
-export function acquireCleanupOperationGuard(): () => void {
+function acquireCleanupOperationGuardState(): {
+	context: OperationGuardContext;
+	release: () => void;
+} {
 	if (maintenanceActive || exclusiveCleanupOperationActive) {
 		throw new CleanupMaintenanceConflictError(
 			"Cleanup-sensitive changes are unavailable during database maintenance or ARR service deletion",
@@ -29,11 +36,18 @@ export function acquireCleanupOperationGuard(): () => void {
 	}
 	activeCleanupOperations += 1;
 	let released = false;
-	return () => {
+	const context = { active: true };
+	const release = () => {
 		if (released) return;
 		released = true;
+		context.active = false;
 		activeCleanupOperations -= 1;
 	};
+	return { context, release };
+}
+
+export function acquireCleanupOperationGuard(): () => void {
+	return acquireCleanupOperationGuardState().release;
 }
 
 /**
@@ -43,7 +57,12 @@ export function acquireCleanupOperationGuard(): () => void {
 export async function withExclusiveCleanupOperationGuard<T>(
 	operation: () => Promise<T>,
 ): Promise<T> {
-	if (maintenanceActive || exclusiveCleanupOperationActive || activeCleanupOperations > 0) {
+	const ownedSharedLease = operationGuardContext.getStore()?.active === true ? 1 : 0;
+	if (
+		maintenanceActive ||
+		exclusiveCleanupOperationActive ||
+		activeCleanupOperations > ownedSharedLease
+	) {
 		throw new CleanupMaintenanceConflictError(
 			"This service cannot be deleted while database maintenance, TRaSH, or library cleanup work is active",
 		);
@@ -57,9 +76,12 @@ export async function withExclusiveCleanupOperationGuard<T>(
 }
 
 export async function withCleanupOperationGuard<T>(operation: () => Promise<T>): Promise<T> {
-	const release = acquireCleanupOperationGuard();
-	try {
+	if (operationGuardContext.getStore()?.active === true) {
 		return await operation();
+	}
+	const { context, release } = acquireCleanupOperationGuardState();
+	try {
+		return await operationGuardContext.run(context, operation);
 	} finally {
 		release();
 	}
@@ -69,7 +91,12 @@ export async function withCleanupMaintenanceGuard<T>(
 	maintenance: () => Promise<T>,
 	options: { holdAfterSuccess?: boolean } = {},
 ): Promise<T> {
-	if (maintenanceActive || exclusiveCleanupOperationActive || activeCleanupOperations > 0) {
+	const ownedSharedLease = operationGuardContext.getStore()?.active === true ? 1 : 0;
+	if (
+		maintenanceActive ||
+		exclusiveCleanupOperationActive ||
+		activeCleanupOperations > ownedSharedLease
+	) {
 		throw new CleanupMaintenanceConflictError();
 	}
 	maintenanceActive = true;

--- a/apps/api/src/lib/library-sync/__tests__/infohash-backfill-by-inode.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/infohash-backfill-by-inode.test.ts
@@ -30,6 +30,7 @@
 import type { Dirent } from "node:fs";
 import type { QuiTorrent } from "@arr/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withCleanupMaintenanceGuard } from "../../library-cleanup/cleanup-maintenance-gate.js";
 
 // Mock fs/promises BEFORE importing the module under test. The mocks
 // return whatever we've staged via `stagedStats` / `stagedDirs`.
@@ -425,6 +426,42 @@ describe("buildFileIdIndex — folder-wrapped torrents (THE BUG FIX)", () => {
 });
 
 describe("buildFileIdIndex — caching", () => {
+	it("holds an independent restore barrier until best-effort persistence settles", async () => {
+		stageFile("/data/torrents/Foo.mkv", 100, 42, 2);
+		const client = makeFakeClient([
+			makeQuiTorrent({ hash: "h1", name: "Foo.mkv", savePath: "/data/torrents" }),
+		]);
+		let releasePersist!: () => void;
+		const upsert = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					releasePersist = resolve;
+				}),
+		);
+		const prisma = { inodeIndexCache: { upsert } };
+
+		let completed = false;
+		const build = buildFileIdIndex(client as never, QUI_INSTANCE, undefined, prisma as never).then(
+			(result) => {
+				completed = true;
+				return result;
+			},
+		);
+		await vi.waitFor(() => expect(upsert).toHaveBeenCalledTimes(1));
+		expect(completed).toBe(false);
+		const maintenanceWork = vi.fn(async () => undefined);
+		await expect(withCleanupMaintenanceGuard(maintenanceWork)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(maintenanceWork).not.toHaveBeenCalled();
+
+		releasePersist();
+		await expect(build).resolves.toMatchObject({ statted: 1 });
+		expect(completed).toBe(true);
+		await expect(withCleanupMaintenanceGuard(maintenanceWork)).resolves.toBeUndefined();
+		expect(maintenanceWork).toHaveBeenCalledTimes(1);
+	});
+
 	it("returns cached index on second call within TTL", async () => {
 		stageFile("/data/torrents/Foo.mkv", 100, 42, 2);
 		const client = makeFakeClient([

--- a/apps/api/src/lib/library-sync/__tests__/sync-scheduler-restore-barrier.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-scheduler-restore-barrier.test.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { withCleanupMaintenanceGuard } from "../../library-cleanup/cleanup-maintenance-gate.js";
+
+const mocks = vi.hoisted(() => ({ syncInstance: vi.fn() }));
+
+vi.mock("../sync-executor.js", () => ({
+	syncInstance: mocks.syncInstance,
+}));
+
+import { LibrarySyncScheduler } from "../sync-scheduler.js";
+
+describe("library sync background restore barrier", () => {
+	it("holds an independent lease until a detached sync settles", async () => {
+		let releaseSync!: (result: unknown) => void;
+		mocks.syncInstance.mockReturnValue(
+			new Promise((resolve) => {
+				releaseSync = resolve;
+			}),
+		);
+		const app = {
+			log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+			prisma: {},
+			arrClientFactory: {},
+			encryptor: {},
+			notificationService: { notify: vi.fn().mockResolvedValue(undefined) },
+		} as unknown as FastifyInstance;
+		const scheduler = new LibrarySyncScheduler();
+		scheduler.initialize(app);
+		const instance = {
+			id: "sync-instance",
+			userId: "user-1",
+			label: "Radarr",
+			service: "RADARR",
+			baseUrl: "https://radarr.invalid",
+			encryptedApiKey: "encrypted",
+			encryptionIv: "iv",
+		};
+		const run = (
+			scheduler as unknown as {
+				runSync(value: typeof instance): Promise<unknown>;
+			}
+		).runSync(instance);
+		await vi.waitFor(() => expect(mocks.syncInstance).toHaveBeenCalledTimes(1));
+
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+
+		releaseSync({
+			instanceId: instance.id,
+			instanceName: instance.label,
+			success: true,
+			itemsProcessed: 0,
+			itemsAdded: 0,
+			itemsUpdated: 0,
+			itemsRemoved: 0,
+			newDownloads: [],
+			durationMs: 1,
+		});
+		await run;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+});

--- a/apps/api/src/lib/library-sync/infohash-backfill-by-inode.ts
+++ b/apps/api/src/lib/library-sync/infohash-backfill-by-inode.ts
@@ -63,6 +63,7 @@ import { readdir, stat } from "node:fs/promises";
 import { gunzipSync, gzipSync } from "node:zlib";
 import type { QuiTorrent } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
+import { withIndependentCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import type { PrismaClient, ServiceInstance } from "../prisma.js";
 import type { QuiClient } from "../qui/client-factory.js";
 import { getErrorMessage } from "../utils/error-message.js";
@@ -425,17 +426,23 @@ export async function buildFileIdIndex(
 	const pending = INDEX_PENDING.get(instance.id);
 	if (pending) return pending;
 
-	const buildPromise = (async (): Promise<FileIdIndex> => {
+	const buildAndPublish = async (): Promise<FileIdIndex> => {
 		const built = await doBuildFileIdIndex(client, instance, log);
 		INDEX_CACHE.set(instance.id, { index: built, builtAt: Date.now() });
-		// Persist asynchronously — caller doesn't need to wait on the
-		// DB write, and a failed persist is non-fatal (next rebuild
-		// will retry). Floating Promise is intentional.
+		// Persist before publishing completion so database maintenance cannot
+		// replace topology while a stale cache write remains in flight.
+		// Persistence remains best-effort inside saveFileIdIndexToDb.
 		if (prisma) {
-			void saveFileIdIndexToDb(prisma, instance.id, built, log);
+			await saveFileIdIndexToDb(prisma, instance.id, built, log);
 		}
 		return built;
-	})();
+	};
+	// A panel route stops awaiting this single-flight producer after its
+	// response timeout. When persistence is enabled, give the producer its own
+	// lease so restore remains blocked until the durable publication settles.
+	const buildPromise = prisma
+		? withIndependentCleanupOperationGuard(buildAndPublish)
+		: buildAndPublish();
 	INDEX_PENDING.set(instance.id, buildPromise);
 	try {
 		return await buildPromise;

--- a/apps/api/src/lib/library-sync/sync-scheduler.ts
+++ b/apps/api/src/lib/library-sync/sync-scheduler.ts
@@ -7,6 +7,7 @@
 
 import { LIBRARY_SERVICES_UPPER } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
+import { withIndependentCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import { createLogger } from "../logger.js";
 import type { NotificationService } from "../notifications/notification-service.js";
 import {
@@ -368,47 +369,52 @@ export class LibrarySyncScheduler {
 		encryptedApiKey: string;
 		encryptionIv: string;
 	}): Promise<SyncResult> {
-		if (!this.app) {
-			throw new Error("Scheduler not initialized");
-		}
-
-		this.activeSyncs.add(instance.id);
-
-		try {
-			log.info({ instanceId: instance.id, instanceName: instance.label }, "Starting library sync");
-
-			const result = await syncInstance(
-				{
-					prisma: this.app.prisma,
-					arrClientFactory: this.app.arrClientFactory,
-					encryptor: this.app.encryptor,
-					log: this.app.log,
-				},
-				instance as Parameters<typeof syncInstance>[1],
-			);
-
-			log.info(
-				{ instanceId: instance.id, instanceLabel: instance.label, success: result.success },
-				"Library sync completed",
-			);
-
-			// Notify about newly downloaded content detected by the sync executor.
-			if (result.success && result.newDownloads.length > 0) {
-				void sendNewDownloadNotification(this.app.notificationService, result, instance).catch(
-					(err) => {
-						log.warn(
-							{ err, instanceLabel: instance.label },
-							"New content notification dispatch failed",
-						);
-					},
-				);
+		return withIndependentCleanupOperationGuard(async () => {
+			if (!this.app) {
+				throw new Error("Scheduler not initialized");
 			}
 
-			return result;
-		} finally {
-			this.activeSyncs.delete(instance.id);
-			this.activeSyncItemCounts.delete(instance.id);
-		}
+			this.activeSyncs.add(instance.id);
+
+			try {
+				log.info(
+					{ instanceId: instance.id, instanceName: instance.label },
+					"Starting library sync",
+				);
+
+				const result = await syncInstance(
+					{
+						prisma: this.app.prisma,
+						arrClientFactory: this.app.arrClientFactory,
+						encryptor: this.app.encryptor,
+						log: this.app.log,
+					},
+					instance as Parameters<typeof syncInstance>[1],
+				);
+
+				log.info(
+					{ instanceId: instance.id, instanceLabel: instance.label, success: result.success },
+					"Library sync completed",
+				);
+
+				// Notify about newly downloaded content detected by the sync executor.
+				if (result.success && result.newDownloads.length > 0) {
+					await sendNewDownloadNotification(this.app.notificationService, result, instance).catch(
+						(err) => {
+							log.warn(
+								{ err, instanceLabel: instance.label },
+								"New content notification dispatch failed",
+							);
+						},
+					);
+				}
+
+				return result;
+			} finally {
+				this.activeSyncs.delete(instance.id);
+				this.activeSyncItemCounts.delete(instance.id);
+			}
+		});
 	}
 
 	/**

--- a/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupMaintenanceGuard,
+	withCleanupOperationGuard,
 } from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { NotificationService } from "../notification-service.js";
 import type { NotificationPayload, SendResult } from "../types.js";
@@ -145,6 +146,31 @@ describe("NotificationService", () => {
 
 		const notification = service.notify(makePayload());
 		await sendStarted.promise;
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		finishSend.resolve({ success: true, retryable: false });
+		await notification;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("keeps an independent lease when its guarded caller stops awaiting", async () => {
+		mockPrisma.notificationSubscription.findMany.mockResolvedValue([
+			makeSubscription("ch-1", "discord"),
+		]);
+		const sendStarted = deferred<void>();
+		const finishSend = deferred<SendResult>();
+		mockDispatcher.send.mockImplementation(async () => {
+			sendStarted.resolve();
+			return finishSend.promise;
+		});
+		let notification!: Promise<void>;
+		await withCleanupOperationGuard(async () => {
+			notification = service.notify(makePayload());
+			await sendStarted.promise;
+		});
+
 		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
 			CleanupMaintenanceConflictError,
 		);

--- a/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
@@ -5,7 +5,11 @@
  * send, retry enqueue, and delivery logging.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { NotificationService } from "../notification-service.js";
 import type { NotificationPayload, SendResult } from "../types.js";
 
@@ -16,6 +20,14 @@ let mockLogger: any;
 let mockDedupGate: any;
 let mockRetryHandler: any;
 let service: NotificationService;
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
 
 function makePayload(overrides?: Partial<NotificationPayload>): NotificationPayload {
 	return {
@@ -118,6 +130,72 @@ describe("NotificationService", () => {
 				status: "sent",
 			}),
 		});
+	});
+
+	it("holds mutation ownership for the complete notification dispatch", async () => {
+		mockPrisma.notificationSubscription.findMany.mockResolvedValue([
+			makeSubscription("ch-1", "discord"),
+		]);
+		const sendStarted = deferred<void>();
+		const finishSend = deferred<SendResult>();
+		mockDispatcher.send.mockImplementation(async () => {
+			sendStarted.resolve();
+			return finishSend.promise;
+		});
+
+		const notification = service.notify(makePayload());
+		await sendStarted.promise;
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		finishSend.resolve({ success: true, retryable: false });
+		await notification;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("rejects notification dispatch while restore owns maintenance", async () => {
+		mockPrisma.notificationSubscription.findMany.mockResolvedValue([
+			makeSubscription("ch-1", "discord"),
+		]);
+		mockDispatcher.send.mockResolvedValue({ success: true, retryable: false } satisfies SendResult);
+		const finishRestore = deferred<void>();
+		const restore = withCleanupMaintenanceGuard(() => finishRestore.promise);
+
+		await expect(service.notify(makePayload())).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+		expect(mockDispatcher.send).not.toHaveBeenCalled();
+
+		finishRestore.resolve();
+		await restore;
+	});
+
+	it("keeps deferred notifications queued while restore owns maintenance", async () => {
+		mockPrisma.notificationSubscription.findMany.mockResolvedValue([
+			makeSubscription("ch-1", "discord"),
+		]);
+		mockDispatcher.send.mockResolvedValue({ success: true, retryable: false } satisfies SendResult);
+		const internals = service as unknown as {
+			deferNotification: (payload: NotificationPayload, deferUntil: string, ruleId: string) => void;
+			flushDeferredNotifications: () => Promise<void>;
+		};
+		internals.deferNotification(
+			makePayload(),
+			new Date(Date.now() - 1_000).toISOString(),
+			"quiet-hours-rule",
+		);
+		const finishRestore = deferred<void>();
+		const restore = withCleanupMaintenanceGuard(() => finishRestore.promise);
+
+		await internals.flushDeferredNotifications();
+		expect(mockDispatcher.send).not.toHaveBeenCalled();
+
+		finishRestore.resolve();
+		await restore;
+		await internals.flushDeferredNotifications();
+		expect(mockDispatcher.send).toHaveBeenCalledTimes(1);
+		expect(mockPrisma.notificationLog.create).toHaveBeenCalledTimes(1);
 	});
 
 	it("routes a logical event to explicit and legacy fallback channels once per channel", async () => {

--- a/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
@@ -187,6 +187,41 @@ describe("RetryHandler", () => {
 		expect(handler.pendingCount).toBe(0);
 	});
 
+	it("holds mutation ownership until max-retry dead-letter logging settles", async () => {
+		const deadLetterStarted = deferred<void>();
+		const finishDeadLetter = deferred<void>();
+		sendFn.mockResolvedValue({
+			success: false,
+			retryable: true,
+			error: "server error",
+		} satisfies SendResult);
+		logDeliveryFn.mockImplementation(async (_channelId, _channelType, _payload, status) => {
+			if (status === "dead_letter") {
+				deadLetterStarted.resolve();
+				await finishDeadLetter.promise;
+			}
+		});
+		handler = new RetryHandler(sendFn, logDeliveryFn, mockLogger);
+		handler.enqueue({
+			channelId: "ch-1",
+			channelType: "DISCORD",
+			config: { webhookUrl: "https://example.com" },
+			payload: createPayload(),
+		});
+
+		const advance = vi.advanceTimersByTimeAsync(30_000 + 120_000 + 600_000);
+		await deadLetterStarted.promise;
+		await Promise.resolve();
+		await Promise.resolve();
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		finishDeadLetter.resolve();
+		await advance;
+		expect(handler.pendingCount).toBe(0);
+	});
+
 	it("respects retryAfterMs from 429 response", async () => {
 		sendFn.mockResolvedValueOnce({
 			success: false,

--- a/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { NotificationChannelType } from "@arr/shared";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { RetryHandler } from "../retry-handler.js";
 import type { NotificationPayload, SendResult } from "../types.js";
 
@@ -41,6 +45,14 @@ function createPayload(title = "Test") {
 		title,
 		body: "Body text",
 	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
 }
 
 describe("RetryHandler", () => {
@@ -81,6 +93,62 @@ describe("RetryHandler", () => {
 			1,
 		);
 		expect(handler.pendingCount).toBe(0);
+	});
+
+	it("holds mutation ownership across retry dispatch and delivery logging", async () => {
+		const sendStarted = deferred<void>();
+		const finishSend = deferred<SendResult>();
+		sendFn.mockImplementation(async () => {
+			sendStarted.resolve();
+			return finishSend.promise;
+		});
+		handler = new RetryHandler(sendFn, logDeliveryFn, mockLogger);
+		handler.enqueue({
+			channelId: "ch-1",
+			channelType: "DISCORD",
+			config: { webhookUrl: "https://example.com" },
+			payload: createPayload(),
+		});
+
+		const advance = vi.advanceTimersByTimeAsync(30_000);
+		await sendStarted.promise;
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		finishSend.resolve({ success: true, retryable: false });
+		await advance;
+		expect(logDeliveryFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not dispatch a retry while restore owns maintenance", async () => {
+		sendFn.mockResolvedValue({ success: true, retryable: false } satisfies SendResult);
+		handler = new RetryHandler(sendFn, logDeliveryFn, mockLogger);
+		handler.enqueue({
+			channelId: "ch-1",
+			channelType: "DISCORD",
+			config: { webhookUrl: "https://example.com" },
+			payload: createPayload(),
+		});
+		const finishRestore = deferred<void>();
+		const restore = withCleanupMaintenanceGuard(() => finishRestore.promise);
+
+		await vi.advanceTimersByTimeAsync(30_000);
+		expect(sendFn).not.toHaveBeenCalled();
+		expect(handler.pendingCount).toBe(1);
+
+		finishRestore.resolve();
+		await restore;
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(sendFn).toHaveBeenCalledTimes(1);
+		expect(logDeliveryFn).toHaveBeenCalledWith(
+			"ch-1",
+			"DISCORD",
+			expect.objectContaining({ title: "Test" }),
+			"sent",
+			undefined,
+			1,
+		);
 	});
 
 	it("dead-letters after max retries (3) are exhausted", async () => {

--- a/apps/api/src/lib/notifications/insights-digest.ts
+++ b/apps/api/src/lib/notifications/insights-digest.ts
@@ -100,7 +100,7 @@ export class InsightsDigestScheduler {
 		const itemList = topItems.map((i) => `• ${i.title} (requested by ${i.requestedBy})`).join("\n");
 		const moreText = items.length > 5 ? `\n+${items.length - 5} more` : "";
 
-		this.notifyFn!({
+		await this.notifyFn!({
 			eventType: "LIBRARY_INSIGHT_REQUESTED_UNWATCHED",
 			title: `${items.length} requested item${items.length !== 1 ? "s" : ""} never watched`,
 			body: `The following Seerr requests are available but have not been watched after ${MIN_AGE_DAYS}+ days:\n${itemList}${moreText}`,
@@ -126,7 +126,7 @@ export class InsightsDigestScheduler {
 			.join("\n");
 		const moreText = items.length > 5 ? `\n+${items.length - 5} more` : "";
 
-		this.notifyFn!({
+		await this.notifyFn!({
 			eventType: "LIBRARY_INSIGHT_WATCHED_MONITORED",
 			title: `${items.length} watched item${items.length !== 1 ? "s" : ""} still monitored`,
 			body: `These items have been watched but are still being monitored for new downloads:\n${itemList}${moreText}`,

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -21,6 +21,10 @@ function redactSecretFields(config: Record<string, unknown>): Record<string, unk
 	);
 }
 import type { Encryptor } from "../auth/encryption.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../library-cleanup/cleanup-maintenance-gate.js";
 import type { PrismaClient } from "../prisma.js";
 import type { AggregationBuffer, AggregationConfig } from "./aggregation-buffer.js";
 import type { DedupGate } from "./dedup-gate.js";
@@ -119,35 +123,48 @@ export class NotificationService {
 	private async flushDeferredNotifications(): Promise<void> {
 		if (this.deferredQueue.length === 0) return;
 
-		const now = Date.now();
-		const ready = this.deferredQueue.filter((item) => item.deliverAt <= now);
-		if (ready.length === 0) return;
+		try {
+			await withCleanupOperationGuard(async () => {
+				const now = Date.now();
+				const ready = this.deferredQueue.filter((item) => item.deliverAt <= now);
+				if (ready.length === 0) return;
 
-		// Remove ready items from queue
-		this.deferredQueue = this.deferredQueue.filter((item) => item.deliverAt > now);
+				// Remove ready items only after notification mutation ownership is established.
+				this.deferredQueue = this.deferredQueue.filter((item) => item.deliverAt > now);
 
-		this.logger.info(
-			{ count: ready.length, remaining: this.deferredQueue.length },
-			"Delivering deferred notifications after quiet hours",
-		);
-
-		// Deliver each deferred notification individually (skipRules prevents re-deferral).
-		// Individual delivery ensures each notification routes to the correct channels
-		// based on its own eventType subscriptions.
-		const deliveryOptions = { skipRules: true };
-		for (const item of ready) {
-			try {
-				await this.notify(item.payload, {
-					...deliveryOptions,
-					userId: item.userId,
-					fallbackEventTypes: item.fallbackEventTypes,
-				});
-			} catch (err: unknown) {
-				this.logger.warn(
-					{ err, eventType: item.payload.eventType },
-					"Failed to deliver deferred notification",
+				this.logger.info(
+					{ count: ready.length, remaining: this.deferredQueue.length },
+					"Delivering deferred notifications after quiet hours",
 				);
+
+				// Deliver each deferred notification individually (skipRules prevents re-deferral).
+				// Individual delivery ensures each notification routes to the correct channels
+				// based on its own eventType subscriptions.
+				const deliveryOptions = { skipRules: true };
+				for (const item of ready) {
+					try {
+						await this.notifyGuarded(item.payload, {
+							...deliveryOptions,
+							userId: item.userId,
+							fallbackEventTypes: item.fallbackEventTypes,
+						});
+					} catch (err: unknown) {
+						this.logger.warn(
+							{ err, eventType: item.payload.eventType },
+							"Failed to deliver deferred notification",
+						);
+					}
+				}
+			});
+		} catch (err: unknown) {
+			if (err instanceof CleanupMaintenanceConflictError) {
+				this.logger.debug(
+					{ queueSize: this.deferredQueue.length },
+					"Deferred notification flush paused during database maintenance",
+				);
+				return;
 			}
+			throw err;
 		}
 	}
 
@@ -156,6 +173,17 @@ export class NotificationService {
 	 * Failures on individual channels are logged but do not throw.
 	 */
 	async notify(
+		payload: NotificationPayload,
+		options?: {
+			skipRules?: boolean;
+			userId?: string;
+			fallbackEventTypes?: NotificationEventType[];
+		},
+	): Promise<void> {
+		return withCleanupOperationGuard(() => this.notifyGuarded(payload, options));
+	}
+
+	private async notifyGuarded(
 		payload: NotificationPayload,
 		options?: {
 			skipRules?: boolean;
@@ -368,6 +396,10 @@ export class NotificationService {
 	 * Test a specific channel's connectivity by decrypting its config and calling the test method.
 	 */
 	async testChannel(channelId: string, userId: string): Promise<void> {
+		return withCleanupOperationGuard(() => this.testChannelGuarded(channelId, userId));
+	}
+
+	private async testChannelGuarded(channelId: string, userId: string): Promise<void> {
 		const channel = await this.prisma.notificationChannel.findFirst({
 			where: { id: channelId, userId },
 		});
@@ -538,6 +570,19 @@ export class NotificationService {
 	 * Public so that RetryHandler can call it for retry/dead-letter logging.
 	 */
 	async logDelivery(
+		channelId: string,
+		channelType: NotificationChannelType,
+		payload: NotificationPayload,
+		status: "sent" | "failed" | "dead_letter",
+		error?: string,
+		retryCount?: number,
+	): Promise<void> {
+		return withCleanupOperationGuard(() =>
+			this.logDeliveryGuarded(channelId, channelType, payload, status, error, retryCount),
+		);
+	}
+
+	private async logDeliveryGuarded(
 		channelId: string,
 		channelType: NotificationChannelType,
 		payload: NotificationPayload,

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -24,6 +24,7 @@ import type { Encryptor } from "../auth/encryption.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,
+	withIndependentCleanupOperationGuard,
 } from "../library-cleanup/cleanup-maintenance-gate.js";
 import type { PrismaClient } from "../prisma.js";
 import type { AggregationBuffer, AggregationConfig } from "./aggregation-buffer.js";
@@ -180,7 +181,7 @@ export class NotificationService {
 			fallbackEventTypes?: NotificationEventType[];
 		},
 	): Promise<void> {
-		return withCleanupOperationGuard(() => this.notifyGuarded(payload, options));
+		return withIndependentCleanupOperationGuard(() => this.notifyGuarded(payload, options));
 	}
 
 	private async notifyGuarded(

--- a/apps/api/src/lib/notifications/retry-handler.ts
+++ b/apps/api/src/lib/notifications/retry-handler.ts
@@ -1,4 +1,8 @@
 import type { NotificationChannelType } from "@arr/shared";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../library-cleanup/cleanup-maintenance-gate.js";
 import type { NotificationLogger, NotificationPayload, SendResult } from "./types.js";
 
 interface RetryItem {
@@ -71,13 +75,15 @@ export class RetryHandler {
 				{ channelId: item.channelId, eventType: item.payload.eventType, attempts: item.attempt },
 				"Notification dead-lettered after max retries",
 			);
-			this.logDeliveryFn(
-				item.channelId,
-				item.channelType,
-				item.payload,
-				"dead_letter",
-				`Exhausted ${MAX_RETRIES} retries`,
-				item.attempt,
+			withCleanupOperationGuard(() =>
+				this.logDeliveryFn(
+					item.channelId,
+					item.channelType,
+					item.payload,
+					"dead_letter",
+					`Exhausted ${MAX_RETRIES} retries`,
+					item.attempt,
+				),
 			).catch(() => {});
 			this.queue.delete(key);
 			return;
@@ -93,43 +99,53 @@ export class RetryHandler {
 
 		const timer = setTimeout(async () => {
 			try {
-				const result = await this.sendFn(item.channelType, item.config, item.payload);
-				if (result.success) {
-					this.logger.info(
-						{ channelId: item.channelId, attempt: item.attempt + 1 },
-						"Notification retry succeeded",
-					);
-					await this.logDeliveryFn(
-						item.channelId,
-						item.channelType,
-						item.payload,
-						"sent",
-						undefined,
-						item.attempt + 1,
-					).catch(() => {});
-					this.queue.delete(key);
-				} else if (result.retryable) {
-					this.scheduleRetry(key, {
-						...item,
-						attempt: item.attempt + 1,
-						retryAfterMs: result.retryAfterMs,
-					});
-				} else {
-					this.logger.warn(
-						{ channelId: item.channelId, error: result.error },
-						"Notification retry failed with non-retryable error",
-					);
-					await this.logDeliveryFn(
-						item.channelId,
-						item.channelType,
-						item.payload,
-						"dead_letter",
-						result.error,
-						item.attempt + 1,
-					).catch(() => {});
-					this.queue.delete(key);
-				}
+				await withCleanupOperationGuard(async () => {
+					const result = await this.sendFn(item.channelType, item.config, item.payload);
+					if (result.success) {
+						this.logger.info(
+							{ channelId: item.channelId, attempt: item.attempt + 1 },
+							"Notification retry succeeded",
+						);
+						await this.logDeliveryFn(
+							item.channelId,
+							item.channelType,
+							item.payload,
+							"sent",
+							undefined,
+							item.attempt + 1,
+						).catch(() => {});
+						this.queue.delete(key);
+					} else if (result.retryable) {
+						this.scheduleRetry(key, {
+							...item,
+							attempt: item.attempt + 1,
+							retryAfterMs: result.retryAfterMs,
+						});
+					} else {
+						this.logger.warn(
+							{ channelId: item.channelId, error: result.error },
+							"Notification retry failed with non-retryable error",
+						);
+						await this.logDeliveryFn(
+							item.channelId,
+							item.channelType,
+							item.payload,
+							"dead_letter",
+							result.error,
+							item.attempt + 1,
+						).catch(() => {});
+						this.queue.delete(key);
+					}
+				});
 			} catch (retryErr) {
+				if (retryErr instanceof CleanupMaintenanceConflictError) {
+					this.logger.debug(
+						{ channelId: item.channelId, attempt: item.attempt + 1 },
+						"Notification retry paused during database maintenance",
+					);
+					this.scheduleRetry(key, { ...item, attempt: item.attempt });
+					return;
+				}
 				this.logger.warn(
 					{ err: retryErr, channelId: item.channelId, attempt: item.attempt + 1 },
 					"Notification retry threw unexpected error, re-queuing",
@@ -148,13 +164,15 @@ export class RetryHandler {
 	flush(): void {
 		for (const [, item] of this.queue) {
 			clearTimeout(item.timer);
-			this.logDeliveryFn(
-				item.channelId,
-				item.channelType,
-				item.payload,
-				"dead_letter",
-				"Server shutdown — retry abandoned",
-				item.attempt,
+			withCleanupOperationGuard(() =>
+				this.logDeliveryFn(
+					item.channelId,
+					item.channelType,
+					item.payload,
+					"dead_letter",
+					"Server shutdown — retry abandoned",
+					item.attempt,
+				),
 			).catch(() => {});
 		}
 		this.queue.clear();

--- a/apps/api/src/lib/notifications/retry-handler.ts
+++ b/apps/api/src/lib/notifications/retry-handler.ts
@@ -69,13 +69,13 @@ export class RetryHandler {
 	private scheduleRetry(
 		key: string,
 		item: Omit<RetryItem, "timer"> & { retryAfterMs?: number },
-	): void {
+	): Promise<void> | void {
 		if (item.attempt >= MAX_RETRIES) {
 			this.logger.warn(
 				{ channelId: item.channelId, eventType: item.payload.eventType, attempts: item.attempt },
 				"Notification dead-lettered after max retries",
 			);
-			withCleanupOperationGuard(() =>
+			const deadLetter = withCleanupOperationGuard(() =>
 				this.logDeliveryFn(
 					item.channelId,
 					item.channelType,
@@ -86,7 +86,7 @@ export class RetryHandler {
 				),
 			).catch(() => {});
 			this.queue.delete(key);
-			return;
+			return deadLetter;
 		}
 
 		const backoffMs =
@@ -116,7 +116,7 @@ export class RetryHandler {
 						).catch(() => {});
 						this.queue.delete(key);
 					} else if (result.retryable) {
-						this.scheduleRetry(key, {
+						await this.scheduleRetry(key, {
 							...item,
 							attempt: item.attempt + 1,
 							retryAfterMs: result.retryAfterMs,
@@ -143,14 +143,14 @@ export class RetryHandler {
 						{ channelId: item.channelId, attempt: item.attempt + 1 },
 						"Notification retry paused during database maintenance",
 					);
-					this.scheduleRetry(key, { ...item, attempt: item.attempt });
+					await this.scheduleRetry(key, { ...item, attempt: item.attempt });
 					return;
 				}
 				this.logger.warn(
 					{ err: retryErr, channelId: item.channelId, attempt: item.attempt + 1 },
 					"Notification retry threw unexpected error, re-queuing",
 				);
-				this.scheduleRetry(key, { ...item, attempt: item.attempt + 1 });
+				await this.scheduleRetry(key, { ...item, attempt: item.attempt + 1 });
 			}
 		}, backoffMs);
 

--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -10,6 +10,7 @@
 import type { PulseAction } from "@arr/shared";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withCleanupMaintenanceGuard } from "../../library-cleanup/cleanup-maintenance-gate.js";
 
 // -----------------------------------------------------------------------------
 // Module mocks — declared before the dispatcher import so vi can hoist them.
@@ -350,6 +351,9 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		expect(result.status).toBe("ok");
 		// The refresher has NOT completed yet — upsert should not have fired.
 		expect(cacheStatusUpsert).not.toHaveBeenCalled();
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toMatchObject({
+			statusCode: 409,
+		});
 
 		// Let the slow refresh complete, then the background task should
 		// run the write-through.
@@ -363,6 +367,7 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		await result.backgroundTask;
 
 		expect(cacheStatusUpsert).not.toHaveBeenCalled();
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
 	});
 
 	it("does not race the sealed refresher's attempt lifecycle when its background promise rejects", async () => {

--- a/apps/api/src/lib/pulse/actions.ts
+++ b/apps/api/src/lib/pulse/actions.ts
@@ -27,6 +27,7 @@ import { requireEnabledInstance } from "../arr/instance-helpers.js";
 import { parseQueueId } from "../dashboard/queue-utils.js";
 import { AppValidationError, ConflictError, InstanceNotFoundError } from "../errors.js";
 import { getHuntingScheduler } from "../hunting/scheduler.js";
+import { withIndependentCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import {
 	createOwnedJellyfinPublicationSnapshot,
 	refreshJellyfinCache,
@@ -247,7 +248,7 @@ function runBackgroundCacheRefresh(opts: {
 		failureRecordedByRefresh = false,
 		publicationAuthority,
 	} = opts;
-	return (async () => {
+	return withIndependentCleanupOperationGuard(async () => {
 		try {
 			const result = await refresh();
 			if (
@@ -280,7 +281,7 @@ function runBackgroundCacheRefresh(opts: {
 				"pulse-action: cache refresh failed (background)",
 			);
 		}
-	})();
+	});
 }
 
 async function recordBackgroundCacheRefreshFailure(

--- a/apps/api/src/lib/queue-cleaner/__tests__/scheduler-restore-barrier.test.ts
+++ b/apps/api/src/lib/queue-cleaner/__tests__/scheduler-restore-barrier.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import { withCleanupMaintenanceGuard } from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { MAX_CLEAN_DURATION_MS } from "../constants.js";
+
+const mocks = vi.hoisted(() => ({
+	executeQueueCleaner: vi.fn(),
+	executeEnhancedPreview: vi.fn(),
+}));
+
+vi.mock("../cleaner-executor.js", () => ({
+	executeQueueCleaner: mocks.executeQueueCleaner,
+	executeEnhancedPreview: mocks.executeEnhancedPreview,
+}));
+
+import { getQueueCleanerScheduler } from "../scheduler.js";
+
+describe("queue cleaner background restore barrier", () => {
+	it("holds an independent lease while startup log reaping is pending", async () => {
+		const scheduler = getQueueCleanerScheduler();
+		let releaseFind!: (rows: unknown[]) => void;
+		const findMany = vi.fn(
+			() =>
+				new Promise<unknown[]>((resolve) => {
+					releaseFind = resolve;
+				}),
+		);
+		scheduler.initialize({
+			prisma: {
+				queueCleanerLog: {
+					findMany,
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+				},
+			},
+		} as never);
+		await vi.waitFor(() => expect(findMany).toHaveBeenCalledTimes(1));
+
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toMatchObject({
+			statusCode: 409,
+		});
+
+		releaseFind([]);
+		await vi.waitFor(async () => {
+			await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+		});
+	});
+
+	it("keeps a dedicated operation lease until a queued manual clean settles", async () => {
+		const scheduler = getQueueCleanerScheduler();
+		const app = {
+			prisma: {
+				queueCleanerLog: {
+					findMany: vi.fn().mockResolvedValue([]),
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+				},
+			},
+		} as never;
+		scheduler.initialize(app);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		let releaseClean!: () => void;
+		const runClean = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					releaseClean = resolve;
+				}),
+		);
+		const schedulerInternals = scheduler as unknown as {
+			runClean(instanceId: string): Promise<void>;
+		};
+		const runCleanSpy = vi.spyOn(schedulerInternals, "runClean").mockImplementation(runClean);
+
+		await expect(scheduler.triggerManualClean("restore-barrier-instance")).resolves.toMatchObject({
+			triggered: true,
+		});
+		expect(runClean).toHaveBeenCalledWith("restore-barrier-instance");
+
+		const maintenanceWork = vi.fn();
+		await expect(withCleanupMaintenanceGuard(async () => maintenanceWork())).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(maintenanceWork).not.toHaveBeenCalled();
+
+		releaseClean();
+		await vi.waitFor(async () => {
+			await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+		});
+		runCleanSpy.mockRestore();
+	});
+
+	it("rejects a retrigger after timeout until the uncancelled executor settles", async () => {
+		vi.useFakeTimers();
+		try {
+			mocks.executeQueueCleaner.mockReset();
+			const scheduler = getQueueCleanerScheduler();
+			let releaseExecution!: (result: unknown) => void;
+			mocks.executeQueueCleaner.mockReturnValue(
+				new Promise((resolve) => {
+					releaseExecution = resolve;
+				}),
+			);
+			const instance = { id: "timeout-instance", label: "Radarr", service: "RADARR" };
+			const app = {
+				prisma: {
+					queueCleanerConfig: {
+						findUnique: vi.fn().mockResolvedValue({
+							instanceId: instance.id,
+							instance,
+							dryRunMode: false,
+						}),
+					},
+					queueCleanerLog: {
+						findMany: vi.fn().mockResolvedValue([]),
+						updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+						create: vi.fn().mockResolvedValue({ id: "log-1" }),
+						update: vi.fn().mockResolvedValue({}),
+					},
+				},
+				notificationService: { notify: vi.fn().mockResolvedValue(undefined) },
+			} as never;
+			scheduler.initialize(app);
+			await vi.advanceTimersByTimeAsync(0);
+
+			await expect(scheduler.triggerManualClean(instance.id)).resolves.toMatchObject({
+				triggered: true,
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(mocks.executeQueueCleaner).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(MAX_CLEAN_DURATION_MS + 1);
+
+			await expect(scheduler.triggerManualClean(instance.id)).resolves.toMatchObject({
+				triggered: false,
+				message: expect.stringContaining("in progress"),
+			});
+			expect(mocks.executeQueueCleaner).toHaveBeenCalledTimes(1);
+
+			releaseExecution({
+				itemsCleaned: 0,
+				itemsSkipped: 0,
+				itemsWarned: 0,
+				cleanedItems: [],
+				skippedItems: [],
+				warnedItems: [],
+				isDryRun: false,
+				status: "success",
+				message: "late completion",
+			});
+			await vi.advanceTimersByTimeAsync(0);
+			expect(
+				(
+					scheduler as unknown as {
+						activeCleanerExecutions: Map<string, Promise<unknown>>;
+					}
+				).activeCleanerExecutions.has(instance.id),
+			).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/apps/api/src/lib/queue-cleaner/scheduler.ts
+++ b/apps/api/src/lib/queue-cleaner/scheduler.ts
@@ -1,4 +1,8 @@
 import type { FastifyInstance } from "fastify";
+import {
+	acquireCleanupOperationGuard,
+	withIndependentCleanupOperationGuard,
+} from "../library-cleanup/cleanup-maintenance-gate.js";
 import { loggers } from "../logger.js";
 import {
 	passthroughTickWrapper,
@@ -53,6 +57,9 @@ class QueueCleanerScheduler {
 	private lastCleanTimes: Map<string, Date> = new Map();
 	// Track instances currently being cleaned to prevent race conditions
 	private cleaningInProgress: Set<string> = new Set();
+	// A timeout does not cancel executeQueueCleaner. Retain per-instance
+	// ownership until that raw executor promise actually settles.
+	private activeCleanerExecutions = new Map<string, Promise<CleanerResult>>();
 	// Health tracking
 	private consecutiveTickFailures = 0;
 	private lastTickError: string | null = null;
@@ -73,7 +80,7 @@ class QueueCleanerScheduler {
 		this.app = app;
 
 		// Clean up any stuck logs from previous runs
-		this.cleanupStuckLogs().catch((error) => {
+		withIndependentCleanupOperationGuard(() => this.cleanupStuckLogs()).catch((error) => {
 			log.error({ err: error }, "Failed to cleanup stuck queue cleaner logs on init");
 		});
 	}
@@ -125,8 +132,13 @@ class QueueCleanerScheduler {
 		this.running = true;
 
 		this.intervalId = setInterval(() => {
-			this.trackTick(() => this.tick())
+			let tickStarted = false;
+			this.trackTick(() => {
+				tickStarted = true;
+				return this.tick();
+			})
 				.then(() => {
+					if (!tickStarted) return;
 					// Success - reset failure tracking
 					this.consecutiveTickFailures = 0;
 					this.lastTickError = null;
@@ -229,7 +241,7 @@ class QueueCleanerScheduler {
 	 */
 	async triggerManualClean(instanceId: string): Promise<{ triggered: boolean; message: string }> {
 		// Check if clean is already in progress (prevents race condition)
-		if (this.cleaningInProgress.has(instanceId)) {
+		if (this.cleaningInProgress.has(instanceId) || this.activeCleanerExecutions.has(instanceId)) {
 			return { triggered: false, message: "Clean already in progress for this instance" };
 		}
 
@@ -241,6 +253,7 @@ class QueueCleanerScheduler {
 		if (!this.app) {
 			throw new SchedulerNotInitializedError("manual clean");
 		}
+		const releaseOperationGuard = acquireCleanupOperationGuard();
 
 		// Mark as in-progress BEFORE setting cooldown time (atomic-ish protection)
 		this.cleaningInProgress.add(instanceId);
@@ -248,44 +261,46 @@ class QueueCleanerScheduler {
 
 		// Run the clean asynchronously - runClean creates and manages its own log entry
 		// Errors are captured in the log entry, making failures visible in Activity tab
-		const logIdPromise = this.runClean(instanceId).finally(() => {
-			// Always clear the in-progress flag when done
-			this.cleaningInProgress.delete(instanceId);
-		});
-
-		// Don't await - we want to return immediately
-		// But we do catch to prevent unhandled rejection AND create visible error entry
-		logIdPromise.catch(async (error) => {
-			const message = getErrorMessage(error, "Unknown error");
-			log.error({ err: error, instanceId }, "Manual queue clean failed before log entry creation");
-
-			// Create an error log entry so the failure is visible in Activity tab
-			// This handles cases where runClean fails before creating its own log entry
-			try {
-				if (this.app) {
-					await this.app.prisma.queueCleanerLog.create({
-						data: {
-							instanceId,
-							status: "error",
-							message: `Clean failed to start: ${message}`,
-							completedAt: new Date(),
-							isDryRun: false,
-						},
-					});
-				}
-			} catch (logError) {
-				// Track this failure so it's visible in health status
-				this.failedLogAttempts.push({
-					instanceId,
-					timestamp: new Date(),
-					error: message,
-				});
+		void this.runClean(instanceId)
+			.catch(async (error) => {
+				const message = getErrorMessage(error, "Unknown error");
 				log.error(
-					{ err: logError, instanceId, originalError: message },
-					"Failed to create error log entry for failed manual clean - check health status",
+					{ err: error, instanceId },
+					"Manual queue clean failed before log entry creation",
 				);
-			}
-		});
+
+				// Create an error log entry so the failure is visible in Activity tab
+				// This handles cases where runClean fails before creating its own log entry
+				try {
+					if (this.app) {
+						await this.app.prisma.queueCleanerLog.create({
+							data: {
+								instanceId,
+								status: "error",
+								message: `Clean failed to start: ${message}`,
+								completedAt: new Date(),
+								isDryRun: false,
+							},
+						});
+					}
+				} catch (logError) {
+					// Track this failure so it's visible in health status
+					this.failedLogAttempts.push({
+						instanceId,
+						timestamp: new Date(),
+						error: message,
+					});
+					log.error(
+						{ err: logError, instanceId, originalError: message },
+						"Failed to create error log entry for failed manual clean - check health status",
+					);
+				}
+			})
+			.finally(() => {
+				// The independent lease outlives the queued HTTP response and includes error logging.
+				this.cleaningInProgress.delete(instanceId);
+				releaseOperationGuard();
+			});
 
 		// Message indicates job is queued, not necessarily completed
 		// Check Activity tab for results
@@ -494,7 +509,10 @@ class QueueCleanerScheduler {
 			const lastRun = config.lastRunAt ?? new Date(0);
 			const nextRun = new Date(lastRun.getTime() + config.intervalMins * 60 * 1000);
 			if (now < nextRun) return false;
-			if (this.cleaningInProgress.has(config.instanceId)) {
+			if (
+				this.cleaningInProgress.has(config.instanceId) ||
+				this.activeCleanerExecutions.has(config.instanceId)
+			) {
 				log.debug(
 					{ instanceId: config.instanceId },
 					"Skipping scheduled clean - already in progress",
@@ -572,8 +590,19 @@ class QueueCleanerScheduler {
 		});
 
 		try {
+			const execution = withIndependentCleanupOperationGuard(() =>
+				executeQueueCleaner(this.app!, config.instance, config),
+			);
+			this.activeCleanerExecutions.set(instanceId, execution);
+			void execution
+				.finally(() => {
+					if (this.activeCleanerExecutions.get(instanceId) === execution) {
+						this.activeCleanerExecutions.delete(instanceId);
+					}
+				})
+				.catch(() => undefined);
 			const result = await withTimeout(
-				executeQueueCleaner(this.app, config.instance, config),
+				execution,
 				MAX_CLEAN_DURATION_MS,
 				`Queue clean timed out after ${MAX_CLEAN_DURATION_MS / 1000} seconds`,
 			);
@@ -614,9 +643,9 @@ class QueueCleanerScheduler {
 				});
 			});
 
-			// Fire-and-forget notifications for clean results
+			// Best-effort notifications remain inside the operation lease.
 			if (result.itemsCleaned > 0 && !result.isDryRun) {
-				this.app.notificationService
+				await this.app.notificationService
 					?.notify({
 						eventType: "QUEUE_ITEMS_REMOVED",
 						title: `Queue cleaner removed ${result.itemsCleaned} item(s) on ${config.instance.label}`,
@@ -646,7 +675,7 @@ class QueueCleanerScheduler {
 					});
 			}
 			if (result.itemsWarned > 0) {
-				this.app.notificationService
+				await this.app.notificationService
 					?.notify({
 						eventType: "QUEUE_STRIKES_ISSUED",
 						title: `Queue cleaner issued strikes on ${config.instance.label}`,
@@ -687,8 +716,8 @@ class QueueCleanerScheduler {
 
 			log.error({ err: error, instanceLabel: config.instance.label }, "Queue cleaner error");
 
-			// Fire-and-forget notification for queue cleaner failure
-			this.app?.notificationService
+			// Best-effort failure notification remains inside the operation lease.
+			await this.app?.notificationService
 				?.notify({
 					eventType: "QUEUE_CLEANER_FAILED",
 					title: `Queue cleaner failed on ${config.instance.label}`,

--- a/apps/api/src/lib/qui/torrent-state-sync.ts
+++ b/apps/api/src/lib/qui/torrent-state-sync.ts
@@ -457,14 +457,16 @@ export async function runQuiTorrentStateSync(
 
 				if (userErrors === 0 && transitions.length > 0 && app.notificationService) {
 					const payloads = buildNotificationPayloads(transitions);
-					for (const payload of payloads) {
-						app.notificationService.notify(payload).catch((error) => {
-							log.warn(
-								{ err: error, userId, eventType: payload.eventType },
-								"qUI torrent-state notification dispatch failed",
-							);
-						});
-					}
+					await Promise.all(
+						payloads.map((payload) =>
+							app.notificationService.notify(payload).catch((error) => {
+								log.warn(
+									{ err: error, userId, eventType: payload.eventType },
+									"qUI torrent-state notification dispatch failed",
+								);
+							}),
+						),
+					);
 					log.info(
 						{ userId, transitions: transitions.length, payloads: payloads.length },
 						"qUI torrent-state sync emitted torrent-state notifications",

--- a/apps/api/src/lib/scheduler-registry/__tests__/scheduler-registry.test.ts
+++ b/apps/api/src/lib/scheduler-registry/__tests__/scheduler-registry.test.ts
@@ -12,6 +12,11 @@ import {
 	SerialJobBusyError,
 	UnknownJobError,
 } from "../scheduler-registry.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+	withCleanupOperationGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
 
 /**
  * Clock that advances through a preset sequence of Dates on each `now()` call.
@@ -92,6 +97,71 @@ describe("SchedulerRegistry", () => {
 			totalRuns: 1,
 			totalFailures: 0,
 		});
+	});
+
+	it("keeps the configured operation wrapper active for the complete tick", async () => {
+		const registry = new SchedulerRegistry(undefined, withCleanupOperationGuard);
+		registry.register(BASE_DEFINITION);
+
+		let releaseTick!: () => void;
+		const tickStarted = new Promise<void>((resolve) => {
+			void registry.track(
+				"example-job",
+				() =>
+					new Promise<void>((release) => {
+						resolve();
+						releaseTick = release;
+					}),
+			);
+		});
+		await tickStarted;
+
+		const maintenanceWork = vi.fn();
+		await expect(withCleanupMaintenanceGuard(async () => maintenanceWork())).rejects.toMatchObject({
+			statusCode: 409,
+		});
+		expect(maintenanceWork).not.toHaveBeenCalled();
+
+		releaseTick();
+		await vi.waitFor(() => expect(registry.getStatus("example-job")?.state).toBe("idle"));
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("treats a maintenance-blocked tick as skipped without changing health history", async () => {
+		const registry = new SchedulerRegistry(
+			undefined,
+			withCleanupOperationGuard,
+			(error) => error instanceof CleanupMaintenanceConflictError,
+		);
+		registry.register(BASE_DEFINITION);
+		let releaseMaintenance!: () => void;
+		const maintenanceStarted = new Promise<void>((resolve) => {
+			void withCleanupMaintenanceGuard(
+				() =>
+					new Promise<void>((release) => {
+						resolve();
+						releaseMaintenance = release;
+					}),
+			);
+		});
+		await maintenanceStarted;
+		const tick = vi.fn(async () => "unexpected");
+
+		await expect(registry.track("example-job", tick)).resolves.toBeUndefined();
+		expect(tick).not.toHaveBeenCalled();
+		expect(registry.getStatus("example-job")).toMatchObject({
+			state: "idle",
+			lastStartedAt: null,
+			lastFinishedAt: null,
+			lastSuccessAt: null,
+			lastFailureAt: null,
+			lastError: null,
+			consecutiveFailures: 0,
+			totalRuns: 0,
+			totalFailures: 0,
+		});
+
+		releaseMaintenance();
 	});
 
 	it("tracks a failed run, re-throws, and increments consecutiveFailures", async () => {

--- a/apps/api/src/lib/scheduler-registry/scheduler-registry.ts
+++ b/apps/api/src/lib/scheduler-registry/scheduler-registry.ts
@@ -3,8 +3,9 @@
  * for the background schedulers this API runs.
  *
  * Design intent:
- *  - Observability only. The registry does NOT own scheduling, locking, or
- *    persistence. Each scheduler plugin continues to own its own timer.
+ *  - The registry does NOT own scheduling, concurrency locking, or persistence.
+ *    Each scheduler plugin continues to own its own timer. A runtime may inject
+ *    one process-wide operation wrapper for cross-cutting safety barriers.
  *  - Incremental adoption. A scheduler can register a job up-front and
  *    instrument execution later; the read-only status surface degrades
  *    gracefully if a job has never run.
@@ -124,7 +125,11 @@ export class UnknownJobError extends Error {
 export class SchedulerRegistry {
 	private readonly jobs = new Map<string, JobRecord>();
 
-	constructor(private readonly clock: Clock = systemClock) {}
+	constructor(
+		private readonly clock: Clock = systemClock,
+		private readonly operationWrapper: TickWrapper = passthroughTickWrapper,
+		private readonly isSkippedOperationError: (error: unknown) => boolean = () => false,
+	) {}
 
 	/**
 	 * Register a job's metadata. Safe to call multiple times with the same id —
@@ -186,12 +191,14 @@ export class SchedulerRegistry {
 			throw new SerialJobBusyError(jobId);
 		}
 
+		const previousState = record.state;
+		const previousLastStartedAt = record.lastStartedAt;
 		const startedAt = this.clock.now();
 		record.lastStartedAt = startedAt;
 		record.state = "running";
 
 		try {
-			const result = await fn();
+			const result = await this.operationWrapper(fn);
 			const finishedAt = this.clock.now();
 			record.lastFinishedAt = finishedAt;
 			record.lastSuccessAt = finishedAt;
@@ -204,6 +211,14 @@ export class SchedulerRegistry {
 			}
 			return result;
 		} catch (error) {
+			if (this.isSkippedOperationError(error)) {
+				// The wrapper rejected before the job body ran (for example, while
+				// restore holds maintenance). Preserve the prior execution ledger:
+				// this was neither a success nor a failure.
+				record.lastStartedAt = previousLastStartedAt;
+				record.state = previousState;
+				return undefined as T;
+			}
 			const finishedAt = this.clock.now();
 			record.lastFinishedAt = finishedAt;
 			record.lastFailureAt = finishedAt;

--- a/apps/api/src/lib/trash-guides/sync-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/sync-scheduler.ts
@@ -188,7 +188,7 @@ export class TrashSyncScheduler {
 				await this.updateNextRunAt(schedule.id, schedule.frequency);
 
 				if (schedule.notifyUser) {
-					this.notifyFn?.({
+					await this.notifyFn?.({
 						eventType: "TRASH_SYNC_ERROR",
 						title: `Scheduled sync skipped: ${templateName}`,
 						body: `Validation failed for ${templateName} → ${instanceLabel}: ${validation.errors.join("; ")}`,
@@ -246,7 +246,7 @@ export class TrashSyncScheduler {
 				);
 
 				if (schedule.notifyUser) {
-					this.notifyFn?.(
+					await this.notifyFn?.(
 						{
 							eventType: "TRASH_DEPLOY_UNCERTAIN",
 							title: `Scheduled sync needs review: ${templateName}`,
@@ -287,7 +287,7 @@ export class TrashSyncScheduler {
 				);
 
 				if (schedule.notifyUser) {
-					this.notifyFn?.({
+					await this.notifyFn?.({
 						eventType: "TRASH_PROFILE_UPDATED",
 						title: `Scheduled sync completed: ${templateName}`,
 						body: `${templateName} synced to ${instanceLabel} successfully`,
@@ -313,7 +313,7 @@ export class TrashSyncScheduler {
 				);
 
 				if (schedule.notifyUser) {
-					this.notifyFn?.({
+					await this.notifyFn?.({
 						eventType: "TRASH_SYNC_ERROR",
 						title: `Scheduled sync failed: ${templateName}`,
 						body: `${templateName} → ${instanceLabel}: ${errorSummary}`,
@@ -339,7 +339,7 @@ export class TrashSyncScheduler {
 			});
 
 			if (schedule.notifyUser) {
-				this.notifyFn?.({
+				await this.notifyFn?.({
 					eventType: "TRASH_SYNC_ERROR",
 					title: `Scheduled sync error: ${templateName}`,
 					body: getErrorMessage(error),

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -404,7 +404,7 @@ export class UpdateScheduler {
 					templatesWithScoreConflicts += autoSyncResult.templatesWithScoreConflicts;
 					templatesWithUncertainDeployments += autoSyncResult.uncertain;
 					for (const outcome of autoSyncResult.uncertainDeployments) {
-						this.notifyFn?.(
+						await this.notifyFn?.(
 							{
 								eventType: "TRASH_DEPLOY_UNCERTAIN",
 								title: `Automatic TRaSH deployment needs review on ${outcome.instanceLabel}`,
@@ -521,7 +521,7 @@ export class UpdateScheduler {
 
 			// Notify about auto-sync results
 			if (templatesAutoSynced > 0) {
-				this.notifyFn?.({
+				await this.notifyFn?.({
 					eventType: "TRASH_PROFILE_UPDATED",
 					title: `TRaSH Guides: ${templatesAutoSynced} template(s) auto-synced`,
 					body: `${templatesAutoSynced} synced, ${templatesNeedingAttention} need attention, ${qualitySizeAutoSynced} quality sizes updated`,
@@ -567,7 +567,7 @@ export class UpdateScheduler {
 			this.stats.nextCheckAt = new Date(Date.now() + intervalMs);
 
 			// Notify about sync failure
-			this.notifyFn?.({
+			await this.notifyFn?.({
 				eventType: "TRASH_SYNC_ERROR",
 				title: "TRaSH Guides sync failed",
 				body: getErrorMessage(error),

--- a/apps/api/src/plugins/scheduler-registry.ts
+++ b/apps/api/src/plugins/scheduler-registry.ts
@@ -1,5 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { KNOWN_JOBS } from "../lib/scheduler-registry/job-definitions.js";
 import { SchedulerRegistry } from "../lib/scheduler-registry/scheduler-registry.js";
 
@@ -25,7 +29,11 @@ declare module "fastify" {
  */
 const schedulerRegistryPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
-		const registry = new SchedulerRegistry();
+		const registry = new SchedulerRegistry(
+			undefined,
+			withCleanupOperationGuard,
+			(error) => error instanceof CleanupMaintenanceConflictError,
+		);
 		// Pre-register every known job so the /api/system/jobs surface always
 		// reflects the full catalog — even jobs whose plugin has not yet adopted
 		// `registry.track()` show up as idle with no execution data.

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -26,12 +26,16 @@ const { mockSessionService } = vi.hoisted(() => ({
 }));
 
 // Mock OIDCProvider class — avoid real discovery/HTTP calls
-const { MockOIDCProvider } = vi.hoisted(() => {
+const { MockOIDCProvider, mockExchangeCode } = vi.hoisted(() => {
 	const mockGetAuthorizationUrl = vi
 		.fn()
 		.mockResolvedValue(
 			"https://provider.example.com/authorize?client_id=test&state=mock-state&code_challenge=mock-challenge",
 		);
+	const mockExchangeCode = vi.fn().mockResolvedValue({
+		access_token: "mock-access-token",
+		id_token: "mock-id-token",
+	});
 	class MockOIDCProvider {
 		config: Record<string, unknown>;
 		static mockGetAuthorizationUrl = mockGetAuthorizationUrl;
@@ -39,17 +43,14 @@ const { MockOIDCProvider } = vi.hoisted(() => {
 			this.config = config;
 		}
 		getAuthorizationUrl = mockGetAuthorizationUrl;
-		exchangeCode = vi.fn().mockResolvedValue({
-			access_token: "mock-access-token",
-			id_token: "mock-id-token",
-		});
+		exchangeCode = mockExchangeCode;
 		extractIdTokenClaims = vi.fn().mockReturnValue({ sub: "provider-user-1" });
 		getUserInfo = vi.fn().mockResolvedValue({
 			sub: "provider-user-1",
 			preferred_username: "oidc-admin",
 		});
 	}
-	return { MockOIDCProvider };
+	return { MockOIDCProvider, mockExchangeCode };
 });
 
 vi.mock("../../lib/auth/oidc-provider.js", () => ({
@@ -71,8 +72,9 @@ vi.mock("oauth4webapi", () => ({
 }));
 
 // Mock connection warmer
+const mockWarmConnectionsForUser = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 vi.mock("../../lib/arr/connection-warmer.js", () => ({
-	warmConnectionsForUser: vi.fn().mockResolvedValue(undefined),
+	warmConnectionsForUser: mockWarmConnectionsForUser,
 }));
 
 // Mock session metadata
@@ -85,8 +87,10 @@ vi.mock("../../lib/auth/session-metadata.js", () => ({
 // ---------------------------------------------------------------------------
 
 import Fastify, { type FastifyRequest } from "fastify";
-import { registerAuthOidcRoutes } from "../auth-oidc.js";
 import { resolveCanonicalIssuer } from "../../lib/auth/oidc-utils.js";
+import { registerBackupMutationGuard } from "../../lib/backup/backup-mutation-gate.js";
+import { withCleanupMaintenanceGuard } from "../../lib/library-cleanup/cleanup-maintenance-gate.js";
+import { registerAuthOidcRoutes } from "../auth-oidc.js";
 
 // ---------------------------------------------------------------------------
 // Mock Prisma client
@@ -169,6 +173,11 @@ beforeEach(async () => {
 		(state: string) =>
 			`https://provider.example.com/authorize?client_id=test&state=${encodeURIComponent(state)}`,
 	);
+	mockExchangeCode.mockReset().mockResolvedValue({
+		access_token: "mock-access-token",
+		id_token: "mock-id-token",
+	});
+	mockWarmConnectionsForUser.mockReset().mockResolvedValue(undefined);
 
 	mockPrisma = createMockPrisma();
 	mockSessionService.rotateActiveSession.mockImplementation(
@@ -221,6 +230,9 @@ beforeEach(async () => {
 			request.sessionToken = "admin-session-token";
 		}
 	});
+
+	// Register the production request mutation barrier before route discovery.
+	registerBackupMutationGuard(app);
 
 	// Register OIDC routes
 	await app.register(registerAuthOidcRoutes, { prefix: "/auth" });
@@ -619,6 +631,89 @@ describe("POST /auth/oidc/login", () => {
 // ===========================================================================
 
 describe("GET /auth/oidc/callback", () => {
+	it("holds the restore barrier while stale OIDC provider authority is in flight", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		let releaseExchange: ((tokens: { access_token: string; id_token: string }) => void) | undefined;
+		mockExchangeCode.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseExchange = resolve;
+				}),
+		);
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+		try {
+			await vi.waitFor(() => expect(mockExchangeCode).toHaveBeenCalledOnce());
+
+			const restoreWork = vi.fn();
+			await expect(withCleanupMaintenanceGuard(async () => restoreWork())).rejects.toMatchObject({
+				statusCode: 409,
+			});
+			expect(restoreWork).not.toHaveBeenCalled();
+		} finally {
+			releaseExchange?.({
+				access_token: "mock-access-token",
+				id_token: "mock-id-token",
+			});
+			await callback;
+		}
+	});
+
+	it("keeps restore excluded while detached connection warming retains old authority", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		let releaseWarmup!: () => void;
+		const warmupBlocked = new Promise<void>((resolve) => {
+			releaseWarmup = resolve;
+		});
+		mockWarmConnectionsForUser.mockReturnValueOnce(warmupBlocked);
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		let callbackStatus: number | undefined;
+		const callback = app
+			.inject({
+				method: "GET",
+				url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			})
+			.then((response: { statusCode: number }) => {
+				callbackStatus = response.statusCode;
+				return response;
+			});
+		const restoreWork = vi.fn();
+		try {
+			await vi.waitFor(() => expect(callbackStatus).toBe(302));
+			expect(mockWarmConnectionsForUser).toHaveBeenCalledOnce();
+			await expect(withCleanupMaintenanceGuard(async () => restoreWork())).rejects.toMatchObject({
+				statusCode: 409,
+			});
+			expect(restoreWork).not.toHaveBeenCalled();
+		} finally {
+			releaseWarmup();
+			await warmupBlocked;
+			await callback;
+		}
+
+		await vi.waitFor(async () => {
+			await expect(withCleanupMaintenanceGuard(restoreWork)).resolves.toBeUndefined();
+		});
+		expect(restoreWork).toHaveBeenCalledOnce();
+	});
+
 	it("links the OIDC identity to the authenticated admin who initiated the flow", async () => {
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
 		mockPrisma.oIDCAccount.create.mockResolvedValue({

--- a/apps/api/src/routes/__tests__/backup.test.ts
+++ b/apps/api/src/routes/__tests__/backup.test.ts
@@ -1,7 +1,6 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BackupPasswordConfigurationError } from "../../lib/backup/backup-service.js";
-import { BackupCompatibilityError } from "../../lib/errors.js";
 import {
 	withCleanupMaintenanceGuard,
 	withCleanupOperationGuard,
@@ -23,6 +22,9 @@ vi.mock("../../lib/backup/backup-service.js", async (importOriginal) => {
 				return mockCreateBackup(...args);
 			}
 			restoreBackup(...args: unknown[]) {
+				return mockRestoreBackup(...args);
+			}
+			restoreBackupFromFile(...args: unknown[]) {
 				return mockRestoreBackup(...args);
 			}
 		},
@@ -185,25 +187,26 @@ describe("POST /api/backup/create", () => {
 		expect(mockCreateBackup).not.toHaveBeenCalled();
 	});
 
-	it("returns bounded 409 for an incomplete legacy restore", async () => {
-		mockRestoreBackup.mockRejectedValue(new BackupCompatibilityError());
-
+	it("returns bounded 503 before validating an uploaded restore", async () => {
 		const response = await app.inject({
 			method: "POST",
 			url: "/api/backup/restore",
 			headers: { "x-test-auth": "1" },
-			payload: { backupData: Buffer.from("legacy-backup").toString("base64") },
+			payload: {},
 		});
 
-		expect(response.statusCode).toBe(409);
+		expect(response.statusCode).toBe(503);
 		expect(JSON.parse(response.payload)).toEqual({
-			error:
-				"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+			error: "Backup restore is temporarily unavailable",
+			details:
+				"Restore is disabled because this version cannot yet guarantee crash-safe database and secrets recovery. No data was changed.",
 		});
+		expect(mockRestoreBackup).not.toHaveBeenCalled();
 	});
 
-	it("preserves the generic 500 mapping for a restore infrastructure failure", async () => {
-		mockRestoreBackup.mockRejectedValue(new Error("database unavailable"));
+	it("returns bounded 503 when restore is fail-closed", async () => {
+		const { BackupRestoreUnavailableError } = await import("../../lib/backup/backup-service.js");
+		expect(new BackupRestoreUnavailableError().statusCode).toBe(503);
 
 		const response = await app.inject({
 			method: "POST",
@@ -212,7 +215,46 @@ describe("POST /api/backup/create", () => {
 			payload: { backupData: Buffer.from("current-backup").toString("base64") },
 		});
 
-		expect(response.statusCode).toBe(500);
-		expect(JSON.parse(response.payload)).toEqual({ error: "Failed to restore backup" });
+		expect(response.statusCode).toBe(503);
+		expect(JSON.parse(response.payload)).toEqual({
+			error: "Backup restore is temporarily unavailable",
+			details:
+				"Restore is disabled because this version cannot yet guarantee crash-safe database and secrets recovery. No data was changed.",
+		});
+		expect(mockRestoreBackup).not.toHaveBeenCalled();
+	});
+
+	it("returns bounded 503 for stored-file restore containment", async () => {
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore-from-file",
+			headers: { "x-test-auth": "1" },
+			payload: { id: "backup-1" },
+		});
+
+		expect(response.statusCode).toBe(503);
+		expect(JSON.parse(response.payload)).toEqual({
+			error: "Backup restore is temporarily unavailable",
+			details:
+				"Restore is disabled because this version cannot yet guarantee crash-safe database and secrets recovery. No data was changed.",
+		});
+		expect(mockRestoreBackup).not.toHaveBeenCalled();
+	});
+
+	it("returns bounded 503 before validating a stored-file restore", async () => {
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore-from-file",
+			headers: { "x-test-auth": "1" },
+			payload: {},
+		});
+
+		expect(response.statusCode).toBe(503);
+		expect(JSON.parse(response.payload)).toEqual({
+			error: "Backup restore is temporarily unavailable",
+			details:
+				"Restore is disabled because this version cannot yet guarantee crash-safe database and secrets recovery. No data was changed.",
+		});
+		expect(mockRestoreBackup).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/__tests__/backup.test.ts
+++ b/apps/api/src/routes/__tests__/backup.test.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BackupPasswordConfigurationError } from "../../lib/backup/backup-service.js";
+import { BackupCompatibilityError } from "../../lib/errors.js";
 import {
 	withCleanupMaintenanceGuard,
 	withCleanupOperationGuard,
@@ -8,8 +9,9 @@ import {
 import { registerBackupRoutes } from "../backup.js";
 import { registerTestErrorHandler } from "./test-helpers.js";
 
-const { mockCreateBackup } = vi.hoisted(() => ({
+const { mockCreateBackup, mockRestoreBackup } = vi.hoisted(() => ({
 	mockCreateBackup: vi.fn(),
+	mockRestoreBackup: vi.fn(),
 }));
 
 vi.mock("../../lib/backup/backup-service.js", async (importOriginal) => {
@@ -19,6 +21,9 @@ vi.mock("../../lib/backup/backup-service.js", async (importOriginal) => {
 		BackupService: class {
 			createBackup(...args: unknown[]) {
 				return mockCreateBackup(...args);
+			}
+			restoreBackup(...args: unknown[]) {
+				return mockRestoreBackup(...args);
 			}
 		},
 	};
@@ -178,5 +183,36 @@ describe("POST /api/backup/create", () => {
 		expect(response.statusCode).toBe(401);
 		expect(JSON.parse(response.payload)).toEqual({ error: "Authentication required" });
 		expect(mockCreateBackup).not.toHaveBeenCalled();
+	});
+
+	it("returns bounded 409 for an incomplete legacy restore", async () => {
+		mockRestoreBackup.mockRejectedValue(new BackupCompatibilityError());
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore",
+			headers: { "x-test-auth": "1" },
+			payload: { backupData: Buffer.from("legacy-backup").toString("base64") },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(JSON.parse(response.payload)).toEqual({
+			error:
+				"This backup does not contain complete configuration or recovery coverage and cannot safely replace the current installation. Create a new backup with the current version and retry.",
+		});
+	});
+
+	it("preserves the generic 500 mapping for a restore infrastructure failure", async () => {
+		mockRestoreBackup.mockRejectedValue(new Error("database unavailable"));
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/backup/restore",
+			headers: { "x-test-auth": "1" },
+			payload: { backupData: Buffer.from("current-backup").toString("base64") },
+		});
+
+		expect(response.statusCode).toBe(500);
+		expect(JSON.parse(response.payload)).toEqual({ error: "Failed to restore backup" });
 	});
 });

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -5,15 +5,16 @@ import * as oauth from "oauth4webapi";
 import { z } from "zod";
 import { warmConnectionsForUser } from "../lib/arr/connection-warmer.js";
 import { OIDCProvider } from "../lib/auth/oidc-provider.js";
-import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
-import { getSessionMetadata } from "../lib/auth/session-metadata.js";
-import { getErrorMessage } from "../lib/utils/error-message.js";
-import { validateRequest } from "../lib/utils/validate.js";
 import {
 	buildOidcRedirectUriFromAppUrl,
 	oidcRedirectUriMatchesAppOrigin,
 	resolveOidcAppUrl,
 } from "../lib/auth/oidc-redirect-uri.js";
+import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
+import { getSessionMetadata } from "../lib/auth/session-metadata.js";
+import { withIndependentCleanupOperationGuard } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
+import { getErrorMessage } from "../lib/utils/error-message.js";
+import { validateRequest } from "../lib/utils/validate.js";
 
 /**
  * In-memory storage for OIDC states and nonces (production: use Redis)
@@ -332,7 +333,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * GET /auth/oidc/callback
 	 * Handles OIDC callback after user authorization
 	 */
-	app.get("/oidc/callback", async (request, reply) => {
+	app.get("/oidc/callback", { config: { backupMutation: true } }, async (request, reply) => {
 		const queryParams = request.query as Record<string, unknown>;
 		request.log.info({ hasCode: "code" in queryParams }, "OIDC callback received");
 
@@ -637,9 +638,11 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			);
 
 			// Pre-warm connections to ARR instances in background (don't await)
-			warmConnectionsForUser(app, user.id).catch((err) => {
-				request.log.debug({ err }, "Connection warm-up wrapper error (non-critical)");
-			});
+			withIndependentCleanupOperationGuard(() => warmConnectionsForUser(app, user.id)).catch(
+				(err) => {
+					request.log.debug({ err }, "Connection warm-up wrapper error (non-critical)");
+				},
+			);
 
 			const redirectPath = isAccountAction ? "/settings#authentication" : "/";
 			request.log.info(

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -384,7 +384,7 @@ export async function registerAutoTagRoutes(app: FastifyInstance, _opts: Fastify
 	// lost from the response, only rotation can show it again. This is a small
 	// UX loss for a meaningful security win — a DB dump no longer yields the
 	// auth token.
-	app.get("/webhook-config", async (request, reply) => {
+	app.get("/webhook-config", { config: { backupMutation: true } }, async (request, reply) => {
 		const userId = request.currentUser!.id;
 		const user = await app.prisma.user.findUnique({ where: { id: userId } });
 		if (!user) return reply.status(404).send({ error: "User not found" });

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -331,7 +331,7 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * GET /backup/settings
 	 * Get backup settings
 	 */
-	app.get("/settings", async (_request, reply) => {
+	app.get("/settings", { config: { backupMutation: true } }, async (_request, reply) => {
 		// Get or create settings atomically
 		const settings = await app.prisma.backupSettings.upsert({
 			where: { id: 1 },

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -11,7 +11,11 @@ import {
 } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
-import { BackupPasswordConfigurationError, BackupService } from "../lib/backup/backup-service.js";
+import {
+	BackupPasswordConfigurationError,
+	BackupRestoreUnavailableError,
+	BackupService,
+} from "../lib/backup/backup-service.js";
 import { BackupCompatibilityError } from "../lib/errors.js";
 import { CleanupMaintenanceConflictError } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
@@ -24,6 +28,10 @@ const idParams = z.object({ id: z.string().min(1) });
 const BACKUP_RATE_LIMIT = { max: 3, timeWindow: "5 minutes" };
 const RESTORE_RATE_LIMIT = { max: 2, timeWindow: "5 minutes" };
 const DELETE_RATE_LIMIT = { max: 5, timeWindow: "5 minutes" };
+
+function refuseBackupRestore(): void {
+	throw new BackupRestoreUnavailableError();
+}
 
 const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	// Helper to create backup service instance
@@ -125,9 +133,9 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Restore from a backup (uploaded file)
 	 */
 	app.post("/restore", { config: { rateLimit: RESTORE_RATE_LIMIT } }, async (request, reply) => {
-		const { backupData } = validateRequest(restoreBackupRequestSchema, request.body);
-
 		try {
+			refuseBackupRestore();
+			const { backupData } = validateRequest(restoreBackupRequestSchema, request.body);
 			const backupService = getBackupService();
 			request.log.info("Restoring backup from upload");
 
@@ -160,6 +168,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				await app.lifecycle.restart("backup-restore");
 			}
 		} catch (error) {
+			if (error instanceof BackupRestoreUnavailableError) {
+				request.log.warn("Backup restore refused by fail-closed safety containment");
+				return reply.status(error.statusCode).send({
+					error: "Backup restore is temporarily unavailable",
+					details: error.message,
+				});
+			}
+
 			if (error instanceof BackupCompatibilityError) {
 				request.log.warn(
 					{ code: error.code },
@@ -193,9 +209,9 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		"/restore-from-file",
 		{ config: { rateLimit: RESTORE_RATE_LIMIT } },
 		async (request, reply) => {
-			const { id: backupId } = validateRequest(restoreBackupFromFileRequestSchema, request.body);
-
 			try {
+				refuseBackupRestore();
+				const { id: backupId } = validateRequest(restoreBackupFromFileRequestSchema, request.body);
 				const backupService = getBackupService();
 				request.log.info({ backupId }, "Restoring backup from file");
 
@@ -227,6 +243,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					await app.lifecycle.restart("backup-restore");
 				}
 			} catch (error) {
+				if (error instanceof BackupRestoreUnavailableError) {
+					request.log.warn("Backup restore from file refused by fail-closed safety containment");
+					return reply.status(error.statusCode).send({
+						error: "Backup restore is temporarily unavailable",
+						details: error.message,
+					});
+				}
+
 				if (error instanceof BackupCompatibilityError) {
 					request.log.warn(
 						{ code: error.code },

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -12,6 +12,7 @@ import {
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { BackupPasswordConfigurationError, BackupService } from "../lib/backup/backup-service.js";
+import { BackupCompatibilityError } from "../lib/errors.js";
 import { CleanupMaintenanceConflictError } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
@@ -159,6 +160,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				await app.lifecycle.restart("backup-restore");
 			}
 		} catch (error) {
+			if (error instanceof BackupCompatibilityError) {
+				request.log.warn(
+					{ code: error.code },
+					"Backup restore rejected because configuration or recovery coverage is incomplete",
+				);
+				return reply.status(409).send({ error: error.message });
+			}
+
 			if (error instanceof CleanupMaintenanceConflictError) {
 				request.log.warn({ err: error }, "Backup restore blocked by active cleanup maintenance");
 				return reply.status(409).send({ error: error.message });
@@ -218,6 +227,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					await app.lifecycle.restart("backup-restore");
 				}
 			} catch (error) {
+				if (error instanceof BackupCompatibilityError) {
+					request.log.warn(
+						{ code: error.code },
+						"Backup restore from file rejected because configuration or recovery coverage is incomplete",
+					);
+					return reply.status(409).send({ error: error.message });
+				}
+
 				if (error instanceof CleanupMaintenanceConflictError) {
 					request.log.warn(
 						{ err: error },

--- a/apps/api/src/routes/qui/panel-routes.ts
+++ b/apps/api/src/routes/qui/panel-routes.ts
@@ -32,6 +32,7 @@ export function registerPanelRoutes(app: FastifyInstance): void {
 	// ownership pattern as the rest of qui.ts.
 	app.get<{ Params: { arrInstanceId: string; arrItemId: string } }>(
 		"/qui/series/:arrInstanceId/:arrItemId/torrents",
+		{ config: { backupMutation: true } },
 		async (request, reply) => {
 			const userId = request.currentUser!.id;
 			const { arrInstanceId } = request.params;
@@ -651,6 +652,7 @@ export function registerPanelRoutes(app: FastifyInstance): void {
 	//   - Action items (stuck, dormant, fs_unavailable, healed)
 	app.get<{ Params: { arrInstanceId: string; arrItemId: string } }>(
 		"/qui/movie/:arrInstanceId/:arrItemId/torrents",
+		{ config: { backupMutation: true } },
 		async (request, reply) => {
 			const userId = request.currentUser!.id;
 			const { arrInstanceId } = request.params;

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -56,7 +56,7 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * GET /system/settings
 	 * Get system-wide settings (ports, listen address, app name, etc.)
 	 */
-	app.get("/settings", async (_request, reply) => {
+	app.get("/settings", { config: { backupMutation: true } }, async (_request, reply) => {
 		// Get or create system settings (singleton)
 		let settings = await app.prisma.systemSettings.findUnique({
 			where: { id: 1 },

--- a/apps/api/src/routes/trash-guides/settings-routes.ts
+++ b/apps/api/src/routes/trash-guides/settings-routes.ts
@@ -151,43 +151,47 @@ export async function registerSettingsRoutes(app: FastifyInstance, _opts: Fastif
 	 * Get the current user's TRaSH Guides settings.
 	 * Creates default settings if they don't exist.
 	 */
-	app.get("/", async (request: FastifyRequest, reply: FastifyReply) => {
-		const userId = request.currentUser!.id; // preHandler guarantees auth
+	app.get(
+		"/",
+		{ config: { backupMutation: true } },
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			const userId = request.currentUser!.id; // preHandler guarantees auth
 
-		// Get or create settings
-		let settings = await app.prisma.trashSettings.findUnique({
-			where: { userId },
-		});
-
-		if (!settings) {
-			settings = await app.prisma.trashSettings.create({
-				data: { userId },
+			// Get or create settings
+			let settings = await app.prisma.trashSettings.findUnique({
+				where: { userId },
 			});
-		}
 
-		return reply.send({
-			settings,
-			defaultRepo: DEFAULT_TRASH_REPO,
-			// Include documentation about the settings
-			documentation: {
-				backupRetentionDays: {
-					description: "Number of days before backups automatically expire",
-					default: 30,
-					range: "0-365 (0 = never expire)",
+			if (!settings) {
+				settings = await app.prisma.trashSettings.create({
+					data: { userId },
+				});
+			}
+
+			return reply.send({
+				settings,
+				defaultRepo: DEFAULT_TRASH_REPO,
+				// Include documentation about the settings
+				documentation: {
+					backupRetentionDays: {
+						description: "Number of days before backups automatically expire",
+						default: 30,
+						range: "0-365 (0 = never expire)",
+					},
+					backupRetention: {
+						description: "Maximum number of backups to keep per instance",
+						default: 10,
+						range: "1-100",
+					},
+					checkFrequency: {
+						description: "How often to check for TRaSH Guides updates (hours)",
+						default: 12,
+						range: "1-168",
+					},
 				},
-				backupRetention: {
-					description: "Maximum number of backups to keep per instance",
-					default: 10,
-					range: "1-100",
-				},
-				checkFrequency: {
-					description: "How often to check for TRaSH Guides updates (hours)",
-					default: 12,
-					range: "1-168",
-				},
-			},
-		});
-	});
+			});
+		},
+	);
 
 	/**
 	 * PATCH /api/trash-guides/settings

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,7 @@ import {
 } from "./bootstrap/index.js";
 import { type ApiEnv, envSchema } from "./config/env.js";
 import { arrErrorToHttpStatus, isArrError } from "./lib/arr/client-factory.js";
+import { registerBackupMutationGuard } from "./lib/backup/backup-mutation-gate.js";
 import { logger } from "./lib/logger.js";
 
 function isPrismaKnownError(
@@ -40,6 +41,7 @@ export const buildServer = (options: ServerOptions = {}): FastifyInstance => {
 		trustProxy: env.TRUST_PROXY,
 	});
 	app.decorate("config", env);
+	registerBackupMutationGuard(app);
 
 	// Handle requests with unexpected Content-Type headers (e.g., Next.js proxy
 	// injecting application/octet-stream on body-less DELETE requests). Without this,

--- a/apps/web/src/features/settings/components/backup-list-section.tsx
+++ b/apps/web/src/features/settings/components/backup-list-section.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import type { BackupFileInfo } from "@arr/shared";
-import { AlertCircle, Archive, Download, FileText, Loader2, Trash2, Upload } from "lucide-react";
-import { useState } from "react";
+import { AlertCircle, Archive, Download, FileText, Loader2, Trash2 } from "lucide-react";
 import {
 	PremiumEmptyState,
 	PremiumSection,
@@ -12,19 +11,10 @@ import {
 	StatusBadge,
 } from "../../../components/layout";
 import { Button, toast } from "../../../components/ui";
-import {
-	useBackups,
-	useDeleteBackup,
-	useDownloadBackup,
-	useRestoreBackupFromFile,
-} from "../../../hooks/api/useBackup";
+import { useBackups, useDeleteBackup, useDownloadBackup } from "../../../hooks/api/useBackup";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { formatBytes } from "../../../lib/format-utils";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
-
-interface BackupListSectionProps {
-	onRestoreComplete: (willRestart: boolean) => void;
-}
 
 const formatDate = (dateString: string) => {
 	return new Date(dateString).toLocaleString();
@@ -43,15 +33,9 @@ const getTypeStatus = (type: string): "success" | "info" | "warning" | "default"
 	}
 };
 
-export const BackupListSection = ({ onRestoreComplete }: BackupListSectionProps) => {
-	const [selectedBackupForRestore, setSelectedBackupForRestore] = useState<BackupFileInfo | null>(
-		null,
-	);
-	const [showBackupRestoreModal, setShowBackupRestoreModal] = useState(false);
-
+export const BackupListSection = () => {
 	const { data: backupsData, isLoading: backupsLoading, error: backupsError } = useBackups();
 	const deleteBackupMutation = useDeleteBackup();
-	const restoreBackupFromFileMutation = useRestoreBackupFromFile();
 	const downloadBackupMutation = useDownloadBackup();
 
 	const backups = backupsData?.backups || [];
@@ -81,214 +65,102 @@ export const BackupListSection = ({ onRestoreComplete }: BackupListSectionProps)
 		}
 	};
 
-	const handleRestoreBackupClick = (backup: BackupFileInfo) => {
-		setSelectedBackupForRestore(backup);
-		setShowBackupRestoreModal(true);
-	};
-
-	const handleRestoreBackupSubmit = async () => {
-		if (!selectedBackupForRestore) return;
-		try {
-			const response = await restoreBackupFromFileMutation.mutateAsync({
-				id: selectedBackupForRestore.id,
-			});
-
-			const willAutoRestart = response.message.includes("restart automatically");
-			setShowBackupRestoreModal(false);
-			setSelectedBackupForRestore(null);
-
-			if (willAutoRestart) {
-				onRestoreComplete(true);
-			} else {
-				toast.success(
-					`Backup restored from ${new Date(response.metadata.timestamp).toLocaleString()}`,
-				);
-				onRestoreComplete(false);
-			}
-		} catch (error: unknown) {
-			const errorMessage = getErrorMessage(error, "Unknown error");
-			toast.error(`Failed to restore backup: ${errorMessage}`);
-		}
-	};
-
 	return (
-		<>
-			<PremiumSection
-				title="Available Backups"
-				description={`${backups.length} backup${backups.length !== 1 ? "s" : ""} stored on the system`}
-				icon={Archive}
-			>
-				{backupsLoading ? (
-					<div className="flex items-center justify-center py-12">
-						<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-					</div>
-				) : backupsError ? (
-					<div
-						className="flex items-center gap-2 p-3 rounded-lg text-sm"
-						style={{
-							backgroundColor: SEMANTIC_COLORS.error.bg,
-							border: `1px solid ${SEMANTIC_COLORS.error.border}`,
-							color: SEMANTIC_COLORS.error.text,
-						}}
-					>
-						<AlertCircle className="h-4 w-4" />
-						Failed to load backups: {backupsError.message}
-					</div>
-				) : backups.length === 0 ? (
-					<PremiumEmptyState
-						icon={FileText}
-						title="No backups found"
-						description="Create a backup above to get started"
-					/>
-				) : (
-					<PremiumTable>
-						<PremiumTableHeader>
-							<tr>
-								<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									Type
-								</th>
-								<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									Filename
-								</th>
-								<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									Date
-								</th>
-								<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									Size
-								</th>
-								<th className="py-3 px-4 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-									Actions
-								</th>
-							</tr>
-						</PremiumTableHeader>
-						<tbody>
-							{backups.map((backup) => (
-								<PremiumTableRow key={backup.id}>
-									<td className="py-3 px-4">
-										<StatusBadge status={getTypeStatus(backup.type)}>
-											{backup.type.charAt(0).toUpperCase() + backup.type.slice(1)}
-										</StatusBadge>
-									</td>
-									<td className="py-3 px-4">
-										<span className="text-sm text-muted-foreground">{backup.filename}</span>
-									</td>
-									<td className="py-3 px-4">
-										<span className="text-sm text-muted-foreground">
-											{formatDate(backup.timestamp)}
-										</span>
-									</td>
-									<td className="py-3 px-4">
-										<span className="text-sm text-muted-foreground">
-											{formatBytes(backup.size)}
-										</span>
-									</td>
-									<td className="py-3 px-4">
-										<div className="flex items-center justify-end gap-2">
-											<Button
-												variant="secondary"
-												size="sm"
-												onClick={() => handleDownloadBackup(backup)}
-												className="gap-1 border-border/50 bg-card/50"
-											>
-												<Download className="h-3.5 w-3.5" />
-												<span className="hidden sm:inline">Download</span>
-											</Button>
-											<Button
-												variant="secondary"
-												size="sm"
-												onClick={() => handleRestoreBackupClick(backup)}
-												className="gap-1 border-border/50 bg-card/50"
-											>
-												<Upload className="h-3.5 w-3.5" />
-												<span className="hidden sm:inline">Restore</span>
-											</Button>
-											<Button
-												variant="danger"
-												size="sm"
-												onClick={() => handleDeleteBackup(backup)}
-												disabled={deleteBackupMutation.isPending}
-												className="gap-1"
-											>
-												<Trash2 className="h-3.5 w-3.5" />
-												<span className="hidden sm:inline">Delete</span>
-											</Button>
-										</div>
-									</td>
-								</PremiumTableRow>
-							))}
-						</tbody>
-					</PremiumTable>
-				)}
-			</PremiumSection>
-
-			{/* Restore Backup Modal */}
-			{showBackupRestoreModal && selectedBackupForRestore && (
-				<div
-					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-xs"
-					role="dialog"
-					aria-modal="true"
-					aria-labelledby="restore-backup-title"
-				>
-					<div className="rounded-xl border border-border/30 bg-muted/10 p-6 w-full max-w-md m-4">
-						<div className="space-y-4">
-							<h3 id="restore-backup-title" className="text-lg font-semibold text-foreground">
-								Restore Backup
-							</h3>
-
-							<div
-								className="p-3 rounded-lg text-sm"
-								style={{
-									backgroundColor: SEMANTIC_COLORS.error.bg,
-									border: `1px solid ${SEMANTIC_COLORS.error.border}`,
-									color: SEMANTIC_COLORS.error.text,
-								}}
-							>
-								<p className="font-medium mb-1">Warning: Destructive Operation</p>
-								<p className="text-xs">
-									Restoring this backup will replace all current data. Any changes made after this
-									backup was created will be lost.
-								</p>
-							</div>
-
-							<div className="space-y-2">
-								<p className="text-sm text-muted-foreground">{selectedBackupForRestore.filename}</p>
-								<p className="text-xs text-muted-foreground">
-									Created: {formatDate(selectedBackupForRestore.timestamp)}
-								</p>
-							</div>
-
-							<div className="flex gap-2">
-								<Button
-									onClick={handleRestoreBackupSubmit}
-									variant="danger"
-									disabled={restoreBackupFromFileMutation.isPending}
-									className="flex-1 gap-2"
-								>
-									{restoreBackupFromFileMutation.isPending ? (
-										<>
-											<Loader2 className="h-4 w-4 animate-spin" />
-											Restoring...
-										</>
-									) : (
-										"Restore Backup"
-									)}
-								</Button>
-								<Button
-									type="button"
-									variant="secondary"
-									onClick={() => {
-										setShowBackupRestoreModal(false);
-										setSelectedBackupForRestore(null);
-									}}
-									disabled={restoreBackupFromFileMutation.isPending}
-								>
-									Cancel
-								</Button>
-							</div>
-						</div>
-					</div>
+		<PremiumSection
+			title="Available Backups"
+			description={`${backups.length} backup${backups.length !== 1 ? "s" : ""} stored on the system; restore is temporarily unavailable`}
+			icon={Archive}
+		>
+			{backupsLoading ? (
+				<div className="flex items-center justify-center py-12">
+					<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
 				</div>
+			) : backupsError ? (
+				<div
+					className="flex items-center gap-2 p-3 rounded-lg text-sm"
+					style={{
+						backgroundColor: SEMANTIC_COLORS.error.bg,
+						border: `1px solid ${SEMANTIC_COLORS.error.border}`,
+						color: SEMANTIC_COLORS.error.text,
+					}}
+				>
+					<AlertCircle className="h-4 w-4" />
+					Failed to load backups: {backupsError.message}
+				</div>
+			) : backups.length === 0 ? (
+				<PremiumEmptyState
+					icon={FileText}
+					title="No backups found"
+					description="Create a backup above to get started"
+				/>
+			) : (
+				<PremiumTable>
+					<PremiumTableHeader>
+						<tr>
+							<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								Type
+							</th>
+							<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								Filename
+							</th>
+							<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								Date
+							</th>
+							<th className="py-3 px-4 text-left text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								Size
+							</th>
+							<th className="py-3 px-4 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+								Actions
+							</th>
+						</tr>
+					</PremiumTableHeader>
+					<tbody>
+						{backups.map((backup) => (
+							<PremiumTableRow key={backup.id}>
+								<td className="py-3 px-4">
+									<StatusBadge status={getTypeStatus(backup.type)}>
+										{backup.type.charAt(0).toUpperCase() + backup.type.slice(1)}
+									</StatusBadge>
+								</td>
+								<td className="py-3 px-4">
+									<span className="text-sm text-muted-foreground">{backup.filename}</span>
+								</td>
+								<td className="py-3 px-4">
+									<span className="text-sm text-muted-foreground">
+										{formatDate(backup.timestamp)}
+									</span>
+								</td>
+								<td className="py-3 px-4">
+									<span className="text-sm text-muted-foreground">{formatBytes(backup.size)}</span>
+								</td>
+								<td className="py-3 px-4">
+									<div className="flex items-center justify-end gap-2">
+										<Button
+											variant="secondary"
+											size="sm"
+											onClick={() => handleDownloadBackup(backup)}
+											className="gap-1 border-border/50 bg-card/50"
+										>
+											<Download className="h-3.5 w-3.5" />
+											<span className="hidden sm:inline">Download</span>
+										</Button>
+										<Button
+											variant="danger"
+											size="sm"
+											onClick={() => handleDeleteBackup(backup)}
+											disabled={deleteBackupMutation.isPending}
+											className="gap-1"
+										>
+											<Trash2 className="h-3.5 w-3.5" />
+											<span className="hidden sm:inline">Delete</span>
+										</Button>
+									</div>
+								</td>
+							</PremiumTableRow>
+						))}
+					</tbody>
+				</PremiumTable>
 			)}
-		</>
+		</PremiumSection>
 	);
 };

--- a/apps/web/src/features/settings/components/backup-restore-card.tsx
+++ b/apps/web/src/features/settings/components/backup-restore-card.tsx
@@ -1,51 +1,8 @@
-"use client";
+import { ShieldAlert } from "lucide-react";
 
-import { Loader2, Upload } from "lucide-react";
-import { useState } from "react";
-
-import { Button, Input, toast } from "../../../components/ui";
-import { useReadBackupFile, useRestoreBackup } from "../../../hooks/api/useBackup";
-import { getErrorMessage } from "../../../lib/error-utils";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 
-interface BackupRestoreCardProps {
-	onRestoreComplete: (willRestart: boolean) => void;
-}
-
-export const BackupRestoreCard = ({ onRestoreComplete }: BackupRestoreCardProps) => {
-	const [restoreFile, setRestoreFile] = useState<File | null>(null);
-	const [showRestoreWarning, setShowRestoreWarning] = useState(false);
-
-	const restoreBackupMutation = useRestoreBackup();
-	const readBackupFileMutation = useReadBackupFile();
-
-	const handleRestoreBackup = async (e: React.FormEvent) => {
-		e.preventDefault();
-		if (!restoreFile) {
-			toast.error("Please select a backup file");
-			return;
-		}
-		try {
-			const backupData = await readBackupFileMutation.mutateAsync(restoreFile);
-			const response = await restoreBackupMutation.mutateAsync({ backupData });
-			setRestoreFile(null);
-			setShowRestoreWarning(false);
-
-			const willAutoRestart = response.message.includes("restart automatically");
-			if (willAutoRestart) {
-				onRestoreComplete(true);
-			} else {
-				toast.success(
-					`Backup restored from ${new Date(response.metadata.timestamp).toLocaleString()}`,
-				);
-				onRestoreComplete(false);
-			}
-		} catch (error: unknown) {
-			const errorMessage = getErrorMessage(error, "Unknown error");
-			toast.error(`Failed to restore backup: ${errorMessage}`);
-		}
-	};
-
+export const BackupRestoreCard = () => {
 	return (
 		<div className="rounded-xl border border-border/30 bg-muted/10 p-6">
 			<div className="space-y-4">
@@ -57,82 +14,27 @@ export const BackupRestoreCard = ({ onRestoreComplete }: BackupRestoreCardProps)
 							border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
 						}}
 					>
-						<Upload className="h-5 w-5" style={{ color: SEMANTIC_COLORS.warning.text }} />
+						<ShieldAlert className="h-5 w-5" style={{ color: SEMANTIC_COLORS.warning.text }} />
 					</div>
 					<div>
-						<h3 className="font-semibold text-foreground">Restore from File</h3>
-						<p className="text-xs text-muted-foreground">Upload a backup file to restore</p>
+						<h3 className="font-semibold text-foreground">Restore temporarily unavailable</h3>
+						<p className="text-xs text-muted-foreground">
+							Backup creation and downloads remain available
+						</p>
 					</div>
 				</div>
 
-				{!showRestoreWarning ? (
-					<Button
-						variant="secondary"
-						onClick={() => setShowRestoreWarning(true)}
-						className="w-full gap-2 border-border/50 bg-card/50"
-					>
-						<Upload className="h-4 w-4" />
-						Restore from Backup
-					</Button>
-				) : (
-					<form onSubmit={handleRestoreBackup} className="space-y-4">
-						<div
-							className="p-3 rounded-lg text-sm"
-							style={{
-								backgroundColor: SEMANTIC_COLORS.error.bg,
-								border: `1px solid ${SEMANTIC_COLORS.error.border}`,
-								color: SEMANTIC_COLORS.error.text,
-							}}
-						>
-							<p className="font-medium mb-1">Warning: Destructive Operation</p>
-							<p className="text-xs">
-								This will replace all current data with the backup contents.
-							</p>
-						</div>
-
-						<div className="space-y-2">
-							<Input
-								type="file"
-								accept=".json"
-								onChange={(e) => setRestoreFile(e.target.files?.[0] || null)}
-								disabled={restoreBackupMutation.isPending}
-								className="bg-card/30 border-border/50"
-							/>
-							{restoreFile && (
-								<p className="text-xs text-muted-foreground">Selected: {restoreFile.name}</p>
-							)}
-						</div>
-
-						<div className="flex gap-2">
-							<Button
-								type="submit"
-								variant="danger"
-								disabled={!restoreFile || restoreBackupMutation.isPending}
-								className="flex-1 gap-2"
-							>
-								{restoreBackupMutation.isPending ? (
-									<>
-										<Loader2 className="h-4 w-4 animate-spin" />
-										Restoring...
-									</>
-								) : (
-									"Restore"
-								)}
-							</Button>
-							<Button
-								type="button"
-								variant="secondary"
-								onClick={() => {
-									setShowRestoreWarning(false);
-									setRestoreFile(null);
-								}}
-								disabled={restoreBackupMutation.isPending}
-							>
-								Cancel
-							</Button>
-						</div>
-					</form>
-				)}
+				<div
+					className="rounded-lg p-3 text-sm"
+					style={{
+						backgroundColor: SEMANTIC_COLORS.warning.bg,
+						border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
+						color: SEMANTIC_COLORS.warning.text,
+					}}
+				>
+					Restore is disabled until database and secrets recovery can remain consistent across a
+					process or host failure. No restore data is read or changed by this version.
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/settings/components/backup-tab.tsx
+++ b/apps/web/src/features/settings/components/backup-tab.tsx
@@ -1,8 +1,3 @@
-"use client";
-
-import { useState } from "react";
-
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { BackupCreateCard } from "./backup-create-card";
 import { BackupEncryptionSection } from "./backup-encryption-section";
 import { BackupListSection } from "./backup-list-section";
@@ -10,85 +5,15 @@ import { BackupRestoreCard } from "./backup-restore-card";
 import { BackupScheduleSection } from "./backup-schedule-section";
 
 export const BackupTab = () => {
-	const { gradient: themeGradient } = useThemeGradient();
-	const [isRestarting, setIsRestarting] = useState(false);
-
-	const pollForServerRestart = () => {
-		const maxAttempts = 30;
-		let attempts = 0;
-
-		const checkServer = async (): Promise<void> => {
-			attempts++;
-			try {
-				const healthResponse = await fetch("/auth/setup-required");
-				if (healthResponse.ok) {
-					window.location.href = "/login";
-					return;
-				}
-			} catch (error) {
-				if (attempts === maxAttempts) {
-					console.error("Server health check failed after maximum attempts:", error);
-				}
-			}
-			if (attempts < maxAttempts) {
-				setTimeout(checkServer, 1000);
-			} else {
-				window.location.href = "/login";
-			}
-		};
-
-		setTimeout(checkServer, 2000);
-	};
-
-	const handleRestoreComplete = (willRestart: boolean) => {
-		if (willRestart) {
-			setIsRestarting(true);
-			pollForServerRestart();
-		}
-	};
-
 	return (
 		<div className="space-y-8">
 			<BackupEncryptionSection />
 			<BackupScheduleSection />
 			<div className="grid gap-6 lg:grid-cols-2">
 				<BackupCreateCard />
-				<BackupRestoreCard onRestoreComplete={handleRestoreComplete} />
+				<BackupRestoreCard />
 			</div>
-			<BackupListSection onRestoreComplete={handleRestoreComplete} />
-
-			{/* Server Restarting Modal */}
-			{isRestarting && (
-				<div
-					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-xs"
-					role="dialog"
-					aria-modal="true"
-					aria-labelledby="server-restarting-title"
-				>
-					<div className="rounded-xl border border-border/30 bg-muted/10 p-6 w-full max-w-md m-4">
-						<div className="flex flex-col items-center text-center space-y-4 py-4">
-							<div
-								className="animate-spin rounded-full h-12 w-12 border-b-2"
-								style={{ borderColor: themeGradient.from }}
-							/>
-							<div>
-								<h3
-									id="server-restarting-title"
-									className="text-lg font-semibold mb-2 text-foreground"
-								>
-									Server Restarting
-								</h3>
-								<p className="text-sm text-muted-foreground">
-									Backup restored successfully. The server is restarting...
-								</p>
-								<p className="text-sm text-muted-foreground mt-2">
-									You will be redirected to login automatically.
-								</p>
-							</div>
-						</div>
-					</div>
-				</div>
-			)}
+			<BackupListSection />
 		</div>
 	);
 };

--- a/apps/web/src/hooks/api/useBackup.ts
+++ b/apps/web/src/hooks/api/useBackup.ts
@@ -1,7 +1,5 @@
 import type {
 	CreateBackupRequest,
-	RestoreBackupFromFileRequest,
-	RestoreBackupRequest,
 	SetBackupPasswordRequest,
 	UpdateBackupSettingsRequest,
 } from "@arr/shared";
@@ -38,32 +36,6 @@ export function useCreateBackup() {
 		onSuccess: () => {
 			// Invalidate backups list to refetch
 			queryClient.invalidateQueries({ queryKey: backupKeys.all });
-		},
-	});
-}
-
-/**
- * Restore application state from an encrypted backup file uploaded by the user.
- *
- * @returns A React Query mutation object whose mutation function accepts a `RestoreBackupRequest` and performs the restore operation
- */
-export function useRestoreBackup() {
-	return useMutation({
-		mutationFn: async (request: RestoreBackupRequest) => {
-			return backupApi.restoreBackup(request);
-		},
-	});
-}
-
-/**
- * Provide a mutation to restore application state from a backup file on the filesystem.
- *
- * @returns A React Query mutation object that accepts a `RestoreBackupFromFileRequest` and restores the application from the specified filesystem backup file.
- */
-export function useRestoreBackupFromFile() {
-	return useMutation({
-		mutationFn: async (request: RestoreBackupFromFileRequest) => {
-			return backupApi.restoreBackupFromFile(request);
 		},
 	});
 }
@@ -116,20 +88,6 @@ export function useUpdateBackupSettings() {
 		onSuccess: () => {
 			// Invalidate settings to refetch
 			queryClient.invalidateQueries({ queryKey: backupKeys.settings });
-		},
-	});
-}
-
-/**
- * Read a backup file and return it as a base64 string.
- * Uses chunked processing to avoid call stack overflow on large files.
- *
- * @returns A React Query mutation that accepts a File and returns a base64 string
- */
-export function useReadBackupFile() {
-	return useMutation({
-		mutationFn: async (file: File) => {
-			return backupApi.readBackupFile(file);
 		},
 	});
 }

--- a/apps/web/src/lib/api-client/backup.ts
+++ b/apps/web/src/lib/api-client/backup.ts
@@ -4,9 +4,6 @@ import type {
 	BackupSettings,
 	CreateBackupRequest,
 	ListBackupsResponse,
-	RestoreBackupFromFileRequest,
-	RestoreBackupRequest,
-	RestoreBackupResponse,
 	SetBackupPasswordRequest,
 	UpdateBackupSettingsRequest,
 } from "@arr/shared";
@@ -25,26 +22,6 @@ export const backupApi = {
 	 */
 	async createBackup(request: CreateBackupRequest): Promise<BackupFileInfo> {
 		return apiRequest<BackupFileInfo>("/api/backup/create", {
-			json: request,
-		});
-	},
-
-	/**
-	 * Restore from an encrypted backup (uploaded file)
-	 */
-	async restoreBackup(request: RestoreBackupRequest): Promise<RestoreBackupResponse> {
-		return apiRequest<RestoreBackupResponse>("/api/backup/restore", {
-			json: request,
-		});
-	},
-
-	/**
-	 * Restore from a backup stored on filesystem
-	 */
-	async restoreBackupFromFile(
-		request: RestoreBackupFromFileRequest,
-	): Promise<RestoreBackupResponse> {
-		return apiRequest<RestoreBackupResponse>("/api/backup/restore-from-file", {
 			json: request,
 		});
 	},
@@ -87,39 +64,6 @@ export const backupApi = {
 			console.error("Failed to download backup:", error);
 			throw error;
 		}
-	},
-
-	/**
-	 * Read backup file as base64 string
-	 * Uses chunked processing to avoid call stack overflow on large files
-	 */
-	async readBackupFile(file: File): Promise<string> {
-		return new Promise((resolve, reject) => {
-			const reader = new FileReader();
-			reader.onload = () => {
-				// FileReader returns ArrayBuffer when using readAsArrayBuffer
-				if (reader.result instanceof ArrayBuffer) {
-					const uint8Array = new Uint8Array(reader.result);
-
-					// Convert to base64 using chunked approach to avoid call stack overflow
-					// Process in 8KB chunks to safely handle large files
-					const CHUNK_SIZE = 8192;
-					let binaryString = "";
-
-					for (let i = 0; i < uint8Array.length; i += CHUNK_SIZE) {
-						const chunk = uint8Array.subarray(i, Math.min(i + CHUNK_SIZE, uint8Array.length));
-						binaryString += String.fromCharCode(...chunk);
-					}
-
-					const base64 = btoa(binaryString);
-					resolve(base64);
-				} else {
-					reject(new Error("Failed to read file as ArrayBuffer"));
-				}
-			};
-			reader.onerror = () => reject(reader.error);
-			reader.readAsArrayBuffer(file);
-		});
 	},
 
 	/**

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -37,7 +37,17 @@ The payload contains all of these arrays:
 The shared TypeScript shape keeps later-added properties optional so 1.0 and
 1.1 files remain representable. Runtime `validateBackup` is authoritative:
 format 1.2 rejects any missing array in the complete contract, including an
-array that would otherwise be safely interpreted as empty.
+array that would otherwise be safely interpreted as empty. The
+`oidcProviders`, `systemSettings`, `backupSettings`, and `vapidKeys` arrays may
+each contain at most one record; an ambiguous payload is rejected before
+secrets or database state can change.
+
+Every portable collection is read sequentially inside one serializable Prisma
+transaction. This keeps the bounded-heap query order while ensuring related
+parents, children, and encrypted configuration come from one database
+snapshot. Active naming recovery rows and their service authority are checked
+again after that snapshot closes so a change at the publication boundary makes
+backup creation fail closed and retry.
 
 History is capped according to the backup retention option and may be omitted
 for scheduled/update backups. The exception is safety coordination: every
@@ -126,6 +136,17 @@ their absence from the backup is not treated as durable authority or success
 evidence. Excluded notification delivery logs are cleared transactionally
 before notification channels are replaced so post-snapshot history cannot be
 reattached to a restored channel ID.
+
+Backup creation and restore also use the process-wide maintenance lease. Every
+HTTP `POST`, `PUT`, `PATCH`, and `DELETE` handler registered under the API root
+holds a shared operation lease for its full handler lifetime, so configuration
+writes cannot overlap the export snapshot or return success while restore
+replaces their rows. Backup create/restore and destructive topology routes are
+allowed to upgrade their request's sole shared lease to the existing stronger
+maintenance or exclusive topology lease. An upgrade fails closed when any
+other operation is active.
+Background notification dispatch and retry publication participate in the same
+barrier. Read-only routes remain available while a normal mutation is running.
 
 ## Legacy restore behavior
 

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -37,6 +37,9 @@ The payload contains all of these arrays:
   `notificationAggregationConfig`, `autoTagRule`, `labelSyncRule`,
   `queueCleanerConfig`, `libraryCleanupConfig`, `libraryCleanupRule`,
   `namingConfig`, and `userCustomFormat`.
+- Library sync configuration: `librarySyncSettings` contains only
+  `instanceId`, `pollingEnabled`, and `pollingIntervalMins`. Volatile sync
+  status is excluded and resets to database defaults.
 - Cleanup coordination: active `libraryCleanupApproval` rows, executed
   approvals still awaiting terminal audit, and active
   `libraryCleanupMediaServerScan` rows are included; an active scan also
@@ -117,7 +120,7 @@ are copied.
 | `InodeIndexCache` | disposable/rebuildable cache | excluded |
 | `LibraryCache` | disposable/rebuildable cache | excluded |
 | `EpisodeFileCache` | disposable/rebuildable cache | excluded |
-| `LibrarySyncStatus` | disposable/rebuildable cache | excluded |
+| `LibrarySyncStatus` | mixed durable config and disposable cache | `pollingEnabled` and `pollingIntervalMins` included as `librarySyncSettings`; sync timestamps, progress, duration, errors, and item counts excluded and reset |
 | `QueueCleanerStrike` | audit/history | excluded |
 | `QueueCleanerLog` | audit/history | excluded |
 | `LibraryCleanupApproval` | coordination | active statuses and executed rows awaiting terminal audit included; terminal-audit markers reset |

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,5 +1,18 @@
 # Backup inventory
 
+> [!WARNING]
+> Backup creation, scheduling, download, and deletion remain available. Restore
+> is temporarily disabled and returns HTTP 503 before reading the supplied
+> backup or changing filesystem/database state. The current restore design
+> cannot guarantee that database ciphertext and `secrets.json` remain a
+> coherent pair across a process or host crash, and its maintenance barrier is
+> not shared across API processes. Issue #815 remains open for a durable,
+> restart-reconciled recovery protocol and provider-backed exclusive lease.
+
+The inventory below documents the complete export format and the safety
+contract a future restore implementation must satisfy. It does not mean that
+restore is enabled in this version.
+
 Arr Dashboard backup format **1.2** emits complete, explicit coverage for the
 durable configuration and authentication state needed to recreate an
 installation. Every collection is represented as an array, including an empty
@@ -137,18 +150,25 @@ evidence. Excluded notification delivery logs are cleared transactionally
 before notification channels are replaced so post-snapshot history cannot be
 reattached to a restored channel ID.
 
-Backup creation and restore also use the process-wide maintenance lease. Every
+Backup creation uses the process-wide maintenance lease. Every
 HTTP `POST`, `PUT`, `PATCH`, and `DELETE` handler registered under the API root
 holds a shared operation lease for its full handler lifetime, so configuration
-writes cannot overlap the export snapshot or return success while restore
-replaces their rows. Backup create/restore and destructive topology routes are
+writes cannot overlap the export snapshot. Backup creation and destructive topology routes are
 allowed to upgrade their request's sole shared lease to the existing stronger
 maintenance or exclusive topology lease. An upgrade fails closed when any
 other operation is active.
 Background notification dispatch and retry publication participate in the same
 barrier. Read-only routes remain available while a normal mutation is running.
 
+This in-process barrier protects coherent export in the supported single-API
+topology. It is not sufficient authority for restore, which remains disabled
+until a provider-backed cross-process exclusion mechanism is available.
+
 ## Legacy restore behavior
+
+The rules in this section are retained as requirements and lower-level
+validation coverage for a future restore implementation. Production restore
+currently returns HTTP 503 before parsing either current or legacy files.
 
 Versions **1.0** and **1.1** remain readable. Their older optional arrays may
 be absent, and a clean target may restore them. A legacy restore is rejected

--- a/docs/BACKUPS.md
+++ b/docs/BACKUPS.md
@@ -1,0 +1,153 @@
+# Backup inventory
+
+Arr Dashboard backup format **1.2** emits complete, explicit coverage for the
+durable configuration and authentication state needed to recreate an
+installation. Every collection is represented as an array, including an empty
+array. Encrypted values are copied with their ciphertext and IV unchanged.
+
+## What format 1.2 contains
+
+The payload contains all of these arrays:
+
+- Authentication and services: `users`, `sessions`, `serviceInstances`,
+  `serviceTags`, `serviceInstanceTags`, `oidcProviders`, `oidcAccounts`, and
+  `webAuthnCredentials`.
+- Singleton/configuration state: `systemSettings`, `backupSettings`, and
+  `vapidKeys`.
+- TRaSH configuration: `trashTemplates`, `trashSettings`,
+  `trashSyncSchedules`, `templateQualityProfileMappings`,
+  `instanceQualityProfileOverrides`, `standaloneCFDeployments`, and
+  `qualitySizeMappings`.
+- Hunting configuration: `huntConfigs`.
+- Durable feature configuration: `notificationChannel`,
+  `notificationSubscription`, `notificationRule`,
+  `notificationAggregationConfig`, `autoTagRule`, `labelSyncRule`,
+  `queueCleanerConfig`, `libraryCleanupConfig`, `libraryCleanupRule`,
+  `namingConfig`, and `userCustomFormat`.
+- Cleanup coordination: active `libraryCleanupApproval` rows, executed
+  approvals still awaiting terminal audit, and active
+  `libraryCleanupMediaServerScan` rows are included; an active scan also
+  carries its parent approval even when that approval is already executed.
+  Nonportable terminal-audit and recovery-attempt timestamps are reset so the
+  restored scheduler can record fresh audit evidence.
+- Bounded operational history: `trashSyncHistory`,
+  `templateDeploymentHistory`, `namingDeployHistory`, `huntLogs`, and
+  `huntSearchHistory`.
+
+The shared TypeScript shape keeps later-added properties optional so 1.0 and
+1.1 files remain representable. Runtime `validateBackup` is authoritative:
+format 1.2 rejects any missing array in the complete contract, including an
+array that would otherwise be safely interpreted as empty.
+
+History is capped according to the backup retention option and may be omitted
+for scheduled/update backups. The exception is safety coordination: every
+nonterminal TRaSH rollback/undeploy row and its referenced `trashBackups` row
+is always included. Active naming recovery rows are also included even when
+history is omitted or capped. These rows preserve resumability and are checked
+for equality against current state during restore.
+
+## Prisma model inventory
+
+This is the current model classification. “Included” means copied by format
+1.2; “conditional” means only the bounded coordination rows described above
+are copied.
+
+| Model | Classification | Backup status |
+| --- | --- | --- |
+| `User` | durable config/auth-secret | included |
+| `Session` | durable config/auth-secret | included |
+| `ServiceTag` | durable config/auth-secret | included |
+| `ServiceInstance` | durable config/auth-secret | included |
+| `ServiceInstanceTag` | durable config/auth-secret | included |
+| `OIDCProvider` | durable config/auth-secret | included |
+| `OIDCAccount` | durable config/auth-secret | included |
+| `WebAuthnCredential` | durable config/auth-secret | included |
+| `BackupSettings` | durable config/auth-secret | included |
+| `SystemSettings` | durable config/auth-secret | included |
+| `TrashTemplate` | durable config/auth-secret | included |
+| `TrashSyncSchedule` | durable config/auth-secret | included |
+| `TrashSettings` | durable config/auth-secret | included |
+| `TemplateQualityProfileMapping` | durable config/auth-secret | included |
+| `InstanceQualityProfileOverride` | durable config/auth-secret | included; pending/uncertain intent is equality-checked |
+| `StandaloneCFDeployment` | durable config/auth-secret | included |
+| `QualitySizeMapping` | durable config/auth-secret | included |
+| `HuntConfig` | durable config/auth-secret | included |
+| `HuntLog` | audit/history | excluded for scheduled/update backups; bounded in manual backups |
+| `HuntSearchHistory` | audit/history | excluded for scheduled/update backups; bounded in manual backups |
+| `UserCustomFormat` | durable config/auth-secret | included |
+| `QueueCleanerConfig` | durable config/auth-secret | included |
+| `LibraryCleanupConfig` | durable config/auth-secret | included |
+| `LibraryCleanupRule` | durable config/auth-secret | included |
+| `NotificationChannel` | durable config/auth-secret | included |
+| `NotificationSubscription` | durable config/auth-secret | included |
+| `VapidKeys` | durable config/auth-secret | included |
+| `NotificationRule` | durable config/auth-secret | included |
+| `NotificationAggregationConfig` | durable config/auth-secret | included |
+| `NamingConfig` | durable config/auth-secret | included |
+| `LabelSyncRule` | durable config/auth-secret | included |
+| `AutoTagRule` | durable config/auth-secret | included |
+| `TrashSyncHistory` | coordination | conditional: nonterminal/uncertain rows always included |
+| `TemplateDeploymentHistory` | coordination | conditional: nonterminal rows always included |
+| `TrashBackup` | coordination | conditional: snapshots referenced by coordination always included |
+| `NamingDeployHistory` | coordination | active recovery rows always included; other rows bounded |
+| `TrashCache` | disposable/rebuildable cache | excluded |
+| `InodeIndexCache` | disposable/rebuildable cache | excluded |
+| `LibraryCache` | disposable/rebuildable cache | excluded |
+| `EpisodeFileCache` | disposable/rebuildable cache | excluded |
+| `LibrarySyncStatus` | disposable/rebuildable cache | excluded |
+| `QueueCleanerStrike` | audit/history | excluded |
+| `QueueCleanerLog` | audit/history | excluded |
+| `LibraryCleanupApproval` | coordination | active statuses and executed rows awaiting terminal audit included; terminal-audit markers reset |
+| `LibraryCleanupMediaServerScan` | coordination | pending/triggering/failed statuses included; terminal audit excluded |
+| `LibraryCleanupMediaServerScanLease` | coordination | excluded; nonportable lease is recoverable from scan state |
+| `LibraryCleanupLog` | audit/history | excluded |
+| `LibraryCleanupAuditEvent` | audit/history | excluded |
+| `NotificationLog` | audit/history | excluded |
+| `PlexCache` | disposable/rebuildable cache | excluded |
+| `PlexGenerationTarget` | disposable/rebuildable cache | excluded |
+| `PlexEpisodeCache` | disposable/rebuildable cache | excluded |
+| `JellyfinCache` | disposable/rebuildable cache | excluded |
+| `JellyfinEpisodeCache` | disposable/rebuildable cache | excluded |
+| `TautulliCache` | disposable/rebuildable cache | excluded |
+| `CacheRefreshStatus` | disposable/rebuildable cache | excluded |
+| `SessionSnapshot` | audit/history | excluded |
+| `SeerrActionLog` | audit/history | excluded |
+| `TmdbListCache` | disposable/rebuildable cache | excluded |
+| `TraktListCache` | disposable/rebuildable cache | excluded |
+| `ListCacheRefreshStatus` | disposable/rebuildable cache | excluded |
+| `QuiActivityLog` | audit/history | excluded |
+| `QuiActionLog` | audit/history | excluded |
+| `QuiEventLog` | audit/history | excluded |
+
+Excluded cache and refresh-status models start empty after restore. They are
+repopulated by the application’s normal provider synchronization, list-cache,
+and scheduled/manual refresh paths after the required application restart;
+their absence from the backup is not treated as durable authority or success
+evidence. Excluded notification delivery logs are cleared transactionally
+before notification channels are replaced so post-snapshot history cannot be
+reattached to a restored channel ID.
+
+## Legacy restore behavior
+
+Versions **1.0** and **1.1** remain readable. Their older optional arrays may
+be absent, and a clean target may restore them. A legacy restore is rejected
+with HTTP 409 when the target already contains a relational durable-configuration
+row whose coverage is absent from the file. The check runs before the current
+secrets file is changed and again inside the database transaction before any
+delete, so an incomplete legacy backup cannot silently erase configuration.
+
+Independent singleton rows are preserved when absent from a legacy file only
+when that is safe. An incomplete legacy payload is rejected if the target has
+stored backup-password state, VAPID private-key state, or an OIDC provider that
+the file omits, because preserving that ciphertext while replacing the
+installation encryption key would make it unusable. A default `BackupSettings`
+row with neither password ciphertext nor IV remains compatible. When a legacy
+file does carry `backupSettings` or `vapidKeys`, each array independently
+authorizes deterministic replacement of that singleton even if an unrelated
+newer configuration collection is absent. A format 1.2 backup always carries
+both singleton arrays.
+
+The compatibility response is intentionally bounded and does not include
+secrets, URLs, names, or configuration contents. Snapshotless legacy partial
+undeploy records are normalized to uncertain audit-only records; they are never
+treated as resumable rollback authority.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -201,7 +201,7 @@ Follow [`CODE-REVIEW.md`](CODE-REVIEW.md) for the finite review contract.
 - **Docker vs Dev**: Different env vars and paths (`/config/` vs `./`)
 - **Secrets auto-generated**: `ENCRYPTION_KEY` and `SESSION_COOKIE_SECRET` are auto-generated to `secrets.json` if not provided
 - **Error responses**: `{ error: "message" }` with optional `details` for validation. Status codes: 400 (bad input), 401 (auth required), 403 (forbidden), 404 (not found/access denied), 423 (locked)
-- **Backup service**: Decomposed into `backup-crypto.ts`, `backup-validation.ts`, `backup-file-utils.ts`, `backup-database.ts`
+- **Backup service**: Decomposed into `backup-crypto.ts`, `backup-validation.ts`, `backup-file-utils.ts`, `backup-database.ts`; see the [backup inventory](BACKUPS.md) for format 1.2 coverage and legacy restore behavior.
 - **Queue Cleaner**: Has its own `QueueCleanerConfig` model for per-instance auto-cleanup settings
 
 ## Release Checklist

--- a/packages/shared/src/types/backup.ts
+++ b/packages/shared/src/types/backup.ts
@@ -74,7 +74,7 @@ export const restoreBackupFromFileRequestSchema = z.object({
 export type RestoreBackupFromFileRequest = z.infer<typeof restoreBackupFromFileRequestSchema>;
 
 // Backup structure (internal, not exposed via API)
-export type BackupFormatVersion = "1.0" | "1.1";
+export type BackupFormatVersion = "1.0" | "1.1" | "1.2";
 
 export interface BackupData {
 	version: BackupFormatVersion;
@@ -105,6 +105,7 @@ export interface BackupData {
 		// TRaSH Guides history/audit (useful for tracking)
 		trashSyncHistory?: unknown[];
 		templateDeploymentHistory?: unknown[];
+		namingDeployHistory?: unknown[];
 
 		// TRaSH instance backups (ARR config snapshots) - optional, can be large.
 		// Recent snapshots follow BackupSettings.includeTrashBackups; snapshots
@@ -118,6 +119,24 @@ export interface BackupData {
 		huntConfigs?: unknown[];
 		huntLogs?: unknown[];
 		huntSearchHistory?: unknown[];
+
+		// Durable configuration (runtime validation requires explicit arrays in v1.2;
+		// properties remain optional here so legacy payloads remain representable).
+		backupSettings?: unknown[];
+		vapidKeys?: unknown[];
+		notificationChannel?: unknown[];
+		notificationSubscription?: unknown[];
+		notificationRule?: unknown[];
+		notificationAggregationConfig?: unknown[];
+		autoTagRule?: unknown[];
+		labelSyncRule?: unknown[];
+		queueCleanerConfig?: unknown[];
+		libraryCleanupConfig?: unknown[];
+		libraryCleanupRule?: unknown[];
+		namingConfig?: unknown[];
+		userCustomFormat?: unknown[];
+		libraryCleanupApproval?: unknown[];
+		libraryCleanupMediaServerScan?: unknown[];
 	};
 	secrets: {
 		encryptionKey: string;

--- a/packages/shared/src/types/backup.ts
+++ b/packages/shared/src/types/backup.ts
@@ -133,6 +133,7 @@ export interface BackupData {
 		queueCleanerConfig?: unknown[];
 		libraryCleanupConfig?: unknown[];
 		libraryCleanupRule?: unknown[];
+		librarySyncSettings?: unknown[];
 		namingConfig?: unknown[];
 		userCustomFormat?: unknown[];
 		libraryCleanupApproval?: unknown[];


### PR DESCRIPTION
## Summary

Keep complete encrypted backup export available, but disable restore until it can coordinate the database and `secrets.json` across crashes and multiple API processes.

Both restore endpoints now return a bounded HTTP 503 before request validation, upload decoding, stored-file lookup, filesystem access, or database work. The settings UI shows the limitation and no longer exposes restore actions.

This replaces #843. That PR established the complete 1.2 export contract and broad mutation inventory, but its restore path remained unsafe under a hard crash and relied on a process-local maintenance barrier. This PR preserves that work and contains the destructive path instead of claiming the full restore architecture is ready.

## Related issue

Related to #815

## Scope

- Preserve the version 1.2 complete encrypted export contract from #843.
- Preserve coherent SQLite and PostgreSQL export coverage and the mutation inventory.
- Preserve non-default library polling settings without exporting volatile sync state.
- Refuse uploaded and stored-file restore at both the HTTP and service boundaries.
- Remove restore controls, hooks, file readers, and client helpers from the settings UI.
- Document that export remains available while restore is disabled.

## Non-goals

- Implementing the provider-backed exclusive restore lease.
- Implementing a restart-reconciled journal or staged secrets promotion protocol.
- Closing #815.
- Preparing a release, publishing an image, changing the private advisory, or changing `next`.

## Acceptance criteria

- [x] Backup creation, scheduling, listing, download, and deletion remain available.
- [x] Both restore routes return HTTP 503 for valid and malformed authenticated requests.
- [x] Route containment runs before application request validation, base64 decoding, and service invocation.
- [x] Both service restore methods reject before parsing, decryption, filesystem access, or Prisma access.
- [x] No settings component exposes a restore action or imports a restore helper.
- [x] Operators see a clear restore-unavailable notice.
- [x] The documentation records the crash-consistency and multi-process prerequisites.
- [x] Format 1.2 exports and validates the portable library polling projection.
- [x] #815 remains open for the durable restore design.

## Changes

- Retains the complete 1.2 export, validation, database inventory, coherent snapshot, and SQLite/PostgreSQL test coverage rebuilt from #843 on current `main`.
- Adds `librarySyncSettings` with only `instanceId`, `pollingEnabled`, and `pollingIntervalMins`; restore sanitizes the projection and lets Prisma reset volatile sync state.
- Adds `BackupRestoreUnavailableError` and immediate service-level refusal for both restore entry points.
- Returns a fixed, redacted 503 from both protected restore routes before decoding or lookup.
- Removes the old secrets/database restore choreography from the production service.
- Removes restore state, dialogs, hooks, API helpers, and local-file reading from the web app.
- Updates the settings copy, README, and backup inventory to describe the containment accurately.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [ ] User-visible behavior was live-verified, when applicable. A fresh unauthenticated fixture cannot reach authenticated settings; the production web build and all 683 web tests passed.
- [x] New queries use centralized query keys and polling constants, when applicable. No query was added.
- [x] New sensitive displays preserve incognito behavior, when applicable. The notice contains no user data.
- [x] New Prisma queries for user-owned resources include `userId`, when applicable. The backup export is installation-wide and selects only non-secret library polling fields.
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable. No service surface was added.
- [x] User-facing counts are precise rather than proxies, when applicable. No count changed.
- [x] Action links reach the correct page with required parameters, when applicable. Restore actions were removed.
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable. HTTP and service guards are intentional defense in depth.

Exact-head evidence on `ece5ac26da3e82267ac743641d18f24047a103a9`:

- `CI=true pnpm run validate:pr`: green.
- API: 4,937 passed, 65 skipped.
- Web: 683 passed.
- Shared: 89 passed.
- PR review contract: 53 passed.
- `pnpm --filter @arr/web build`: green.
- SQLite real-database backup round trip: 2 passed, including volatile-state sanitization.
- Final data-safety and security delta reviews: no P0 through P3 findings.
- Final regression review: one documentation P3 corrected; targeted correction review clean.

## Review plan

- Initial broad-reviewed head: `4820183a5e7bcaef45ad87785417802a56f61327`
- Containment correction head: `d5e23c050c72707081d07ef8be5543951144d309`
- Library polling correction head: `ece5ac26da3e82267ac743641d18f24047a103a9`
- Targeted delta range: `d5e23c050c72707081d07ef8be5543951144d309..ece5ac26da3e82267ac743641d18f24047a103a9`
- Material-scope change declared? Yes. The standing maintainer authorization permits fail-closed containment when full safe restore is too large for the correction epoch.
- Independent regression reviewer: clean on the final delta.
- Independent data-safety reviewer, when required: clean on the final delta.
- Independent security reviewer: clean on the final delta.
- GitHub Codex review head: `ece5ac26da3e82267ac743641d18f24047a103a9`; completed with no major issues.
- Maintainer decision: approved for merge under the standing convergence authorization after all exact-head gates passed.

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| GH843-CX-9 | P1 | introduced-correctness | Restore inherited Prisma's five-second interactive transaction limit for a populated backup. | Superseded by fail-closed restore containment; no restore transaction begins. | Durable restore design in #815. |
| F815-DS-CRASH | P1 | worsened-preexisting safety | A hard crash after replacing `secrets.json` but before database commit could restart with old ciphertext and the new key. | Removed the production service choreography and refuse restore before filesystem or database work. | Add a restart-reconciled journal and staged secrets promotion before re-enabling restore. |
| F815-DS-MULTI | P1 | contract violation | The maintenance gate is process-local and cannot exclude a second API process sharing the database. | Restore is disabled at route and service boundaries. | Add provider-backed exclusive ownership before re-enabling restore. |
| F815-RG-MAXWAIT | P2 | contract violation | A longer transaction timeout did not extend Prisma's separate two-second acquisition wait. | No longer applicable because restore never requests a transaction. | Cover lock acquisition in the future restore design. |
| F815-SC-ROUTE | P3 | contract violation | The first containment draft validated and decoded requests before returning 503. | Both handlers now refuse before validation, decode, lookup, or service invocation; valid and malformed tests pass. | None. |
| F815-RG-WEB | P3 | contract violation | Unused restore hooks and client helpers remained easy to reactivate. | Removed the hooks, API helpers, file reader, UI state, and restore controls. | None. |
| GH852-CX-1 | P1 | introduced-correctness | Format 1.2 omitted non-default library polling settings, so a future restore would silently fall back to enabled/15 minutes. | Added a required three-field `librarySyncSettings` projection, strict pre-transaction validation, legacy compatibility checks, dependency-ordered restore, and SQLite round-trip coverage. | None. |
| F815-RG-DOC | P3 | contract violation | The primary format inventory omitted the newly required `librarySyncSettings` collection. | Added the exact portable fields and volatile-state reset contract; targeted regression re-review is clean. | None. |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
